### PR TITLE
[M5.B.2] feat(auth): регистрация email+password с outbox + zxcvbn + argon2id (#127)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,15 +27,20 @@
     "@nestjs/platform-express": "^10.4.6",
     "@nestjs/terminus": "^10.2.3",
     "@prisma/client": "^5.21.1",
+    "argon2": "^0.41.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "ioredis": "^5.4.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.7",
     "@nestjs/schematics": "^10.2.3",
     "@types/express": "^4.17.21",
     "@types/node": "^20.16.13",
+    "@types/zxcvbn": "^4.4.5",
     "prisma": "^5.21.1",
     "ts-node": "^10.9.2"
   }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { EventsBusModule } from './common/events-bus/events-bus.module';
 import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
 import { RedisModule } from './common/redis/redis.module';
+import { AuthModule } from './modules/auth/auth.module';
 import { HealthModule } from './modules/health/health.module';
 
 @Module({
@@ -18,6 +19,7 @@ import { HealthModule } from './modules/health/health.module';
     EventsBusModule,
     OutboxModule,
     HealthModule,
+    AuthModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 
@@ -12,6 +12,15 @@ async function bootstrap(): Promise<void> {
   const config = app.get(ConfigService);
   const port = config.get<number>('API_PORT', 4000);
   const host = config.get<string>('API_HOST', '0.0.0.0');
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // отбрасывает поля, которых нет в DTO
+      forbidNonWhitelisted: true, // 400 если отправлены неожиданные поля
+      transform: true, // превращает plain object → DTO instance, активирует @Transform
+      transformOptions: { enableImplicitConversion: false },
+    }),
+  );
 
   app.enableShutdownHooks();
 

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Headers, HttpCode, HttpStatus, Ip, Post } from '@nestjs/common';
+
+import { RegisterDto } from './dto/register.dto';
+import { AuthService } from './services/auth.service';
+
+import type { RegisterResponse } from './dto/register.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * POST /auth/register
+   *
+   * Body: { email, password, role? }
+   * Returns 201 + { userId, email, role } или 409 если email занят.
+   *
+   * Rate-limit: 5 попыток / 15 мин на IP (через throttler #221).
+   * Декоратор будет добавлен после реализации throttler в #221.
+   */
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  async register(
+    @Body() dto: RegisterDto,
+    @Ip() ip: string,
+    @Headers('x-forwarded-for') xForwardedFor?: string,
+  ): Promise<RegisterResponse> {
+    // X-Forwarded-For приоритетнее (за reverse-proxy в prod), Ip() — fallback
+    const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
+    return this.authService.register(dto, realIp);
+  }
+}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+
+import { AuthController } from './auth.controller';
+import { AuthService } from './services/auth.service';
+import { PasswordService } from './services/password.service';
+
+/**
+ * Auth module — register / login / logout / refresh / 2FA / password-reset.
+ * Источник: docs/BACKLOG/M5/B_AUTH.md.
+ *
+ * В этом slice реализован только register (#127). Остальные сервисы
+ * добавляются в следующих issues (#128–#137) — каждая отдельным PR.
+ */
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService, PasswordService],
+  exports: [AuthService, PasswordService],
+})
+export class AuthModule {}

--- a/apps/api/src/modules/auth/dto/register.dto.ts
+++ b/apps/api/src/modules/auth/dto/register.dto.ts
@@ -1,0 +1,37 @@
+import { Transform, Type } from 'class-transformer';
+import { IsEmail, IsEnum, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+import { UserRole } from '@prisma/client';
+
+/**
+ * DTO для POST /auth/register.
+ *
+ * Минимальная валидация на уровне DTO:
+ * - email: валидный формат + lowercased
+ * - password: минимум 12 символов; полная zxcvbn-проверка — в AuthService
+ *   (там доступен сложный score-check, который не помещается в декораторе)
+ * - role (опционально): только если admin продвигает другого user'а — для
+ *   публичной регистрации игнорируется на уровне сервиса (default=client).
+ */
+export class RegisterDto {
+  @IsEmail({}, { message: 'Некорректный email' })
+  @MaxLength(254, { message: 'Email слишком длинный' })
+  @Transform(({ value }: { value: string }) => value.trim().toLowerCase())
+  email!: string;
+
+  @IsString()
+  @MinLength(12, { message: 'Пароль должен быть не менее 12 символов' })
+  @MaxLength(128, { message: 'Пароль слишком длинный' })
+  password!: string;
+
+  @IsOptional()
+  @Type(() => String)
+  @IsEnum(UserRole, { message: 'Недопустимая роль' })
+  role?: UserRole;
+}
+
+export interface RegisterResponse {
+  userId: string;
+  email: string;
+  role: UserRole;
+}

--- a/apps/api/src/modules/auth/services/auth.service.ts
+++ b/apps/api/src/modules/auth/services/auth.service.ts
@@ -1,0 +1,123 @@
+import { ConflictException, Injectable, Logger, UnprocessableEntityException } from '@nestjs/common';
+import { UserRole, UserStatus } from '@prisma/client';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import { PasswordService } from './password.service';
+
+import type { RegisterDto, RegisterResponse } from '../dto/register.dto';
+
+/**
+ * AuthService — register/login/2FA/refresh бизнес-логика.
+ * В этом slice реализован только register (#127). Login (#128), refresh (#129),
+ * logout (#130), 2FA (#132/#133) — следующие issues.
+ */
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+    private readonly password: PasswordService,
+  ) {}
+
+  /**
+   * Регистрация нового пользователя.
+   *
+   * Шаги:
+   * 1. Проверка zxcvbn-силы пароля (фейлим если score < 2)
+   * 2. Транзакция:
+   *    - Поиск user по email — если есть → 409 Conflict
+   *    - argon2id-хеш пароля
+   *    - INSERT users
+   *    - outbox.add('auth.user.registered') — в той же транзакции
+   * 3. Возврат RegisterResponse (БЕЗ password_hash)
+   *
+   * 'admin' и 'finance' роли через публичную регистрацию ИГНОРИРУЮТСЯ —
+   * сводятся к 'client'. Эти роли только через ручное продвижение через
+   * admin-endpoint в фазе 4 (или миграцией).
+   *
+   * Rate-limit (5 попыток / 15 мин на IP) — на уровне @nestjs/throttler
+   * декоратора в контроллере (#221 настройка).
+   */
+  async register(dto: RegisterDto, ipAddress?: string): Promise<RegisterResponse> {
+    // 1. Проверка силы пароля
+    const strength = this.password.checkStrength(dto.password, [dto.email]);
+    if (!strength.ok) {
+      throw new UnprocessableEntityException({
+        message: 'Пароль слишком слабый',
+        warning: strength.warning,
+        suggestions: strength.suggestions,
+      });
+    }
+
+    // 2. Подавляем admin/finance в публичной регистрации
+    const role = this.sanitizeRole(dto.role);
+
+    const passwordHash = await this.password.hash(dto.password);
+
+    // 3. Транзакция: проверка уникальности + insert + outbox
+    const user = await this.prisma.$transaction(async (tx) => {
+      const existing = await tx.user.findUnique({
+        where: { email: dto.email },
+        select: { id: true },
+      });
+      if (existing) {
+        throw new ConflictException('Email уже зарегистрирован');
+      }
+
+      const created = await tx.user.create({
+        data: {
+          email: dto.email,
+          passwordHash,
+          role,
+          status: UserStatus.active,
+        },
+        select: { id: true, email: true, role: true, createdAt: true },
+      });
+
+      // Событие публикуется через outbox в той же транзакции.
+      // Subscribers:
+      // - clients-svc → создаст пустой Client (#138)
+      // - comm-svc → welcome email (#162)
+      await this.outbox.add(tx, {
+        type: 'auth.user.registered',
+        schemaVersion: 1,
+        actor: { type: 'user', id: created.id },
+        payload: {
+          userId: created.id,
+          email: created.email,
+          role: created.role,
+          source: ipAddress ? `ip:${ipAddress}` : 'unknown',
+        },
+      });
+
+      return created;
+    });
+
+    this.logger.log({ userId: user.id, role: user.role }, 'auth.user.registered');
+
+    return {
+      userId: user.id,
+      email: user.email,
+      role: user.role,
+    };
+  }
+
+  /**
+   * Подавляет admin/finance роли в публичной регистрации.
+   * Возможные значения сужены до client, guide, manager, concierge.
+   * Для guide/manager/concierge тоже надо иметь invite-flow в фазе 4 —
+   * пока разрешаем, но это TODO.
+   */
+  private sanitizeRole(role?: UserRole): UserRole {
+    if (!role) return UserRole.client;
+    if (role === UserRole.admin || role === UserRole.finance) {
+      this.logger.warn({ requestedRole: role }, 'role.elevation.blocked');
+      return UserRole.client;
+    }
+    return role;
+  }
+}

--- a/apps/api/src/modules/auth/services/password.service.ts
+++ b/apps/api/src/modules/auth/services/password.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as argon2 from 'argon2';
+import zxcvbn from 'zxcvbn';
+
+const MIN_ZXCVBN_SCORE = 2; // 0–4. 2 = «ок», 3+ = «хорошо», 4 = «отлично».
+                            // На фазу 3 score=2 минимум: пароль не из топ-100k популярных
+                            // и не очевидно слабый. Жёстче не делаем — иначе клиенты бунтуют.
+
+const ARGON2_OPTIONS: argon2.Options = {
+  type: argon2.argon2id,
+  memoryCost: 19_456, // 19 MiB — OWASP 2024 рекомендация
+  timeCost: 2,
+  parallelism: 1,
+};
+
+export interface PasswordStrengthResult {
+  ok: boolean;
+  score: number; // 0..4
+  warning?: string;
+  suggestions: string[];
+}
+
+/**
+ * PasswordService — единая точка работы с паролями.
+ * Все hash/verify проходят здесь, чтобы можно было заменить алгоритм
+ * (например при появлении quantum-safe в фазе 5) без правки caller'ов.
+ */
+@Injectable()
+export class PasswordService {
+  private readonly logger = new Logger(PasswordService.name);
+
+  /**
+   * Проверка пароля через zxcvbn. Возвращает score + подсказки на русском.
+   * Не блокирует если score >= MIN_ZXCVBN_SCORE; подсказки можно показать
+   * клиенту в UI как helper-text.
+   */
+  checkStrength(password: string, userInputs: string[] = []): PasswordStrengthResult {
+    const result = zxcvbn(password, userInputs);
+    return {
+      ok: result.score >= MIN_ZXCVBN_SCORE,
+      score: result.score,
+      warning: result.feedback.warning || undefined,
+      suggestions: result.feedback.suggestions ?? [],
+    };
+  }
+
+  async hash(password: string): Promise<string> {
+    return argon2.hash(password, ARGON2_OPTIONS);
+  }
+
+  /**
+   * Time-constant verify (argon2.verify timing-safe by design).
+   * При подозрении что hash был сгенерирован старыми параметрами — возвращает
+   * флаг needsRehash, чтобы caller мог пере-хешировать пароль при следующем
+   * успешном login (silent upgrade).
+   */
+  async verify(hash: string, password: string): Promise<{ valid: boolean; needsRehash: boolean }> {
+    try {
+      const valid = await argon2.verify(hash, password);
+      const needsRehash = valid && argon2.needsRehash(hash, ARGON2_OPTIONS);
+      return { valid, needsRehash };
+    } catch (error) {
+      this.logger.warn({ err: error }, 'argon2.verify.failed');
+      return { valid: false, needsRehash: false };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #127 (M5.B.2) — `POST /auth/register` с zxcvbn-strength + argon2id + outbox для `auth.user.registered`.

## Что сделано

### Структура

```
apps/api/src/modules/auth/
├── auth.controller.ts        — POST /auth/register
├── auth.module.ts
├── dto/register.dto.ts        — email lowercased, password 12+, role optional
└── services/
    ├── auth.service.ts        — register flow с транзакцией + outbox
    └── password.service.ts    — argon2id hash/verify + zxcvbn strength
```

### Bocmonenne flow

1. **DTO validation:** email format + lowercase, password 12+ chars
2. **Strength check** через zxcvbn (`MIN_SCORE=2`)
3. **`sanitizeRole`** — admin/finance подавляются, остаётся client (в публичной регистрации нельзя получить высокие роли)
4. **argon2id hash** (OWASP 2024: 19 MiB, t=2, p=1)
5. **Транзакция:** `findUnique(email)` → 409 если занят → `create(user)` → `outbox.add(tx, 'auth.user.registered')` ← **в той же транзакции**
6. Возврат `RegisterResponse` без `password_hash`

### Глобальный ValidationPipe

- `whitelist: true` — отбрасывает поля не из DTO
- `forbidNonWhitelisted: true` — 400 при лишних полях (защита от prototype pollution)
- `transform: true` — активирует `@Transform` декораторы

### Зависимости

- prod: `argon2 ^0.41.1`, `zxcvbn ^4.4.2`, `class-validator`, `class-transformer`
- dev: `@types/zxcvbn`

## Архитектурные решения

> 1. **`publish 'auth.user.registered'` через outbox в транзакции** — первая реальная демонстрация outbox-pattern (#119). Без него: при rollback (например, race condition после findUnique до create) событие всё равно ушло бы → comm-svc отправил welcome email несуществующему user'у.
> 2. **admin/finance подавляются** — нельзя получить через публичную регистрацию. Эти роли только через invite-flow (TODO фаза 4) или admin-endpoint.
> 3. **argon2id с 19 MiB memoryCost** — OWASP 2024 рекомендация. +50ms latency, защита от GPU-bruteforce. В фазе 4 при росте нагрузки можно ослабить до 9 MiB.
> 4. **zxcvbn MIN_SCORE=2** — компромисс UX/безопасность. Score=3 был бы безопаснее, но режет пароли типа `Корова1234!`. На фазе 4 после анализа real-data можно повысить.
> 5. **`needsRehash`** возвращается из verify — для silent upgrade при login (если в прошлом был более слабый hash, при следующем успешном входе пере-хешируем).

## Test plan

- [x] DTO валидация работает (email format, password length, lowercase)
- [x] Транзакция корректна (rollback → outbox откатился)
- [ ] e2e тест: register → user в БД → outbox-entry создана → relay-worker публикует в Redis → audit подписчик пишет в audit_events. Будет в #137.

## Не реализовано (по решению)

- **Rate-limit 5 попыток / 15 мин** — будет в #221 (throttler на gateway). Не пере-делываем сейчас.

## Связанные

Closes #127
Зависит от: #119 (outbox merged), #126 (User модель merged)
Разблокирует: #128 (login — verify пароля), #138 (Client профиль создаётся подписчиком на `auth.user.registered`), #162 (welcome email подписчик)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_