### PR TITLE
[M5.A.3] chore(repo): ESLint flat config + Prettier + EditorConfig (#113)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+build/
+.next/
+coverage/
+*.tsbuildinfo
+pnpm-lock.yaml
+*.md
+docs/
+LICENSE

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "quoteProps": "as-needed",
+  "embeddedLanguageFormatting": "auto",
+  "plugins": []
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "echo 'TODO: nest start --watch (см. issue #116)'",
     "build": "echo 'TODO: nest build (см. issue #116)'",
-    "lint": "echo 'TODO: eslint (см. issue #113)'",
+    "lint": "eslint .",
     "test": "echo 'TODO: jest (см. issue #116)'",
     "type-check": "tsc -b"
   }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "echo 'TODO: expo start (фаза 4)'",
     "build": "echo 'TODO: eas build (фаза 4)'",
-    "lint": "echo 'TODO: eslint (см. issue #113)'",
+    "lint": "eslint .",
     "test": "echo 'TODO: jest (фаза 4)'",
     "type-check": "tsc -b"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "echo 'TODO: next dev (см. issue #121)'",
     "build": "echo 'TODO: next build (см. issue #121)'",
-    "lint": "echo 'TODO: eslint (см. issue #113)'",
+    "lint": "eslint .",
     "test": "echo 'TODO: vitest (см. issue #121)'",
     "type-check": "tsc -b"
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,100 @@
+// @ts-check
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import importPlugin from 'eslint-plugin-import';
+import prettierConfig from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/.next/**',
+      '**/coverage/**',
+      '**/*.tsbuildinfo',
+    ],
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+        ...globals.es2022,
+      },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      // TypeScript
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
+      '@typescript-eslint/no-import-type-side-effects': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+
+      // Imports
+      'import/order': [
+        'error',
+        {
+          'groups': [
+            'builtin',
+            'external',
+            'internal',
+            ['parent', 'sibling', 'index'],
+            'type',
+          ],
+          'newlines-between': 'always',
+          'alphabetize': { order: 'asc', caseInsensitive: true },
+        },
+      ],
+      'import/no-duplicates': 'error',
+      'import/no-default-export': 'off',
+
+      // Style
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'eqeqeq': ['error', 'smart'],
+      'curly': ['error', 'multi-line'],
+    },
+  },
+
+  // Тесты — релаксации
+  {
+    files: ['**/*.spec.ts', '**/*.test.ts', '**/*.spec.tsx', '**/*.test.tsx'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
+  // Конфиги — без type-check
+  {
+    files: ['*.config.{js,mjs,ts}', '**/*.config.{js,mjs,ts}'],
+    extends: [tseslint.configs.disableTypeChecked],
+  },
+
+  // Prettier должен быть последним — отключает форматирующие правила ESLint
+  prettierConfig,
+);

--- a/package.json
+++ b/package.json
@@ -12,11 +12,21 @@
   "scripts": {
     "dev": "pnpm --parallel --filter='./apps/*' run dev",
     "build": "pnpm --recursive --filter='./apps/*' --filter='./packages/*' run build",
-    "lint": "pnpm --recursive --filter='./apps/*' --filter='./packages/*' run lint",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "pnpm --recursive --filter='./apps/*' --filter='./packages/*' run test",
     "type-check": "tsc -b"
   },
   "devDependencies": {
-    "typescript": "^5.6.3"
+    "@eslint/js": "^9.13.0",
+    "eslint": "^9.13.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.31.0",
+    "globals": "^15.11.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3",
+    "typescript-eslint": "^8.11.0"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -b",
-    "lint": "echo 'TODO: eslint (см. issue #113)'",
+    "lint": "eslint .",
     "test": "echo 'TODO: vitest'",
     "type-check": "tsc -b"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -b",
-    "lint": "echo 'TODO: eslint (см. issue #113)'",
+    "lint": "eslint .",
     "test": "echo 'TODO: vitest'",
     "type-check": "tsc -b"
   }


### PR DESCRIPTION
## Summary

Closes #113 (M5.A.3) — ESLint flat config v9 + Prettier 3 + EditorConfig.

## Что сделано

### ESLint (`eslint.config.mjs` — flat config)
- `@eslint/js` recommended + `typescript-eslint` `recommendedTypeChecked` + `stylisticTypeChecked`
- `eslint-plugin-import` с `import/order` (builtin → external → internal → relative → type), alphabetize, newlines-between
- Кастомные: `consistent-type-imports` (inline), `no-floating-promises`, `no-misused-promises`, `no-explicit-any` (warn), `no-unused-vars` с `_`-prefix
- Релаксации в `*.spec.ts/*.test.ts` (any и non-null-assertion разрешены)
- Конфиги (`*.config.*`) — `disableTypeChecked`
- `prettier-config` **последним** → отключает форматирующие правила ESLint

### Prettier (`.prettierrc`, `.prettierignore`)
- single quote, 100 cols, trailing comma all, LF
- bracketSpacing true, arrowParens always
- ignore: node_modules / dist / .next / coverage / lock files / docs

### EditorConfig (`.editorconfig`)
- 2 spaces, LF, UTF-8, insert final newline
- Makefile: tabs (обязательно для make)
- `*.md`: без trim trailing whitespace (две пробела = `<br>` в Markdown)

### Скрипты
- `pnpm lint` → `eslint .`
- `pnpm lint:fix` → `eslint . --fix`
- `pnpm format` / `pnpm format:check`
- В каждом workspace заменили TODO-заглушку на `eslint .`

### devDeps (корневой package.json)
- eslint 9.x (flat config)
- typescript-eslint 8.x (для ESLint 9 + TS 5.6)
- eslint-plugin-import 2.31, eslint-config-prettier 9.1, globals 15.11
- prettier 3.3

## Связь с архитектурой / принципами

> **Рекомендация в коде:** разделение «Prettier владеет форматированием, ESLint — семантикой» — стандарт индустрии. Без `eslint-config-prettier` ESLint и Prettier дерутся за trailing commas и quotes, и dev'ы получают conflicting fixes. С ним — каждый делает своё.
>
> `import/order` важнее, чем кажется на первый взгляд: при автодеплое и code-review порядок импортов = порядок чтения, alphabetize+groups делает diffs читаемыми.

## Test plan

- [x] `eslint.config.mjs` валиден как ESM-модуль
- [x] `.prettierrc` валидный JSON
- [ ] `pnpm install` (требует Вику)
- [ ] `pnpm lint` без ошибок (требует Вику; на пустых пакетах должен пройти trivially)
- [ ] `pnpm format:check` без diff'ов (требует Вику)

> **Серверное действие для Вики:** добавлю комментарий в issue #233 с дополнительными командами `pnpm lint` + `pnpm format:check` после `pnpm install`.

## Связанные issues

Closes #113
Зависит от: #112 (merged)
Разблокирует: #114 (CI с jobs lint+format:check), #116 (NestJS — будет соблюдать lint)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_