### PR TITLE
[M5.A.4] chore(ci): GitHub Actions — lint, format, type-check, test (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '9.12.0'
+
+jobs:
+  check:
+    name: Lint + Format + Type-check + Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: ESLint
+        run: pnpm lint
+
+      - name: Prettier check
+        run: pnpm format:check
+
+      - name: TypeScript type-check
+        run: pnpm type-check
+
+      - name: Tests
+        run: pnpm test


### PR DESCRIPTION
## Summary

Closes #114 (M5.A.4) — GitHub Actions CI workflow.

## Что сделано

`.github/workflows/ci.yml` — единый job `check` на `ubuntu-latest` с шагами:

1. `actions/checkout@v4`
2. `pnpm/action-setup@v4` (pnpm 9.12.0)
3. `actions/setup-node@v4` (Node 20, cache: 'pnpm')
4. `pnpm install --frozen-lockfile`
5. `pnpm lint` (ESLint)
6. `pnpm format:check` (Prettier)
7. `pnpm type-check` (`tsc -b`)
8. `pnpm test`

## Особенности

- **Triggers:** push в любую ветку + PR в main. Это даёт раннюю обратную связь даже до открытия PR.
- **Concurrency:** `cancel-in-progress` по `ref` — если push новый коммит в ту же ветку, старый run убивается (не платим минут за устаревшие коммиты).
- **Timeout:** 15 минут. Больше — алёрт.
- **Cache:** `actions/setup-node` cache 'pnpm' — кеширует pnpm store по hash от `pnpm-lock.yaml`.

> **Решение «один job вместо параллельных»:** при текущем размере репо `5× pnpm install` параллельно (~2.5 мин wall-clock) дороже одного линейного прохода (~1.5 мин), потому что install — bottleneck. Когда test suite вырастет (фаза 4), разнесём на параллельные shards.

## Когда CI станет зелёным

> ⚠️ **Сейчас CI может быть красным** на этом PR, потому что в репо ещё нет `pnpm-lock.yaml`, а `--frozen-lockfile` требует его наличия.
>
> **Первый зелёный run** случится **после того, как Вика выполнит issue #233** и закоммитит `pnpm-lock.yaml` в main отдельным PR (это указано в acceptance #233).

Это **сознательное решение**: лучше иметь strict CI с самого начала, чем потом ловить недетерминированные `pnpm install` на полпути.

## Test plan

- [x] YAML валиден
- [x] Структура соответствует Acceptance из #114
- [ ] Зелёный CI после merge'а #233 (Вика создаст lock-файл)

## Связанные issues

Closes #114
Зависит от: #113 (merged)
Серверное действие: #233 (Вика — verify Wave 0 + commit pnpm-lock.yaml)
Разблокирует: все будущие PR проверяются автоматически

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_