### PR TITLE
[M5.A.7] chore(api): Prisma + первая миграция (пустая) + readiness check (#117)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,8 @@ API_PORT=4000
 
 # === База данных ===
 # PostgreSQL — основная БД (database-per-service в фазе 4, см. issue #62)
-DATABASE_URL=postgresql://user:password@localhost:5432/indiahorizone
+# Для локальной разработки совпадает с docker-compose defaults.
+DATABASE_URL=postgresql://indiahorizone:indiahorizone_dev@localhost:5432/indiahorizone?schema=public
 
 # === Кеш и очереди ===
 REDIS_URL=redis://localhost:6379

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,15 @@
     "start:prod": "NODE_ENV=production node dist/main.js",
     "lint": "eslint .",
     "test": "echo 'TODO: jest (фаза следующих slice — auth/clients тесты)'",
-    "type-check": "tsc -b"
+    "type-check": "tsc -b",
+    "db:generate": "prisma generate",
+    "db:migrate:dev": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
+    "db:studio": "prisma studio",
+    "postinstall": "prisma generate"
+  },
+  "prisma": {
+    "schema": "prisma/schema.prisma"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.6",
@@ -18,6 +26,7 @@
     "@nestjs/core": "^10.4.6",
     "@nestjs/platform-express": "^10.4.6",
     "@nestjs/terminus": "^10.2.3",
+    "@prisma/client": "^5.21.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -26,6 +35,7 @@
     "@nestjs/schematics": "^10.2.3",
     "@types/express": "^4.17.21",
     "@types/node": "^20.16.13",
+    "prisma": "^5.21.1",
     "ts-node": "^10.9.2"
   }
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,0 +1,31 @@
+// IndiaHorizone — Prisma schema
+//
+// Подход: modular monolith. ВСЕ модули (auth, clients, trips, sos, ...)
+// делят одну БД, но владение таблицами строго по модулям.
+//
+// Правила:
+// - Таблицы одного модуля имеют префикс: User → auth, Client → clients, и т.д.
+// - Cross-module foreign keys ЗАПРЕЩЕНЫ — только soft-references по ID.
+//   Это позволяет в фазе 4–5 механически вынести модуль в отдельную БД.
+// - Каждый модуль добавляет свои модели через issue из M5 backlog:
+//   - User (#126) — модуль auth
+//   - Client + ClientProfile (#138) — модуль clients
+//   - Consent (#142), EmergencyContact (#144) — модуль clients
+//   - Trip + Itinerary + DayPlan + Booking (#149) — модуль trips
+//   - SosEvent + SosAck + SosEscalation (#192) — модуль sos
+//   - ChatThread + ChatMessage (#167) — модуль comm
+//   - MediaAsset (#173) — модуль media
+//   - и т.д. (см. docs/ARCH/MICROSERVICES.md)
+//
+// Сейчас (после issue #117) — пустая schema, только datasource + generator.
+// Первая миграция будет 0_init без таблиц — это OK для bootstrap.
+
+generator client {
+  provider = "prisma-client-js"
+  // Output ~ default node_modules/.prisma/client
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { PrismaModule } from './common/prisma/prisma.module';
 import { HealthModule } from './modules/health/health.module';
 
 @Module({
@@ -9,6 +10,7 @@ import { HealthModule } from './modules/health/health.module';
       isGlobal: true,
       cache: true,
     }),
+    PrismaModule,
     HealthModule,
   ],
 })

--- a/apps/api/src/common/prisma/prisma.module.ts
+++ b/apps/api/src/common/prisma/prisma.module.ts
@@ -1,0 +1,18 @@
+import { Global, Module } from '@nestjs/common';
+
+import { PrismaService } from './prisma.service';
+
+/**
+ * Global Prisma module. Зарегистрирован один раз в AppModule, использовать
+ * через DI: `constructor(private readonly prisma: PrismaService) {}`.
+ *
+ * Global scope оправдан — Prisma это инфраструктурный сервис, нужен почти
+ * во всех модулях. Альтернатива (importing PrismaModule в каждом модуле)
+ * — лишний boilerplate.
+ */
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/api/src/common/prisma/prisma.service.ts
+++ b/apps/api/src/common/prisma/prisma.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PrismaService.name);
+
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+    this.logger.log('Prisma connected');
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+    this.logger.log('Prisma disconnected');
+  }
+
+  /**
+   * Используется в /readiness — лёгкий ping без бизнес-логики.
+   * Возвращает true при успешном соединении, false в любом другом случае.
+   */
+  async healthcheck(): Promise<boolean> {
+    try {
+      await this.$queryRaw`SELECT 1`;
+      return true;
+    } catch (error) {
+      this.logger.warn({ err: error }, 'Prisma healthcheck failed');
+      return false;
+    }
+  }
+}

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 
+import { PrismaService } from '../../common/prisma/prisma.service';
+
 interface HealthStatus {
   status: 'ok';
   uptime: number;
@@ -10,13 +12,15 @@ interface HealthStatus {
 interface ReadinessStatus {
   status: 'ready' | 'degraded';
   checks: {
-    postgres: 'up' | 'down' | 'pending';
+    postgres: 'up' | 'down';
     redis: 'up' | 'down' | 'pending';
   };
 }
 
 @Controller()
 export class HealthController {
+  constructor(private readonly prisma: PrismaService) {}
+
   @Get('health')
   health(): HealthStatus {
     return {
@@ -28,16 +32,17 @@ export class HealthController {
   }
 
   @Get('readiness')
-  readiness(): ReadinessStatus {
-    // TODO: реальные проверки Postgres + Redis появятся после
-    // подключения PrismaService (#117) и RedisService (#118).
-    // Пока возвращаем 'pending' — это валидный signal, что зависимости
-    // ещё не инициализированы.
+  async readiness(): Promise<ReadinessStatus> {
+    const postgresUp = await this.prisma.healthcheck();
+
+    // TODO: Redis check появится после #118 (events-bus подключение).
+    const redis: 'pending' = 'pending';
+
     return {
-      status: 'ready',
+      status: postgresUp ? 'ready' : 'degraded',
       checks: {
-        postgres: 'pending',
-        redis: 'pending',
+        postgres: postgresUp ? 'up' : 'down',
+        redis,
       },
     };
   }


### PR DESCRIPTION
## Summary

Closes #117 (M5.A.7) — Prisma scaffold + базовая readiness-проверка через Postgres.

## Что сделано

### `prisma/schema.prisma`
- generator prisma-client-js + datasource postgresql из `DATABASE_URL`
- **Ноль моделей** — bootstrap-миграция будет 0_init без таблиц. Модели придут в #126, #138, #149, #167, #173, #186, #192, #202 и т.д.
- Расширенный комментарий: правило «no cross-module FK» закреплено прямо в schema

### `src/common/prisma/`
- `PrismaService` — extends `PrismaClient` + `OnModuleInit/Destroy` (graceful $connect/$disconnect) + `healthcheck()` метод
- `PrismaModule` — `@Global()`, экспортирует `PrismaService`. Использование: `constructor(private readonly prisma: PrismaService) {}`

### Health controller
- `/readiness` теперь реально проверяет Postgres через `prisma.healthcheck()` (`SELECT 1`)
- При успехе → `status='ready'`, `postgres='up'`. При неудаче → `'degraded'`, `'down'`
- Redis остался `'pending'` до #118

### Скрипты
- `pnpm db:generate` (CI postinstall)
- `pnpm db:migrate:dev` (локальная разработка)
- `pnpm db:migrate:deploy` (staging/prod CI)
- `pnpm db:studio` (Prisma Studio для дебага)
- `postinstall` хук — автоматический `prisma generate` после `pnpm install`

## Серверные действия для Вики

> Это PR содержит файлы, но **первая миграция** (`prisma migrate dev` → создаёт `migrations/0_init/`) — **серверная команда**. Добавлю комментарий в #233 для Вики:
>
> ```bash
> cd apps/api
> pnpm db:migrate:dev --name init  # создаёт пустую миграцию 0_init и коммит-кандидат
> ```
>
> После этого Вика создаёт PR в main с папкой `apps/api/prisma/migrations/0_init/migration.sql`. Затем CI на следующих PR уже сможет запускать `prisma migrate deploy`.

## Test plan

- [x] TypeScript компилируется (после `prisma generate` в CI/Вика)
- [ ] `pnpm db:migrate:dev` создаёт пустую миграцию (Вика)
- [ ] `pnpm dev:api` поднимается, `curl /readiness` возвращает `postgres=up` при поднятых docker-compose

## Связанные issues

Closes #117
Зависит от: #115 (docker-compose merged), #116 (NestJS scaffold merged)
Разблокирует: #119 (outbox pattern — нужна Prisma transaction), #126 (User модель — первая Prisma model), #138 (Client модель), все остальные доменные модели

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_