### PR TITLE
[M5.B.1] feat(auth): User модель + Prisma (#126)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,3 +83,48 @@ model ProcessedEvent {
   @@index([processedAt], map: "idx_processed_events_ttl")
   @@map("processed_events")
 }
+
+// === auth модуль (#126–#137) ===
+//
+// Источник: docs/BACKLOG/M5/B_AUTH.md, docs/ARCH/MICROSERVICES.md § auth-svc.
+// auth — security-критичный модуль, в фазе 4 — первый кандидат на extraction.
+// Правила: cross-module FK запрещены. Profile (модуль clients) ссылается на
+// User по userId через soft-reference, не FK.
+
+enum UserRole {
+  client
+  guide
+  manager
+  concierge
+  finance
+  admin
+
+  @@map("user_role")
+}
+
+enum UserStatus {
+  active
+  suspended
+  pending
+
+  @@map("user_status")
+}
+
+/// Пользователь системы. Любой actor с возможностью авторизации (клиент,
+/// гид, менеджер, concierge, финансы, admin) — User. Профиль клиента
+/// (имя, паспорт, preferences) — отдельная сущность Client в модуле clients
+/// (#138), привязка через userId без FK.
+model User {
+  id           String     @id @default(uuid()) @db.Uuid
+  /// Email lowercased (приведение в коде на уровне приложения).
+  /// Unique с case-insensitive collation в Postgres (citext или lower-index).
+  email        String     @unique
+  passwordHash String     @map("password_hash")
+  role         UserRole   @default(client)
+  status       UserStatus @default(active)
+  createdAt    DateTime   @default(now()) @map("created_at")
+  updatedAt    DateTime   @updatedAt @map("updated_at")
+
+  @@index([email], map: "idx_users_email")
+  @@map("users")
+}


### PR DESCRIPTION
## Summary

Closes #126 (M5.B.1) — User модель + enum UserRole/UserStatus в Prisma.

## Что сделано

- **`UserRole`** enum: `client | guide | manager | concierge | finance | admin`
- **`UserStatus`** enum: `active | suspended | pending`
- **`User`** model: `id (uuid), email (unique), passwordHash, role, status, createdAt, updatedAt` + index по email

## Архитектурные решения

> 1. **Profile (модуль clients) НЕ имеет FK на `users.id`** — только soft-reference через `userId`. Правило «no cross-module FK» из `MICROSERVICES.md` — позволяет в фазе 4 вынести `clients-svc` в отдельную БД без переписывания.
> 2. **role default = `client`**. Роли `admin/finance` — только через ручное продвижение (через миграцию или admin-endpoint в фазе 4).
> 3. **Email lowercased на уровне приложения** (приведение в `AuthService.register` в #127). CITEXT не используем — Prisma support частичный, dump/restore квирки.
> 4. **status `pending`** зарезервирован для email-verification в фазе 4. В MVP-1 регистрируются сразу как `active`.

## Test plan

- [x] Структура schema валидна
- [ ] `pnpm db:migrate:dev --name user_model` (Вика, #233)

## Связанные

Closes #126
Зависит от: #117 (Prisma merged)
Разблокирует: #127 (регистрация — пишет в User), #128 (login — читает User), все остальные #128–#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_