### PR TITLE
[M5.A.9] chore(api): Transactional outbox pattern + relay worker (#119)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -29,3 +29,34 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+// === Cross-cutting infrastructure (модуль common) ===
+//
+// Эти таблицы — не часть бизнес-модуля, а инфра.
+// outbox_entries — Transactional Outbox Pattern (#119)
+// processed_events — Idempotency для подписчиков (#120)
+
+/// Outbox для событий: запись в той же транзакции, что и бизнес-операция.
+/// Outbox-relay воркер периодически забирает unpublished и публикует в Redis Streams.
+/// Это гарантия, что события не потеряются при rollback'нутой транзакции, и не
+/// появятся при failed publish'е — основная гигиена event-driven систем.
+model OutboxEntry {
+  id            String    @id @default(uuid()) @db.Uuid
+  /// Тип события: <service>.<entity>.<verb>, например "auth.user.registered"
+  eventType     String    @map("event_type")
+  /// Версия схемы payload (DomainEvent.schemaVersion)
+  schemaVersion Int       @map("schema_version") @default(1)
+  /// JSON payload + envelope-метаданные (correlationId, actor)
+  payload       Json
+  /// UUIDv4 для DomainEvent.id — генерируется на этапе записи, гарантирует
+  /// идемпотентность при повторной публикации в Redis Streams.
+  eventId       String    @unique @map("event_id") @db.Uuid
+  createdAt     DateTime  @default(now()) @map("created_at")
+  /// NULL пока не опубликовано. После успешного XADD — proставляется.
+  publishedAt   DateTime? @map("published_at")
+  /// Счётчик попыток публикации (для DLQ при > N попытках)
+  attempts      Int       @default(0)
+
+  @@index([publishedAt, createdAt], map: "idx_outbox_unpublished")
+  @@map("outbox_entries")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { EventsBusModule } from './common/events-bus/events-bus.module';
+import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
 import { RedisModule } from './common/redis/redis.module';
 import { HealthModule } from './modules/health/health.module';
@@ -15,6 +16,7 @@ import { HealthModule } from './modules/health/health.module';
     PrismaModule,
     RedisModule,
     EventsBusModule,
+    OutboxModule,
     HealthModule,
   ],
 })

--- a/apps/api/src/common/outbox/outbox-relay.worker.ts
+++ b/apps/api/src/common/outbox/outbox-relay.worker.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
+
+import { EventsBusService } from '../events-bus/events-bus.service';
+import type { DomainEvent } from '../events-bus/types';
+import { PrismaService } from '../prisma/prisma.service';
+
+const POLL_INTERVAL_MS = 1_000;
+const BATCH_SIZE = 50;
+const MAX_ATTEMPTS = 5;
+
+/**
+ * OutboxRelayWorker — background-loop, который забирает unpublished outbox-записи
+ * и публикует их в Redis Streams через EventsBusService.
+ *
+ * Принципы:
+ * - Polling 1 сек (для фазы 3 достаточно; в фазе 4 можно перейти на listen/notify
+ *   через Postgres NOTIFY или отдельный leader-election worker).
+ * - Batch 50 записей за раз — быстрее малого RPS обрабатывает burst'ы при
+ *   массовых операциях (например, sales создаёт 100 trips подряд).
+ * - At-least-once публикация: если XADD упал — оставляем published_at NULL,
+ *   повторная попытка на следующем тике + инкремент attempts.
+ * - После MAX_ATTEMPTS попыток — лог ERROR, оставляем в outbox для ручного
+ *   разбора через admin-endpoint (в #119 не делаем — реализуется в audit-svc #218).
+ *
+ * Single-instance assumption: предполагается ОДИН worker на api-deployment
+ * (фаза 3 — один контейнер). При scale-out — leader-election (фаза 4).
+ */
+@Injectable()
+export class OutboxRelayWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OutboxRelayWorker.name);
+  private timer: NodeJS.Timeout | null = null;
+  private active = false;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly bus: EventsBusService,
+  ) {}
+
+  onModuleInit(): void {
+    this.active = true;
+    this.scheduleNext();
+    this.logger.log({ pollMs: POLL_INTERVAL_MS, batch: BATCH_SIZE }, 'outbox-relay.started');
+  }
+
+  onModuleDestroy(): void {
+    this.active = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.logger.log('outbox-relay.stopped');
+  }
+
+  private scheduleNext(): void {
+    if (!this.active) return;
+    this.timer = setTimeout(() => {
+      void this.tick();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private async tick(): Promise<void> {
+    try {
+      await this.processBatch();
+    } catch (error) {
+      this.logger.error({ err: error }, 'outbox-relay.tick.failed');
+    } finally {
+      this.scheduleNext();
+    }
+  }
+
+  private async processBatch(): Promise<void> {
+    const entries = await this.prisma.outboxEntry.findMany({
+      where: {
+        publishedAt: null,
+        attempts: { lt: MAX_ATTEMPTS },
+      },
+      orderBy: { createdAt: 'asc' },
+      take: BATCH_SIZE,
+    });
+
+    if (entries.length === 0) {
+      return;
+    }
+
+    this.logger.debug({ count: entries.length }, 'outbox-relay.batch');
+
+    for (const entry of entries) {
+      const envelope = entry.payload as unknown as DomainEvent;
+      try {
+        await this.bus.publish({
+          id: entry.eventId,
+          occurredAt: envelope.occurredAt ?? entry.createdAt.toISOString(),
+          type: entry.eventType,
+          schemaVersion: entry.schemaVersion,
+          correlationId: envelope.correlationId,
+          causationId: envelope.causationId,
+          actor: envelope.actor,
+          payload: envelope.payload,
+        });
+
+        await this.prisma.outboxEntry.update({
+          where: { id: entry.id },
+          data: { publishedAt: new Date() },
+        });
+      } catch (error) {
+        const newAttempts = entry.attempts + 1;
+        this.logger.warn(
+          { err: error, eventId: entry.eventId, type: entry.eventType, attempts: newAttempts },
+          'outbox-relay.publish.failed',
+        );
+
+        await this.prisma.outboxEntry.update({
+          where: { id: entry.id },
+          data: { attempts: newAttempts },
+        });
+
+        if (newAttempts >= MAX_ATTEMPTS) {
+          this.logger.error(
+            { eventId: entry.eventId, type: entry.eventType },
+            'outbox-relay.dlq',
+          );
+          // TODO (audit-svc #218): отправить в DLQ-stream для ручного разбора
+        }
+      }
+    }
+  }
+}

--- a/apps/api/src/common/outbox/outbox.module.ts
+++ b/apps/api/src/common/outbox/outbox.module.ts
@@ -1,0 +1,28 @@
+import { Global, Module } from '@nestjs/common';
+
+import { OutboxRelayWorker } from './outbox-relay.worker';
+import { OutboxService } from './outbox.service';
+
+/**
+ * Outbox Module — Transactional Outbox Pattern.
+ *
+ * Использование:
+ *   constructor(private readonly outbox: OutboxService) {}
+ *   await this.prisma.$transaction(async (tx) => {
+ *     ...бизнес-логика...
+ *     await this.outbox.add(tx, { type: 'auth.user.registered', ... });
+ *   });
+ *
+ * OutboxRelayWorker запускается автоматически в onModuleInit() и публикует
+ * записи в Redis Streams через EventsBusService.
+ *
+ * См. docs/ARCH/EVENTS.md § Сначала commit DB, потом publish.
+ */
+@Global()
+@Module({
+  providers: [OutboxService, OutboxRelayWorker],
+  exports: [OutboxService],
+})
+export class OutboxModule {}
+
+export { OutboxService } from './outbox.service';

--- a/apps/api/src/common/outbox/outbox.service.ts
+++ b/apps/api/src/common/outbox/outbox.service.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+
+import { Injectable, Logger } from '@nestjs/common';
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import type { DomainEvent } from '../events-bus/types';
+
+import { PrismaService } from '../prisma/prisma.service';
+
+/**
+ * OutboxService — запись событий в outbox в той же транзакции, что и
+ * бизнес-операция. После commit'а транзакции outbox-relay воркер
+ * (см. OutboxRelayWorker) подхватит запись и опубликует в Redis Streams.
+ *
+ * Использование:
+ *
+ *   await this.prisma.$transaction(async (tx) => {
+ *     const user = await tx.user.create({ data: { ... } });
+ *     await this.outbox.add(tx, {
+ *       type: 'auth.user.registered',
+ *       schemaVersion: 1,
+ *       actor: { type: 'user', id: user.id },
+ *       payload: { userId: user.id, email: user.email },
+ *     });
+ *     return user;
+ *   });
+ *
+ * Если транзакция откатилась — outbox-запись тоже откатилась. Если коммит
+ * прошёл — relay-worker заберёт и опубликует at-least-once.
+ *
+ * Соответствует docs/ARCH/EVENTS.md § Сначала commit DB, потом publish.
+ */
+@Injectable()
+export class OutboxService {
+  private readonly logger = new Logger(OutboxService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Записать событие в outbox в рамках переданной транзакции.
+   *
+   * @param tx — Prisma transaction client (получается через prisma.$transaction)
+   * @param event — DomainEvent без id/occurredAt (генерируются здесь)
+   *
+   * Возвращает eventId — UUIDv4, который попадёт в DomainEvent.id при
+   * публикации. Можно использовать для последующего отслеживания и
+   * idempotency на стороне subscribers.
+   */
+  async add<T>(
+    tx: Prisma.TransactionClient | PrismaClient,
+    event: Omit<DomainEvent<T>, 'id' | 'occurredAt'>,
+  ): Promise<string> {
+    const eventId = randomUUID();
+    const occurredAt = new Date().toISOString();
+
+    const fullEnvelope: DomainEvent<T> = {
+      id: eventId,
+      occurredAt,
+      type: event.type,
+      schemaVersion: event.schemaVersion,
+      correlationId: event.correlationId,
+      causationId: event.causationId,
+      actor: event.actor,
+      payload: event.payload,
+    };
+
+    await tx.outboxEntry.create({
+      data: {
+        eventId,
+        eventType: event.type,
+        schemaVersion: event.schemaVersion,
+        payload: fullEnvelope as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    this.logger.debug({ eventId, type: event.type }, 'outbox.added');
+    return eventId;
+  }
+
+  /**
+   * Без транзакции — для случаев, когда событие публикуется вне business-операции
+   * (например, scheduled job-ы, system events). Нужно использовать осознанно —
+   * стандартный path всегда через add() с tx.
+   */
+  async addStandalone<T>(event: Omit<DomainEvent<T>, 'id' | 'occurredAt'>): Promise<string> {
+    return this.add(this.prisma, event);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #119 (M5.A.9) — Transactional Outbox Pattern с автоматическим relay worker'ом.

## Что сделано

### `prisma/schema.prisma` — `OutboxEntry`
- `eventId` (unique UUIDv4) — попадёт в `DomainEvent.id` при публикации
- `eventType`, `schemaVersion`, `payload` (JSONB), `createdAt`, `publishedAt nullable`, `attempts`
- Index `(publishedAt, createdAt)` для быстрого поиска unpublished

### `OutboxService`
- `add(tx, event)` — запись в outbox в рамках Prisma transaction
- `addStandalone(event)` — для system events без бизнес-транзакции
- eventId генерируется один раз → переиспользуется при publish для idempotency

### `OutboxRelayWorker`
- Background polling 1 сек, batch 50 записей
- `findMany unpublished` → `bus.publish()` → `update publishedAt`
- При failed publish — increment `attempts`, повтор на следующем тике
- При `attempts >= 5` — лог ERROR (DLQ — в #218 audit-svc)
- Single-instance в фазе 3, leader-election в фазе 4

### Использование (пример для #127 register)

```ts
await this.prisma.$transaction(async (tx) => {
  const user = await tx.user.create({ data: { ... } });
  await this.outbox.add(tx, {
    type: 'auth.user.registered',
    schemaVersion: 1,
    actor: { type: 'user', id: user.id },
    payload: { userId: user.id, email: user.email },
  });
  return user;
});
```

## Архитектурные решения (зафиксированы в коде)

> 1. **eventId генерируется один раз** при записи в outbox. Идемпотентность на уровне subscribers (через `processed_events` в #120) опирается именно на этот id.
> 2. **`bus.publish()` вызывается ТОЛЬКО из outbox-relay**, не из бизнес-логики. Это гарантия: rollback транзакции → outbox откатился → событие НЕ опубликовано. Без этой дисциплины events текут наружу при failed transactions.
> 3. **Polling 1 сек** — компромисс латентности и нагрузки (50 SELECT/сек на пустом outbox = ничтожно). При фазе 4 — переход на Postgres `LISTEN/NOTIFY` снижает латентность до ~10 мс.

## Test plan

- [x] Структура файлов соответствует Acceptance из #119
- [x] TypeScript компилируется
- [ ] `pnpm db:migrate:dev --name outbox_entries` создаёт миграцию (Вика, #233)
- [ ] Тест: rollback транзакции → запись в outbox откатилась — будет добавлен с первым реальным использованием в #127

## Связанные

Closes #119
Зависит от: #117 (Prisma merged), #118 (events-bus merged)
Разблокирует: #120 (processed_events idempotency), #126/#127 (User модель + register — первый caller `outbox.add`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_