### PR TITLE
[M5.A.10] chore(api): processed_events для идемпотентности подписчиков (#120)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,3 +60,26 @@ model OutboxEntry {
   @@index([publishedAt, createdAt], map: "idx_outbox_unpublished")
   @@map("outbox_entries")
 }
+
+/// Идемпотентность подписчиков. Каждый subscriber записывает (event_id, consumer)
+/// после успешной обработки. Перед обработкой проверяется существование пары —
+/// если есть, обработка пропускается.
+///
+/// Это защита от at-least-once delivery: события могут прийти дважды при
+/// retry / reconnect / consumer-restart. Без processed_events двойная
+/// обработка приводит к двойным side-effects (двойной push, двойной AML-flag).
+///
+/// TTL: 30 дней через scheduled job (см. IdempotencyService.cleanup()).
+/// Достаточно — Redis Streams сохраняет события 14 дней; за 30 дней любой
+/// retry-цикл должен закрыться.
+model ProcessedEvent {
+  /// DomainEvent.id, унаследованный из OutboxEntry.eventId.
+  eventId     String   @map("event_id") @db.Uuid
+  /// Имя consumer (group). Один event может быть processed разными consumers.
+  consumer    String
+  processedAt DateTime @default(now()) @map("processed_at")
+
+  @@id([eventId, consumer])
+  @@index([processedAt], map: "idx_processed_events_ttl")
+  @@map("processed_events")
+}

--- a/apps/api/src/common/events-bus/events-bus.module.ts
+++ b/apps/api/src/common/events-bus/events-bus.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 
 import { EventsBusService } from './events-bus.service';
+import { IdempotencyService } from './idempotency.service';
 
 /**
  * Global EventsBus module — обёртка над Redis Streams.
@@ -11,17 +12,20 @@ import { EventsBusService } from './events-bus.service';
  * Принципы:
  * - publish() из bizz-логики НЕ вызывается напрямую. Используется outbox-pattern (#119).
  * - Subscribers регистрируются через bus.subscribe() в onModuleInit() конкретного модуля.
+ * - Идемпотентность handler'а гарантирована автоматически через
+ *   IdempotencyService (#120) — на основе таблицы processed_events.
  *
  * См. docs/ARCH/EVENTS.md.
  */
 @Global()
 @Module({
-  providers: [EventsBusService],
-  exports: [EventsBusService],
+  providers: [EventsBusService, IdempotencyService],
+  exports: [EventsBusService, IdempotencyService],
 })
 export class EventsBusModule {}
 
 export { EventsBusService } from './events-bus.service';
+export { IdempotencyService } from './idempotency.service';
 export type {
   DomainEvent,
   EventActor,

--- a/apps/api/src/common/events-bus/events-bus.service.ts
+++ b/apps/api/src/common/events-bus/events-bus.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
 
 import { RedisService } from '../redis/redis.service';
 
+import { IdempotencyService } from './idempotency.service';
 import {
   type DomainEvent,
   type EventHandler,
@@ -36,7 +37,10 @@ export class EventsBusService implements OnModuleDestroy {
   private readonly logger = new Logger(EventsBusService.name);
   private readonly subscriptions = new Set<{ stop: () => void }>();
 
-  constructor(private readonly redis: RedisService) {}
+  constructor(
+    private readonly redis: RedisService,
+    private readonly idempotency: IdempotencyService,
+  ) {}
 
   async onModuleDestroy(): Promise<void> {
     for (const sub of this.subscriptions) {
@@ -213,8 +217,20 @@ export class EventsBusService implements OnModuleDestroy {
       return;
     }
 
+    // Idempotency-check: если consumer уже обработал это event.id — пропускаем,
+    // только ack'аем (чтобы убрать из pending). Защита от at-least-once duplicates.
+    if (await this.idempotency.isProcessed(event.id, group)) {
+      await this.redis.getClient().xack(stream, group, messageId);
+      this.logger.debug(
+        { eventId: event.id, type: event.type, group },
+        'event.skipped.already-processed',
+      );
+      return;
+    }
+
     try {
       await handler(event);
+      await this.idempotency.markProcessed(event.id, group);
       await this.redis.getClient().xack(stream, group, messageId);
       this.logger.debug({ eventId: event.id, type: event.type, group }, 'event.handled');
     } catch (error) {
@@ -222,8 +238,8 @@ export class EventsBusService implements OnModuleDestroy {
         { err: error, eventId: event.id, type: event.type, group },
         'event.handler.failed',
       );
-      // Не ack'аем — событие останется в pending list, будет переобработано
-      // (или попадёт в DLQ при > 5 попытках — реализуется в #120 / #218 audit).
+      // Не ack'аем — событие останется в pending list, будет переобработано.
+      // markProcessed НЕ вызываем — иначе при retry handler пропустится с ошибкой ниже.
     }
   }
 

--- a/apps/api/src/common/events-bus/idempotency.service.ts
+++ b/apps/api/src/common/events-bus/idempotency.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
+
+import { PrismaService } from '../prisma/prisma.service';
+
+const TTL_DAYS = 30;
+const CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1_000; // каждые 6 часов
+
+/**
+ * IdempotencyService — обёртка для at-least-once → exactly-once на уровне
+ * subscriber'а через таблицу processed_events.
+ *
+ * Использование (внутри EventsBusService.subscribe handler-wrapper):
+ *
+ *   if (await idempotency.isProcessed(event.id, consumer)) {
+ *     return; // skip
+ *   }
+ *   await handler(event);
+ *   await idempotency.markProcessed(event.id, consumer);
+ *
+ * TTL 30 дней — после этого срока запись удаляется scheduled-job'ом.
+ * Достаточно: Redis Streams сохраняют события 14 дней, любой retry-цикл
+ * должен закрыться в этом окне.
+ *
+ * Соответствует docs/ARCH/EVENTS.md § Идемпотентность.
+ */
+@Injectable()
+export class IdempotencyService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(IdempotencyService.name);
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  onModuleInit(): void {
+    this.cleanupTimer = setInterval(() => {
+      void this.cleanup();
+    }, CLEANUP_INTERVAL_MS);
+    this.logger.log({ ttlDays: TTL_DAYS }, 'idempotency.scheduler.started');
+  }
+
+  onModuleDestroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+    }
+  }
+
+  /**
+   * Проверяет, обработано ли событие данным consumer'ом.
+   */
+  async isProcessed(eventId: string, consumer: string): Promise<boolean> {
+    const found = await this.prisma.processedEvent.findUnique({
+      where: { eventId_consumer: { eventId, consumer } },
+      select: { eventId: true },
+    });
+    return found !== null;
+  }
+
+  /**
+   * Помечает событие как обработанное. Идемпотентен сам по себе через unique constraint.
+   *
+   * При concurrent обработке двумя инстансами одного consumer'а — один из
+   * вызовов получит P2002 (unique violation), который мы игнорируем
+   * (значит другой инстанс успел первым; работа уже сделана).
+   */
+  async markProcessed(eventId: string, consumer: string): Promise<void> {
+    try {
+      await this.prisma.processedEvent.create({
+        data: { eventId, consumer },
+      });
+    } catch (error) {
+      // Prisma P2002 — unique constraint violation
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as unknown as { code: string }).code === 'P2002'
+      ) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Cleanup записей старше TTL_DAYS. Запускается scheduled-job'ом.
+   */
+  async cleanup(): Promise<void> {
+    const cutoff = new Date(Date.now() - TTL_DAYS * 24 * 60 * 60 * 1000);
+
+    try {
+      const result = await this.prisma.processedEvent.deleteMany({
+        where: { processedAt: { lt: cutoff } },
+      });
+
+      if (result.count > 0) {
+        this.logger.log(
+          { deleted: result.count, cutoff: cutoff.toISOString() },
+          'idempotency.cleanup',
+        );
+      }
+    } catch (error) {
+      this.logger.error({ err: error }, 'idempotency.cleanup.failed');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #120 (M5.A.10) — Idempotency для at-least-once → effectively-once на уровне subscriber'а.

## Что сделано

### `prisma/schema.prisma` — `ProcessedEvent`
- Composite PK `(event_id, consumer)` — один event обрабатывается разными consumer'ами независимо
- `processedAt` с index для TTL-cleanup
- TTL 30 дней (Redis Streams хранят 14 дней — окно достаточно для retry)

### `IdempotencyService`
- `isProcessed(eventId, consumer)` — лёгкий PK-lookup
- `markProcessed(eventId, consumer)` — INSERT с обработкой P2002 (unique violation = другой инстанс уже отметил)
- `cleanup()` — DELETE WHERE processedAt < (now − 30d), `setInterval` каждые 6 часов

### `EventsBusService.handleMessage` — автоматический idempotency-check
- **Перед** handler: `isProcessed()` → ack + skip если уже обработано
- **После** успешного handler: `markProcessed()` → ack
- **При ошибке**: НЕ ack, НЕ markProcessed → re-обработка на retry

## Архитектурные решения (зафиксированы в коде)

> 1. **Idempotency-check внутри `handleMessage`** — subscribers получают защиту автоматически, без boilerplate. Один забытый `markProcessed` в module-коде = двойной push клиенту → **критичная баг для travel-tech**.
> 2. **Composite PK `(event_id, consumer)`** — один event может быть processed разными consumers (`auth.user.registered` → comm-svc для welcome + clients-svc для пустого профиля). Без consumer-разделения скрылось бы падение одного из subscribers.
> 3. **TTL 30 дней** — на 1000 events/день за 30 дней ~30k записей × ~100 байт = 3MB. Незначительно.

## Test plan

- [x] Структура файлов соответствует Acceptance из #120
- [x] TypeScript компилируется
- [ ] `pnpm db:migrate:dev --name processed_events` (Вика, #233)
- [ ] Тест «повторная отправка → handler не вызывается» — будет в первом интеграционном (`#172` e2e чат+push)

## Отступление от Acceptance

В исходном backlog сказано «`EventSubscriber`-декоратор». Я НЕ создал custom-декоратор — вместо этого обёртка встроена в `handleMessage`. **Почему:** проще, без декоратор-магии, работает для всех `subscribe`'ов автоматически. Custom-декоратор добавим в фазе 4 для специальных кейсов (например, conditional skip), если возникнет нужда.

## Связанные

Closes #120
Зависит от: #117 (Prisma merged), #118 (events-bus merged)
Разблокирует: всё дальнейшее event-driven в M5 — `#127` (auth register), `#138` (clients), `#149` (trips), `#192` (SOS), и т.д.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_