### PR TITLE
docs(ux): полный design-bundle от Claude Design — 11 экранов MVP-1/MVP-2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@ pnpm-lock.yaml
 *.md
 docs/
 LICENSE
+# AI-generated prototypes from Claude Design — не правим руками (см. docs/UX/prototypes/README.md)
+docs/UX/prototypes/from-claude-design/

--- a/docs/UX/prototypes/README.md
+++ b/docs/UX/prototypes/README.md
@@ -55,19 +55,21 @@ https://api.anthropic.com/v1/design/h/<hash>?open_file=ui_kits/<theme>/<screen>.
 
 ## Индекс экранов
 
-| Тема | Файл | Code-issue(s) | MVP | Status |
+> Все prototype-файлы в `from-claude-design/project/ui_kits/trip_dashboard/`. JSX-версии (для React) и HTML-версии (для browser preview) идут парами.
+
+| Тема | Файлы | Code-issue(s) | MVP | Status |
 |---|---|---|---|---|
-| Auth (login + register + 2FA + reset + suspicious) | [`auth.html`](./auth.html) (API: [link](https://api.anthropic.com/v1/design/h/pHs57PS-D8ELYurHBp6PGA?open_file=ui_kits%2Ftrip_dashboard%2Fauth.html)) | #134, #135, #136 | MVP-1 | 🟡 prototype done, ждёт code |
-| Профиль + согласия | _ждёт_ | #147 | MVP-1 | ⚪ |
-| Trip Dashboard главный | _ждёт_ | #154 | MVP-1 | ⚪ |
-| Маршрут (день за днём) | _ждёт_ | #156 | MVP-1 | ⚪ |
-| Чат клиент↔concierge | _ждёт_ | #170 | MVP-2 | ⚪ |
-| Кружок recorder | _ждёт_ | #179 | MVP-2 | ⚪ |
-| Дневник поездки | _ждёт_ | #184 | MVP-2 | ⚪ |
-| Экран фидбэка | _ждёт_ | #190 | MVP-2 | ⚪ |
-| SOS hold-to-trigger | _ждёт_ | #198 | MVP-2 | ⚪ |
-| SOS active screen | _ждёт_ | #199 | MVP-2 | ⚪ |
-| Concierge SOS dashboard | _ждёт_ | #200 | MVP-2 | ⚪ |
+| Auth (login + register + 2FA + reset + suspicious) | [`auth.html`](./from-claude-design/project/ui_kits/trip_dashboard/auth.html) · [`AuthScreens.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx) | #134, #135, #136 | MVP-1 | 🟡 prototype done, ревью passed |
+| Профиль + согласия | [`profile.html`](./from-claude-design/project/ui_kits/trip_dashboard/profile.html) · [`ProfileScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/ProfileScreen.jsx) | #147 | MVP-1 | 🟡 prototype done |
+| Trip Dashboard главный | [`index.html`](./from-claude-design/project/ui_kits/trip_dashboard/index.html) · [`TripDashboard.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/TripDashboard.jsx) | #154 | MVP-1 | 🟡 prototype done |
+| Маршрут (день за днём) | [`itinerary.html`](./from-claude-design/project/ui_kits/trip_dashboard/itinerary.html) · [`ItineraryScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/ItineraryScreen.jsx) | #156 | MVP-1 | 🟡 prototype done |
+| Чат клиент↔concierge | [`chat.html`](./from-claude-design/project/ui_kits/trip_dashboard/chat.html) · [`ChatScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/ChatScreen.jsx) | #170 | MVP-2 | 🟡 prototype done |
+| Кружок recorder | [`recorder.html`](./from-claude-design/project/ui_kits/trip_dashboard/recorder.html) · [`RecorderScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/RecorderScreen.jsx) | #179 | MVP-2 | 🟡 prototype done |
+| Дневник поездки | [`journal.html`](./from-claude-design/project/ui_kits/trip_dashboard/journal.html) · [`JournalScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/JournalScreen.jsx) | #184 | MVP-2 | 🟡 prototype done |
+| Экран фидбэка | [`feedback.html`](./from-claude-design/project/ui_kits/trip_dashboard/feedback.html) · [`FeedbackScreen.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/FeedbackScreen.jsx) | #190 | MVP-2 | 🟡 prototype done |
+| SOS (trigger + active + concierge dashboard) | [`sos.html`](./from-claude-design/project/ui_kits/trip_dashboard/sos.html) · [`SOSScreens.jsx`](./from-claude-design/project/ui_kits/trip_dashboard/SOSScreens.jsx) | #198, #199, #200 | MVP-2 | 🟡 prototype done |
+| Design system tokens (preview cards) | [`from-claude-design/project/preview/`](./from-claude-design/project/preview/) | DESIGN_SYSTEM.md | — | 🟢 reference |
+| Source CSS (saffron + semantic + Inter) | [`colors_and_type.css`](./from-claude-design/project/colors_and_type.css) | DESIGN_SYSTEM.md | — | 🟢 reference |
 
 **Легенда статусов:**
 - ⚪ — экран не прототипирован

--- a/docs/UX/prototypes/from-claude-design/README.md
+++ b/docs/UX/prototypes/from-claude-design/README.md
@@ -1,0 +1,25 @@
+# CODING AGENTS: READ THIS FIRST
+
+This is a **handoff bundle** from Claude Design (claude.ai/design).
+
+A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported this bundle so a coding agent can implement the designs for real.
+
+## What you should do — IMPORTANT
+
+**Read the chat transcripts first.** There are 1 chat transcript(s) in `indiahorizone-design-system/chats/`. The transcripts show the full back-and-forth between the user and the design assistant — they tell you **what the user actually wants** and **where they landed** after iterating. Don't skip them. The final HTML files are the output, but the chat is where the intent lives.
+
+**Read `indiahorizone-design-system/project/ui_kits/trip_dashboard/auth.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
+
+**If anything is ambiguous, ask the user to confirm before you start implementing.** It's much cheaper to clarify scope up front than to build the wrong thing.
+
+## About the design files
+
+The design medium is **HTML/CSS/JS** — these are prototypes, not production code. Your job is to **recreate them pixel-perfectly** in whatever technology makes sense for the target codebase (React, Vue, native, whatever fits). Match the visual output; don't copy the prototype's internal structure unless it happens to fit.
+
+**Don't render these files in a browser or take screenshots unless the user asks you to.** Everything you need — dimensions, colors, layout rules — is spelled out in the source. Read the HTML and CSS directly; a screenshot won't tell you anything they don't.
+
+## Bundle contents
+
+- `indiahorizone-design-system/README.md` — this file
+- `indiahorizone-design-system/chats/` — conversation transcripts (read these!)
+- `indiahorizone-design-system/project/` — the `IndiaHorizone Design System` project files (HTML prototypes, assets, components)

--- a/docs/UX/prototypes/from-claude-design/chats/chat1.md
+++ b/docs/UX/prototypes/from-claude-design/chats/chat1.md
@@ -1,0 +1,464 @@
+# Подтверждение экранов
+
+_Started 2026-04-25 12:44 UTC_
+
+---
+
+## User
+
+
+
+## Assistant
+
+I'll start by exploring the GitHub repo to understand the brand and design context.
+
+_[tool: update_todos]_
+
+_[tool: github_get_tree]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_get_tree]_
+
+_[tool: github_get_tree]_
+
+_[tool: github_get_tree]_
+
+Let me explore key UI/UX docs and packages to understand the design system better.
+
+_[tool: github_get_tree]_
+
+_[tool: github_get_tree]_
+
+_[tool: github_get_tree]_
+
+_[tool: github_get_tree]_
+
+Excellent — DESIGN_SYSTEM.md is the goldmine. Let me read it and the core UX/UI files.
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+_[tool: github_read_file]_
+
+I have everything I need. Let me set up the project and start building.
+
+_[tool: set_project_title]_
+
+_[tool: github_read_file]_
+
+_[tool: snip]_
+
+Now I'll build the design system. Let me create the foundation files first.
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+Now let me build the preview cards and UI kit. I'll create them in batches.
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[Continuing — snipping resolved phases]
+
+_[tool: snip]_
+
+Now component preview cards.
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: register_assets]_
+
+_[tool: snip]_
+
+Now let me build the Trip Dashboard UI kit — the main deliverable per the user's request.
+
+_[tool: copy_starter_component]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+[Continuing — building Trip Dashboard UI kit]
+
+_[tool: snip]_
+
+[Building Trip Dashboard components]
+
+_[tool: write_file]_
+
+[Continuing — building Trip Dashboard index]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+I've finished building the IndiaHorizone Design System. Here's where things landed.
+
+## Caveats
+
+- **Иконки в Trip Dashboard** — пока emoji-маркеры (как в спеке `CORE.md`). Для production надо заменить на Lucide React; CDN-вариант лежит в `preview/brand-icons.html`.
+- **Логотип** — собран из wordmark «India**Horizone**» с saffron-mark, потому что в репо настоящего logo-файла нет. Если есть финальный лого — скиньте SVG/PNG, заменим в `preview/brand-logo.html` и в UI kit.
+- **Шрифт Inter** — подгружается с Google Fonts CDN, локальные TTF-файлы не выкачивал. Если нужен оффлайн-вариант — скажите, добавлю в `fonts/`.
+- **Только один UI kit** — Trip Dashboard mobile (это и просил запрос). CRM, ops-panel, analytics в репо ещё не реализованы (`apps/web/page.tsx` — пустой scaffold), так что их строить не из чего.
+- **SOS hold-to-trigger** — упрощённая прогресс-полоска, а не круговой charge с SVG из tailwind keyframe `sos-charge`. Функционально работает, но визуально не финальная версия.
+
+## 🎯 Помогите доработать
+
+1. **Подтвердите тон saffron** — `hsl(24 95% 53%)` в hover/press состояниях кнопок выглядит ок, или хочется чуть глубже?
+2. **Иконки** — оставляем emoji в Trip Dashboard как «быстрые маркеры», или сразу перевожу на Lucide outline (стоит того в первую же итерацию)?
+3. **Логотип** — пришлите финальный SVG, либо подтвердите, что текущая «IH»-mark + wordmark — рабочий вариант для design system.
+4. **Дополнительные экраны** — главный экран готов; следующая логичная итерация — экран **записи кружка** (5 состояний из `VIDEO_CIRCLE.md`) и **просмотр документов**. Делать?
+
+## User
+
+все подтвердил. жди следующих иссуе на другие экраны
+
+## Assistant
+
+_[tool: snip]_
+
+Принято. Жду новых issue на следующие экраны (запись кружка, документы, маршрут, concierge-чат и т.д.) — компоненты в `TripDashboard.jsx` и токены в `colors_and_type.css` готовы к расширению.
+
+## User
+
+ты можешь самостоятельно эти иссуе выполнить?
+
+## Assistant
+
+_[tool: snip]_
+
+Да, могу — давайте начнём с MVP-1, я сделаю все 4 экрана как тweaks-варианты в одном файле + расширим UI kit. Начну с **#147 Профиль** и **#156 Маршрут** (#154 уже есть, #135 Login сделаю следом). Делаю в этом же `ui_kits/trip_dashboard/` — компоненты переиспользуются.
+
+Делать всё MVP-1 + MVP-2 (10 экранов) сразу — большой объём; предлагаю порядок:
+
+1. **MVP-1 в этом ходе:** #135 Login/Register/2FA, #147 Профиль с табами и consents, #156 Маршрут — добавлю как отдельные HTML + JSX компоненты, зарегистрирую в Design System tab.
+2. **MVP-2 следующим ходом:** чат, кружок-recorder, дневник, фидбэк, SOS hold + active screen.
+
+Подтвердите порядок (или скажите «погнали всё подряд») — и я выполню. Если уже подтверждено — стартую с MVP-1 в новом сообщении после очистки контекста.
+
+## User
+
+давай все , но последовательно
+и пожалуйста выполняй требования к этим иссуе
+
+## Assistant
+
+[I'll snip aggressively and start MVP-1 #135 Login/Register/2FA.]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+[Snipping aggressively]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+[Continuing — building #147 Profile screen with tabs and consents]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[Snipping completed phases]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[Snipping prior work and continuing with MVP-1 verification, then MVP-2]
+
+_[tool: snip]_
+
+_[tool: done]_
+
+[Continuing — building MVP-2: chat client↔concierge #170]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[Continuing — building #179 Кружок recorder, #184 Дневник, #190 Фидбэк, #198 SOS hold, #199 SOS active]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[Continuing with #184 Дневник, #190 Фидбэк, #198/199 SOS]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[snipping]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+[snipping]
+
+_[tool: snip]_
+
+_[tool: done]_
+
+[snipping]
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+_[tool: snip]_
+
+Все 10 экранов MVP-1 + MVP-2 готовы:
+
+**MVP-1 (W21):**
+- `auth.html` — #135 Login + Register (zxcvbn) + 2FA (QR + recovery codes)
+- `profile.html` — #147 4 таба: личные данные + consents (4 уровня photo / A/B/C/D geo) + emergency + паспорт
+- `trip_dashboard.html` — #154 главный экран (готов был ранее)
+- `itinerary.html` — #156 12 дней expandable + прогресс «вы прошли N/12»
+
+**MVP-2 (W26):**
+- `chat.html` — #170 bubbles + typing + read-receipts + attachments + offline banner
+- `recorder.html` — #179 full-screen recorder, hold/tap, 60s countdown, preview + retake
+- `journal.html` — #184 таймлайн + фото-сетки + кружки-плееры + private share
+- `feedback.html` — #190 текст/кружок + 5 emoji-mood
+- `sos.html` — #198 hold-2sec charge + #199 live status sent→ack→connected
+
+Все зарегистрированы как assets в Design System tab — открывайте по очереди и оставляйте комментарии. Дальше: жду фидбек по каждому экрану либо команду «всё ок, упаковывай» — и подготовлю handoff package для разработки.
+
+## User
+
+Regenerate "Feedback — Текст / Кружок": кружок - первичен!.   и фото еще нужно подгружать
+
+## Assistant
+
+[Updating Feedback screen: кружок primary, photo upload added]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: show_to_user]_
+
+_[tool: snip]_
+
+Готово — Feedback переделал:
+
+- **Кружок — primary**: тёмная карточка сверху с большой shutter-кнопкой и подписью «До 60 секунд. Самый живой формат».
+- **Настроение** (5 emoji-mood) — всегда видно, не прячется за табом.
+- **Фото-стрипа** — превью загруженных + dashed-кнопка «＋ Фото» (нативный file picker, multi-select).
+- **Текст** — secondary, меньшая высота, под фото.
+
+Откройте `feedback.html` и скажите, если нужно поменять иерархию или визуал кружка.[Adding parsed passport fields to Profile #147]
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+[snipping]
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: show_to_user]_
+
+Готово — на табе «Паспорт» добавил полные распознанные строки:
+
+**Загранпаспорт** — серия и номер, фамилия/имя латиницей, пол, дата и место рождения, дата выдачи, срок действия, кем выдан, гражданство; OCR-бейдж 98%, кнопки «Исправить» и «Просмотр скана».
+
+**Виза India e-Tourist** — номер, тип (e-Tourist 30 дней), даты выдачи и окончания, кратность въездов.
+
+## User
+
+ты закрыл 135 иссуе?, если нет - сделай пожалуйста все что там написано
+
+## Assistant
+
+[Snipping aggressively, then re-fetching #135 to verify completeness]
+
+_[tool: snip]_
+
+_[tool: web_fetch]_
+
+## User
+
+и? ты все исуе сделал так как там описано?
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: github_read_file]_
+
+[Honest answer — I built the screens covering the spec from DESIGN_SYSTEM/CORE/VIDEO_CIRCLE docs, but I don't have access to GitHub issue #135's actual checklist text. Let me check the BACKLOG folder properly.]
+
+_[tool: github_get_tree]_
+
+[Reading B_AUTH for #135 spec]
+
+_[tool: snip]_
+
+_[tool: github_read_file]_
+
+[Snipping aggressively]
+
+_[tool: snip]_
+
+Честный ответ: **нет, не все.** Я сделал только UI-часть `IH-M5-B-010` (экраны register / login / 2FA), причём не полностью — не хватает экранов `/forgot-password` и `/reset-password/:token`. Остальные 11 пунктов слайса B — это **бэкенд** (NestJS, Prisma, JWT, RBAC, argon2, KMS) и **e2e-тесты** (Playwright) — мой инструментарий для них не подходит, я работаю с HTML/JS-артефактами и дизайном.
+
+Что могу сделать прямо сейчас в рамках своей роли:
+
+1. **Дорисовать недостающие UI-экраны B-010**: `/forgot-password` (запрос email) и `/reset-password/:token` (новый пароль + zxcvbn).
+2. **Расширить 2FA-экран** до полного flow B-008: страница ввода кода после login (challengeId), отдельный экран recovery-code как fallback.
+3. **Suspicious-session UI (B-011)**: модалка/email-preview «новый вход из страны X» с кнопками «это я / не я».
+4. **Скачивание recovery codes** — кнопка «Скачать .txt» на 2FA-setup.
+
+Пункты B-001…B-009, B-012 — это задачи бэкенда и QA, я их не реализую. Если хотите — оставлю их как открытые в чек-листе и закрою UI-часть полностью.
+
+**Делать UI-довод (1–4)?** Скажите «да» — добавлю в одном файле `auth.html` через свитчер новых режимов.
+
+## User
+
+да
+
+## Assistant
+
+[Adding the missing auth UI flows]
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+[snip aggressively]
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: show_to_user]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+Готово — `auth.html` теперь покрывает весь UI слайса B (#135) по спеке:
+
+**Все 7 экранов через переключатель сверху-справа:**
+1. **Login** — email + пароль + ссылка «Забыли пароль?»
+2. **Register** — имя/email/пароль с zxcvbn-метром + чекбокс согласий
+3. **2FA setup** (B-007) — QR + код вручную → ввод 6-значного кода → **recovery-коды + кнопка «Скачать .txt»** (одноразовый показ)
+4. **2FA challenge** (B-008) — 6-значный код после login + fallback «использовать recovery-код» + helper «срок 5 минут»
+5. **Forgot password** (B-009) — запрос email + anti-enumeration сообщение
+6. **Reset password** (B-009) — новый пароль с подтверждением + предупреждение «выйдете со всех устройств»
+7. **Suspicious-session** (B-011) — карточка с when/where/device + «это я» / «не я → reset»
+
+**Что НЕ закрыто** (вне моей роли — это бэкенд/QA): B-001…B-009 серверная часть (Prisma, JWT-rotation, argon2id, KMS-secrets, rate-limits, outbox events) и B-012 e2e Playwright. UI-доводка слайса B полная.
+
+_[tool: fork_verifier_agent]_
+
+Готово.
+
+## User
+
+а ты закоммитил?
+
+## Assistant
+
+_[tool: snip]_
+
+Нет, не закоммитил — у меня нет доступа на запись в ваш GitHub-репозиторий. Я могу только читать его и импортировать файлы оттуда.
+
+Чтобы закоммитить мою работу в `Rivega42/indiahorizone`, есть два пути:
+
+1. **Скачать проект как ZIP** и закоммитить локально — могу собрать архив прямо сейчас.
+2. **Получить публичные ссылки на отдельные файлы** (например, `auth.html`, `AuthScreens.jsx`, `FeedbackScreen.jsx`, `ProfileScreen.jsx`) — и вы их подтянете в репо.
+
+Что удобнее?
+

--- a/docs/UX/prototypes/from-claude-design/project/README.md
+++ b/docs/UX/prototypes/from-claude-design/project/README.md
@@ -1,0 +1,182 @@
+# IndiaHorizone Design System
+
+> Tech-enabled India concierge для русскоязычных клиентов.
+> Премиум-минимализм SaaS (Linear / Vercel / Booking Genius) + saffron-accent как nod к India.
+
+---
+
+## О бренде
+
+**IndiaHorizone** — нишевой travel-tech сервис: персональные поездки в Индию для русскоязычных клиентов с локальной поддержкой, понятным маршрутом и сопровождением на каждом этапе.
+
+**Внутренняя формула:**
+> Не турагентство. Не просто путешествия. А tech-enabled India concierge для русскоязычных клиентов.
+
+**Ключевые продукты:**
+- 📱 **Trip Dashboard** (mobile + web) — клиентский кабинет: маршрут, документы, кружок-фидбэк, SOS, оффлайн-доступ
+- 🛠️ **CRM** — менеджерская панель: воронка, карточки клиентов, коммуникация
+- 👨‍💼 **Operational panel** — для гидов в Индии
+- 📊 **Analytics** — для управляющих
+
+**Аудитория:** русскоязычные путешественники 30–55 лет, средний+ сегмент. Хотят Индию **без хаоса** — управляемо, безопасно, с поддержкой на родном языке.
+
+---
+
+## CONTENT FUNDAMENTALS
+
+### Тон
+- **Тёплый, спокойный, профессиональный.** Не «ура-туризм», не корпоративный канцелярит.
+- **Без жаргона.** «Маршрут», не «itinerary». «Поездка», не «трип». «Согласие», не «consent».
+- **Снижение тревоги.** Тексты должны успокаивать клиента в чужой стране.
+
+### Обращение
+- Только **«вы»**, тёплое. Без «уважаемый клиент» или «дорогой пользователь».
+- Никогда не «ты».
+
+### Casing
+- **Sentence case** в кнопках, заголовках, метках. («Открыть документы», не «Открыть Документы» и не «ОТКРЫТЬ ДОКУМЕНТЫ»)
+- ALL CAPS только для eyebrow-меток с `tracking-widest` (caption).
+
+### Глаголы и CTA
+- **Глагол + объект.** «Открыть документы» вместо «Документы». «Записать кружок» вместо «Создать запись».
+- **Submit-кнопки:** глагол + объект — «Отправить код», не «OK».
+- **Empty states с next-action:** «Здесь появятся ваши кружки. Запишите первый →».
+
+### Ошибки без вины
+- «Не получилось загрузить — проверьте подключение и попробуйте снова», **не** «Вы ввели неверные данные».
+
+### Числа и даты
+- Русское форматирование: `42 000 ₽` (не `₽42,000`).
+- Даты: `25 апр 2026, 14:30` (не `04/25/26 2:30 PM`).
+- Tabular-nums (моноширинные цифры) для цен, таймеров, счётчиков.
+
+### Эмодзи
+- **Используются умеренно** — как функциональные маркеры в UI: 🇮🇳 страна, 📂 документы, 🗺️ маршрут, 💬 чат, 📞 звонок, 🆘 SOS, 🎬 кружок, ✅ готово, 📡 нет сети.
+- Не как декорация. Не в формальных текстах (оферта, политика).
+
+### Внутренние термины
+- **«Кружок»** — это видео-фидбэк (60 сек кругом). Не «video circle», не «видео-отзыв».
+- **«День N из M»** — стандартная локация в поездке.
+- **«Сейчас» / «Следующее»** — два опорных раздела таймлайна.
+
+### Примеры копирайта
+| ✅ Хорошо | ❌ Плохо |
+|---|---|
+| «Как прошёл день?» | «Оцените ваш опыт сегодня» |
+| «Помощь идёт. Дежурный — Мария. Ответ ~60 сек» | «Ваш запрос принят» |
+| «В очереди — отправим, как появится сеть» | «Ошибка отправки» |
+| «Записать кружок» | «Создать видео-отзыв» |
+| «Открыть документы» | «Документы» |
+
+---
+
+## VISUAL FOUNDATIONS
+
+### Палитра
+- **Один акцент — saffron** `hsl(24 95% 53%)` (#F58A1F). Все CTA, focus-rings, активные состояния, ссылки.
+- **Никаких stereotype-Indian**: не добавлять Mughal-зелёный, золотой, фиолетовый. Saffron — единственный nod к Индии.
+- **Нейтрали** — холодный true-grayscale (HSL `0 0%`), от white до near-black `#121212`.
+- **Семантика**: success зелёный `#1FB95C`, warning оранжевый `#F2A516`, destructive красный `#EF4444` (= SOS), info синий `#3D7DF6`.
+
+### Типографика
+- **Inter** (Google Fonts, subsets `latin + cyrillic`). Веса 400 / 500 / 600 / 700.
+- Mono fallback: `ui-monospace, "JetBrains Mono"` — для tabular чисел и кода.
+- **Body 14px** (text-sm) по умолчанию — Inter в кириллице хорошо читается на 14px.
+- Заголовки `font-semibold`, не `font-bold` (премиум-вайб).
+- Letter-spacing отрицательный для крупного типа (-0.015em–-0.02em).
+- Italic — только для cited text.
+
+### Backgrounds
+- **Чистый white / near-black**. Без градиентов, без декоративных текстур.
+- Нет full-bleed photo backgrounds в UI (фото только внутри карточек/imagery).
+- Нет hand-drawn illustrations, нет pattern fills.
+
+### Borders & cards
+- **Border-radius** базовый = `10px` (`--radius`). Inputs `8px`, badges `6px`, big cards `16px`, pills/avatars `9999px`.
+- **Cards** — фон `--card` (white) + 1px border `--border` (`hsl(0 0% 90%)`) + опционально `shadow-sm`. Без heavy drop shadows.
+- **No left-accent-border cards.** Это slop-троп.
+
+### Shadows
+- Очень мягкая система: `sm` (1px), `md` (карточка hover), `lg` (modal), `xl` (SOS-кнопка, elevated CTA).
+- Все shadow — нейтрально-чёрные с низкой альфой (5–10%). Без цветных свечений.
+
+### Spacing
+- 4px grid (Tailwind). Scale: 2 / 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64.
+- Page padding: `px-4` mobile → `px-6` sm → `px-8` lg.
+- Cards: `p-4` mobile → `p-6` desktop.
+- Между параграфами: `space-y-4`. Между группами: `space-y-8`.
+
+### Animation
+- **Быстро и сдержанно.** 100ms для микро (hover/focus), 200ms по умолчанию, 300ms для drawer/modal, 500ms для page transitions.
+- Easing: `ease-out` для входа, `ease-in-out` дефолт, `cubic-bezier(0.4, 0, 0.2, 1)` для важных reveal.
+- Нет bounces, нет spring-overshoot. Нет Lottie, нет Rive.
+- **SOS-charge** (2 сек заполнение круга) — единственная характерная анимация.
+- Уважаем `prefers-reduced-motion`.
+
+### Hover / press states
+- **Hover на primary**: `opacity-90` или чуть темнее (`brightness-95`).
+- **Hover на ghost/outline**: фон `--accent` (= `hsl(0 0% 96%)`).
+- **Press**: `scale-[0.98]` + `opacity-90`. Никакого heavy shrink.
+- **Focus-visible** обязательно: `ring-2 ring-ring ring-offset-2`.
+
+### Transparency & blur
+- Используются **минимально**. Backdrop-blur — только для модальных оверлеев и нижних tab-bar в iOS-стиле (если требуется).
+- Нет «glassmorphism» как декоративного приёма.
+
+### Imagery
+- **Тёплая палитра** (Индия): мягкий warm light, без пересатурации.
+- **Не cool/B&W/grain.** Цветная, но не кричащая.
+- Для travel-photo — портретные ориентации в карточках, ландшафт для hero-блоков.
+- Документы (паспорт/виза) показываются как scan-preview с лёгким border, без декоративных рамок.
+
+### Layout rules
+- **Mobile-first**, минимальный viewport — 360px (старые Android).
+- SOS — **всегда виден** на главном экране Trip Dashboard, на других — floating bottom-right.
+- Главный экран — карточная вертикальная компоновка: `Сейчас → Следующее → Quick actions → Кружок → SOS`.
+- Container max-width на desktop: `2xl` (1536px), но реальный контент в Trip Dashboard ограничен `max-w-md` (мобильная компоновка).
+
+### Iconography
+- **Lucide React** — единственная icon-библиотека. Outline 24×24, stroke 2px, currentColor.
+- Не миксовать с Heroicons / Phosphor / Tabler.
+- Размеры: 16 / 20 / 24 / 32px.
+- Эмодзи допустимы как UI-маркеры (см. CONTENT FUNDAMENTALS), но иконы предпочтительнее для интерактивных контролов.
+
+---
+
+## ICONOGRAPHY
+
+**Базовая библиотека:** [Lucide](https://lucide.dev/) (`lucide-react`). В этом design system иконы загружаются с CDN: `https://unpkg.com/lucide-static@latest/icons/<name>.svg` — см. `assets/icons/`.
+
+**Правила:**
+- Outline only, stroke 2px, currentColor (наследует `--foreground`).
+- Размеры: `w-4` (16px inline) / `w-5` (20px buttons) / `w-6` (24px nav) / `w-8` (32px hero).
+- Icon-only кнопки — обязательный `aria-label`.
+- Stroke не варьируется — везде 2px (1.5/2.5 не использовать).
+
+**Кастомные иконы** (в коде проекта, ещё не реализованы):
+- `IconSosShield` — для SOS-кнопки.
+- `IconCircleRecord` — для recorder кружка.
+
+**Эмодзи как маркеры:** 🇮🇳 (страна) · 📂 (документы) · 🗺️ (маршрут) · 💬 (concierge) · 📞 (гид) · 🆘 (SOS) · 🎬 (кружок) · ✅ (готово) · 📡 (нет сети) · ⚡ (быстрые действия). Используются ограниченно, в Trip Dashboard.
+
+---
+
+## Index / манифест
+
+| Файл | Что внутри |
+|---|---|
+| `README.md` | Этот файл — content fundamentals, visual foundations, iconography |
+| `colors_and_type.css` | CSS-переменные палитры + семантические type-классы |
+| `SKILL.md` | Skill-определение для Claude Code / Agent Skills |
+| `fonts/` | Inter (Google Fonts) — подгружается с CDN, локальная копия не требуется |
+| `assets/icons/` | Lucide icon set + key brand emoji references |
+| `assets/logo/` | IndiaHorizone wordmark / mark |
+| `preview/` | HTML cards для Design System tab (type / colors / spacing / components / brand) |
+| `ui_kits/trip_dashboard/` | UI-kit: Trip Dashboard mobile (главный экран, документы, кружок, SOS) |
+
+### Источники
+- **Repo:** [Rivega42/indiahorizone](https://github.com/Rivega42/indiahorizone) (main branch)
+- **Design system doc:** `docs/UX/DESIGN_SYSTEM.md` в репо
+- **Tokens (источник):** `apps/web/app/globals.css` + `apps/web/tailwind.config.ts`
+- **Trip Dashboard ядро:** `docs/UX/FEATURES/CORE.md`
+- **Кружок UX:** `docs/UX/VIDEO_CIRCLE.md`

--- a/docs/UX/prototypes/from-claude-design/project/SKILL.md
+++ b/docs/UX/prototypes/from-claude-design/project/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: indiahorizone-design
+description: Use this skill to generate well-branded interfaces and assets for IndiaHorizone, either for production or throwaway prototypes/mocks/etc. Contains essential design guidelines, colors, type, fonts, assets, and UI kit components for prototyping.
+user-invocable: true
+---
+
+Read the README.md file within this skill, and explore the other available files.
+
+If creating visual artifacts (slides, mocks, throwaway prototypes, etc), copy assets out and create static HTML files for the user to view. If working on production code, you can copy assets and read the rules here to become an expert in designing with this brand.
+
+If the user invokes this skill without any other guidance, ask them what they want to build or design, ask some questions, and act as an expert designer who outputs HTML artifacts _or_ production code, depending on the need.
+
+## Quick rules for IndiaHorizone
+
+- **Brand:** tech-enabled India concierge for Russian-speaking clients. Premium-minimalism (Linear / Vercel / Booking Genius vibe) with **saffron** as the only Indian-color accent.
+- **Don't:** add Mughal greens / golds / purples; gradient backgrounds; heavy drop shadows; cards with colored left-border accent; emoji as decoration; English in UI.
+- **Do:** Inter (latin + cyrillic), 14px body default, true-grayscale neutrals, saffron `hsl(24 95% 53%)` for primary CTA / focus / active, destructive red for SOS, mobile-first from 360px.
+- **Copy:** Russian, "вы" (warm), verb+object CTAs ("Открыть документы", not "Документы"), no jargon. Term "кружок" = video feedback.

--- a/docs/UX/prototypes/from-claude-design/project/colors_and_type.css
+++ b/docs/UX/prototypes/from-claude-design/project/colors_and_type.css
@@ -1,0 +1,243 @@
+/*
+ * IndiaHorizone Design System — Colors & Type
+ * Source of truth: docs/UX/DESIGN_SYSTEM.md (in github repo Rivega42/indiahorizone)
+ * All colors in HSL for easy dark-mode + brightness tuning.
+ *
+ * Use:
+ *   <link rel="stylesheet" href="colors_and_type.css">
+ *   <link rel="preconnect" href="https://fonts.googleapis.com">
+ *   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+ */
+
+:root {
+  /* ============================================================
+   * NEUTRALS (true-grayscale, hsl(0 0% ...))
+   * ============================================================ */
+  --background: 0 0% 100%;
+  --foreground: 0 0% 9%;
+  --muted: 0 0% 96%;
+  --muted-foreground: 0 0% 45%;
+  --border: 0 0% 90%;
+  --input: 0 0% 90%;
+  --accent: 0 0% 96%;
+  --accent-foreground: 0 0% 9%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 9%;
+
+  /* ============================================================
+   * BRAND — saffron-orange (единственный indian-color акцент)
+   * Не добавлять зелёный/фиолетовый/золотой Mughal-палитры.
+   * ============================================================ */
+  --primary: 24 95% 53%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 24 95% 53%;
+
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 9%;
+
+  /* ============================================================
+   * SEMANTIC
+   * ============================================================ */
+  --success: 142 71% 45%;
+  --success-foreground: 0 0% 100%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 0 0% 7%;
+  /* destructive = SOS-критично; красный read как «опасность» */
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --info: 217 91% 60%;
+  --info-foreground: 0 0% 100%;
+
+  /* ============================================================
+   * RADIUS
+   * ============================================================ */
+  --radius: 0.625rem;          /* 10px — default */
+  --radius-sm: 0.25rem;        /* 4px — inline tags */
+  --radius-md: 0.375rem;       /* 6px — inputs, small buttons */
+  --radius-lg: 0.625rem;       /* 10px — buttons, cards (default) */
+  --radius-xl: 1rem;           /* 16px — large cards, modals */
+  --radius-full: 9999px;       /* pills, avatars, FAB */
+
+  /* ============================================================
+   * SHADOWS
+   * ============================================================ */
+  --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.05);
+  --shadow-md: 0 4px 6px -1px hsl(0 0% 0% / 0.1), 0 2px 4px -2px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 10px 15px -3px hsl(0 0% 0% / 0.1), 0 4px 6px -4px hsl(0 0% 0% / 0.1);
+  --shadow-xl: 0 20px 25px -5px hsl(0 0% 0% / 0.1), 0 8px 10px -6px hsl(0 0% 0% / 0.1);
+
+  /* ============================================================
+   * MOTION
+   * ============================================================ */
+  --duration-fast: 100ms;
+  --duration-base: 200ms;
+  --duration-slow: 300ms;
+  --duration-lazy: 500ms;
+  --ease-spring: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ============================================================
+   * TYPE
+   * ============================================================ */
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --background: 0 0% 7%;
+    --foreground: 0 0% 96%;
+    --muted: 0 0% 15%;
+    --muted-foreground: 0 0% 64%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --accent: 0 0% 15%;
+    --accent-foreground: 0 0% 96%;
+    --card: 0 0% 9%;
+    --card-foreground: 0 0% 96%;
+    --popover: 0 0% 9%;
+    --popover-foreground: 0 0% 96%;
+
+    --primary-foreground: 0 0% 7%;
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 0 0% 96%;
+
+    --success-foreground: 0 0% 7%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 96%;
+    --info-foreground: 0 0% 7%;
+  }
+}
+
+/* ================================================================
+ * BASE
+ * ================================================================ */
+html {
+  -webkit-tap-highlight-color: transparent;
+  font-family: var(--font-sans);
+  color: hsl(var(--foreground));
+  background: hsl(var(--background));
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11"; /* Inter alts */
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ================================================================
+ * TYPE — semantic classes
+ * Mirror DESIGN_SYSTEM.md spec: display / h1..h4 / body-lg / body / body-sm / caption
+ * ================================================================ */
+
+.t-display {
+  font-size: 48px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+}
+
+.t-h1 {
+  font-size: 36px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  font-weight: 600;
+}
+
+.t-h2 {
+  font-size: 24px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  font-weight: 600;
+}
+
+.t-h3 {
+  font-size: 20px;
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.t-h4 {
+  font-size: 18px;
+  line-height: 1.35;
+  font-weight: 500;
+}
+
+.t-body-lg {
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.t-body {
+  font-size: 14px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.t-body-sm {
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+.t-caption {
+  font-size: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+}
+
+.t-mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Default heading map (use semantic .t-* if you need exact fidelity) */
+h1 { font: 600 36px/1.15 var(--font-sans); letter-spacing: -0.015em; }
+h2 { font: 600 24px/1.25 var(--font-sans); letter-spacing: -0.01em; }
+h3 { font: 600 20px/1.3 var(--font-sans); }
+h4 { font: 500 18px/1.35 var(--font-sans); }
+p  { font: 400 14px/1.5 var(--font-sans); }
+
+/* ================================================================
+ * COLOR UTILITY (for preview cards, lightweight; full system uses Tailwind)
+ * ================================================================ */
+.bg-background { background: hsl(var(--background)); }
+.bg-card { background: hsl(var(--card)); }
+.bg-muted { background: hsl(var(--muted)); }
+.bg-primary { background: hsl(var(--primary)); }
+.bg-success { background: hsl(var(--success)); }
+.bg-warning { background: hsl(var(--warning)); }
+.bg-destructive { background: hsl(var(--destructive)); }
+.bg-info { background: hsl(var(--info)); }
+
+.text-foreground { color: hsl(var(--foreground)); }
+.text-muted-foreground { color: hsl(var(--muted-foreground)); }
+.text-primary { color: hsl(var(--primary)); }
+.text-destructive { color: hsl(var(--destructive)); }
+.text-success { color: hsl(var(--success)); }
+.text-warning { color: hsl(var(--warning)); }
+
+.border-default { border: 1px solid hsl(var(--border)); }

--- a/docs/UX/prototypes/from-claude-design/project/preview/brand-icons.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/brand-icons.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Iconography</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 10px; }
+  .ico { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 10px 4px; border: 1px solid hsl(var(--border)); border-radius: 10px; }
+  .ico svg { stroke: hsl(var(--foreground)); }
+  .ico .name { font: 500 10px/1.2 var(--font-mono); color: hsl(var(--muted-foreground)); text-align: center; }
+  .meta { font: 500 11px/1.4 var(--font-sans); color: hsl(var(--muted-foreground)); margin-top: 12px; }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h6l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/></svg><div class="name">folder</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z"/><path d="M9 3v15M15 6v15"/></svg><div class="name">map</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg><div class="name">message</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/></svg><div class="name">phone</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v6M12 14v8M2 12h6M14 12h8"/></svg><div class="name">plus</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg><div class="name">clock</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg><div class="name">check</div></div>
+    <div class="ico"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5M2 12l10 5 10-5"/></svg><div class="name">layers</div></div>
+  </div>
+  <div class="meta">Lucide · outline · stroke 2px · 24×24 · currentColor</div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/brand-logo.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/brand-logo.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Logo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 24px; background: hsl(var(--background)); display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: center; }
+  .panel { padding: 20px; border-radius: var(--radius-xl); border: 1px solid hsl(var(--border)); display: flex; align-items: center; gap: 12px; }
+  .panel.dark { background: hsl(0 0% 7%); border-color: hsl(0 0% 16%); }
+  .mark { width: 36px; height: 36px; border-radius: 10px; background: hsl(24 95% 53%); display: flex; align-items: center; justify-content: center; color: #fff; font: 700 18px/1 var(--font-sans); letter-spacing: -0.04em; }
+  .word { font: 600 22px/1 var(--font-sans); letter-spacing: -0.02em; color: hsl(var(--foreground)); }
+  .word .h { color: hsl(24 95% 53%); }
+  .panel.dark .word { color: #fff; }
+  .meta { font: 500 11px/1 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 8px; text-transform: uppercase; letter-spacing: 0.08em; }
+</style>
+</head>
+<body>
+  <div>
+    <div class="panel"><div class="mark">IH</div><div class="word">India<span class="h">Horizone</span></div></div>
+    <div class="meta">Light surface</div>
+  </div>
+  <div>
+    <div class="panel dark"><div class="mark">IH</div><div class="word">India<span class="h">Horizone</span></div></div>
+    <div class="meta">Dark surface</div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/colors-brand.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/colors-brand.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Colors — Brand</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: flex; gap: 12px; align-items: stretch; }
+  .swatch { flex: 1; border-radius: 12px; border: 1px solid hsl(var(--border)); overflow: hidden; }
+  .chip { height: 92px; }
+  .meta { padding: 10px 12px; }
+  .name { font: 600 13px/1.3 var(--font-sans); color: hsl(var(--foreground)); }
+  .tok { font: 500 11px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 2px; }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="swatch">
+      <div class="chip" style="background:hsl(24 95% 53%)"></div>
+      <div class="meta">
+        <div class="name">Saffron Primary</div>
+        <div class="tok">--primary · #F58A1F · hsl(24 95% 53%)</div>
+      </div>
+    </div>
+    <div class="swatch">
+      <div class="chip" style="background:hsl(24 95% 53%); position:relative;">
+        <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#fff;font:600 14px/1 var(--font-sans);">Aa</div>
+      </div>
+      <div class="meta">
+        <div class="name">Primary Foreground</div>
+        <div class="tok">--primary-foreground · #FFFFFF</div>
+      </div>
+    </div>
+    <div class="swatch">
+      <div class="chip" style="background:hsl(24 95% 53% / 0.12)"></div>
+      <div class="meta">
+        <div class="name">Saffron Tint (12%)</div>
+        <div class="tok">backgrounds, badges</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/colors-neutrals.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/colors-neutrals.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Colors — Neutrals</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
+  .sw { border-radius: 10px; border: 1px solid hsl(var(--border)); overflow: hidden; }
+  .chip { height: 60px; }
+  .meta { padding: 8px 10px; }
+  .name { font: 600 11px/1.2 var(--font-sans); }
+  .tok { font: 500 10px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 2px; }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 100%); border-bottom:1px solid hsl(var(--border))"></div><div class="meta"><div class="name">Background</div><div class="tok">0 0% 100%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 96%)"></div><div class="meta"><div class="name">Muted / Accent</div><div class="tok">0 0% 96%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 90%)"></div><div class="meta"><div class="name">Border / Input</div><div class="tok">0 0% 90%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 45%)"></div><div class="meta"><div class="name">Muted FG</div><div class="tok">0 0% 45%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 9%)"></div><div class="meta"><div class="name">Foreground</div><div class="tok">0 0% 9%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 0% 7%)"></div><div class="meta"><div class="name">BG (dark)</div><div class="tok">0 0% 7%</div></div></div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/colors-semantic.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/colors-semantic.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Colors — Semantic</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+  .sw { border-radius: 10px; border: 1px solid hsl(var(--border)); overflow: hidden; }
+  .chip { height: 72px; display:flex; align-items:center; justify-content:center; color:#fff; font:600 12px/1 var(--font-sans); }
+  .meta { padding: 8px 10px; }
+  .name { font: 600 12px/1.2 var(--font-sans); }
+  .tok { font: 500 10px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 2px; }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <div class="sw"><div class="chip" style="background:hsl(142 71% 45%)">✓</div><div class="meta"><div class="name">Success</div><div class="tok">142 71% 45%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(38 92% 50%); color:#1a1a1a">!</div><div class="meta"><div class="name">Warning</div><div class="tok">38 92% 50%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(0 84% 60%)">SOS</div><div class="meta"><div class="name">Destructive · SOS</div><div class="tok">0 84% 60%</div></div></div>
+    <div class="sw"><div class="chip" style="background:hsl(217 91% 60%)">i</div><div class="meta"><div class="name">Info</div><div class="tok">217 91% 60%</div></div></div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-alerts.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-alerts.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Toast & alerts</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(0 0% 98%); display: flex; flex-direction: column; gap: 10px; }
+  .alert { display: flex; gap: 12px; padding: 12px 14px; border-radius: var(--radius-lg); border: 1px solid; align-items: flex-start; font: 400 13px/1.5 var(--font-sans); }
+  .alert .ico { font-size: 18px; line-height: 1; }
+  .alert .ttl { font-weight: 600; margin-bottom: 2px; }
+  .a-success { background: hsl(142 71% 45% / 0.08); border-color: hsl(142 71% 45% / 0.3); color: hsl(142 71% 22%); }
+  .a-warning { background: hsl(38 92% 50% / 0.08); border-color: hsl(38 92% 50% / 0.3); color: hsl(38 92% 25%); }
+  .a-info    { background: hsl(217 91% 60% / 0.08); border-color: hsl(217 91% 60% / 0.3); color: hsl(217 70% 35%); }
+  .a-error   { background: hsl(0 84% 60% / 0.08); border-color: hsl(0 84% 60% / 0.3); color: hsl(0 70% 35%); }
+  .toast { background: hsl(0 0% 9%); color: #fff; border-radius: var(--radius-lg); padding: 12px 14px; box-shadow: var(--shadow-lg); font: 400 13px/1.4 var(--font-sans); display: flex; gap: 10px; align-items: center; max-width: 360px; }
+</style>
+</head>
+<body>
+  <div class="alert a-success"><span class="ico">✓</span><div><div class="ttl">Кружок отправлен</div>Concierge получил ваш кружок 💚</div></div>
+  <div class="alert a-warning"><span class="ico">⚠</span><div><div class="ttl">Виза истекает через 5 дней</div>Подайте заявление в посольство, чтобы продлить пребывание.</div></div>
+  <div class="alert a-info"><span class="ico">📡</span><div><div class="ttl">Нет сети — использую кеш</div>Все документы доступны оффлайн.</div></div>
+  <div class="toast"><span>✓</span>Сохранено</div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-badges.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-badges.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Badges & status</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; align-items: center; }
+  .badge { display:inline-flex; align-items:center; gap:6px; font: 500 12px/1 var(--font-sans); padding: 5px 10px; border-radius: 9999px; }
+  .b-primary { background: hsl(24 95% 53% / 0.12); color: hsl(24 95% 38%); }
+  .b-success { background: hsl(142 71% 45% / 0.12); color: hsl(142 71% 30%); }
+  .b-warning { background: hsl(38 92% 50% / 0.15); color: hsl(38 92% 33%); }
+  .b-destructive { background: hsl(0 84% 60% / 0.12); color: hsl(0 70% 45%); }
+  .b-info { background: hsl(217 91% 60% / 0.12); color: hsl(217 70% 45%); }
+  .b-neutral { background: hsl(0 0% 96%); color: hsl(0 0% 25%); border:1px solid hsl(var(--border)); }
+  .dot { width: 6px; height: 6px; border-radius: 9999px; background: currentColor; }
+  .label { font: 500 10px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.08em; min-width: 80px; }
+</style>
+</head>
+<body>
+  <div class="row"><span class="label">tonal</span>
+    <span class="badge b-primary"><span class="dot"></span>Сейчас</span>
+    <span class="badge b-success">✓ Отправлено</span>
+    <span class="badge b-warning">Виза истекает</span>
+    <span class="badge b-destructive">SOS активен</span>
+    <span class="badge b-info">📡 В очереди</span>
+    <span class="badge b-neutral">День 3 из 12</span>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-buttons.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-buttons.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Buttons</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-bottom: 12px; }
+  .btn { font: 500 14px/1 var(--font-sans); padding: 10px 16px; border-radius: var(--radius-lg); border: 1px solid transparent; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; transition: all 100ms ease-out; }
+  .btn-primary { background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); }
+  .btn-primary:hover { filter: brightness(0.95); }
+  .btn-outline { background: transparent; color: hsl(var(--foreground)); border-color: hsl(var(--border)); }
+  .btn-outline:hover { background: hsl(var(--accent)); }
+  .btn-ghost { background: transparent; color: hsl(var(--foreground)); }
+  .btn-ghost:hover { background: hsl(var(--accent)); }
+  .btn-destructive { background: hsl(var(--destructive)); color: #fff; }
+  .btn-sm { padding: 6px 12px; font-size: 13px; }
+  .btn-lg { padding: 14px 22px; font-size: 16px; }
+  .btn-icon { padding: 8px; width: 36px; height: 36px; justify-content: center; }
+  .label { font: 500 10px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.08em; min-width: 70px; }
+</style>
+</head>
+<body>
+  <div class="row"><span class="label">primary</span>
+    <button class="btn btn-primary">Открыть документы</button>
+    <button class="btn btn-primary btn-sm">Записать кружок</button>
+    <button class="btn btn-primary btn-lg">Отправить код</button>
+  </div>
+  <div class="row"><span class="label">outline</span>
+    <button class="btn btn-outline">Я лучше текстом</button>
+    <button class="btn btn-outline btn-sm">Переснять</button>
+  </div>
+  <div class="row"><span class="label">ghost · icon</span>
+    <button class="btn btn-ghost">Отмена</button>
+    <button class="btn btn-ghost btn-icon" aria-label="Закрыть">✕</button>
+  </div>
+  <div class="row"><span class="label">destructive</span>
+    <button class="btn btn-destructive">🆘 SOS · нажмите и держите</button>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-cards.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-cards.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Cards</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(0 0% 98%); display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .card { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius-xl); padding: 16px; }
+  .eyebrow { font: 500 11px/1 var(--font-sans); letter-spacing: 0.15em; text-transform: uppercase; color: hsl(var(--muted-foreground)); }
+  .title { font: 600 16px/1.3 var(--font-sans); margin: 8px 0 4px; }
+  .meta { font: 400 13px/1.4 var(--font-sans); color: hsl(var(--muted-foreground)); }
+  .badge { display:inline-flex; align-items:center; gap:6px; font: 500 11px/1 var(--font-sans); padding: 4px 8px; border-radius: 9999px; background: hsl(24 95% 53% / 0.12); color: hsl(24 95% 38%); }
+  .countdown { font: 600 13px/1.2 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 8px; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <span class="badge">● Сейчас</span>
+    <div class="title">Завтрак, отель Lazylagoon</div>
+    <div class="meta">8:30 – 10:00 · ресторан у бассейна</div>
+  </div>
+  <div class="card">
+    <span class="eyebrow">Следующее</span>
+    <div class="title">Йога-урок, пляж Палолем</div>
+    <div class="meta">с инструктором Раджем · 1.2 км от отеля</div>
+    <div class="countdown">↓ через 1ч 45м</div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-fields.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-fields.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Form fields</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .field label { display: block; font: 500 13px/1.2 var(--font-sans); margin-bottom: 6px; }
+  .req { color: hsl(var(--destructive)); }
+  input, textarea { width: 100%; box-sizing: border-box; font: 400 14px/1.5 var(--font-sans); padding: 10px 12px; border: 1px solid hsl(var(--border)); border-radius: var(--radius-md); background: hsl(var(--background)); color: hsl(var(--foreground)); outline: none; transition: border-color 100ms ease-out, box-shadow 100ms ease-out; }
+  input:focus, textarea:focus { border-color: hsl(var(--ring)); box-shadow: 0 0 0 3px hsl(24 95% 53% / 0.2); }
+  .helper { font: 400 12px/1.4 var(--font-sans); color: hsl(var(--muted-foreground)); margin-top: 4px; }
+  .err { font: 400 12px/1.4 var(--font-sans); color: hsl(var(--destructive)); margin-top: 4px; }
+  input.error { border-color: hsl(var(--destructive)); }
+</style>
+</head>
+<body>
+  <div class="field">
+    <label>Email <span class="req">*</span></label>
+    <input type="email" placeholder="вы@почта.рф" />
+    <div class="helper">Используется только для восстановления пароля.</div>
+  </div>
+  <div class="field">
+    <label>Номер паспорта</label>
+    <input type="text" value="75 0123456" class="error" />
+    <div class="err">Не получилось распознать — проверьте серию и номер.</div>
+  </div>
+  <div class="field" style="grid-column: span 2">
+    <label>Заметка для concierge</label>
+    <textarea rows="2" placeholder="Например: «прилетим раньше, можно ли в номер»"></textarea>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-quick-actions.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-quick-actions.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Quick actions</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(0 0% 98%); }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; max-width: 480px; }
+  .qa { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: var(--radius-xl); padding: 14px 10px; display: flex; flex-direction: column; align-items: center; gap: 8px; cursor: pointer; transition: all 150ms ease-out; }
+  .qa:hover { background: hsl(var(--accent)); transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+  .qa-icon { width: 40px; height: 40px; border-radius: 10px; background: hsl(24 95% 53% / 0.10); display: flex; align-items: center; justify-content: center; font-size: 20px; }
+  .qa-label { font: 500 13px/1.2 var(--font-sans); color: hsl(var(--foreground)); }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <button class="qa"><div class="qa-icon">📂</div><div class="qa-label">Документы</div></button>
+    <button class="qa"><div class="qa-icon">🗺️</div><div class="qa-label">Маршрут</div></button>
+    <button class="qa"><div class="qa-icon">💬</div><div class="qa-label">Concierge</div></button>
+    <button class="qa"><div class="qa-icon">📞</div><div class="qa-label">Гид</div></button>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/components-sos.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/components-sos.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>SOS button states</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 24px 20px; background: hsl(0 0% 98%); }
+  .row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; align-items: end; }
+  .stack { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .label { font: 500 10px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.08em; }
+
+  .sos { width: 100%; height: 56px; border-radius: var(--radius-xl); background: hsl(0 84% 60%); color: #fff; font: 600 15px/1 var(--font-sans); display:flex; align-items:center; justify-content:center; gap: 8px; box-shadow: var(--shadow-xl); border: none; cursor: pointer; position: relative; overflow: hidden; }
+  .sos.charging::after {
+    content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 60%;
+    background: hsl(0 84% 50%);
+  }
+  .sos > * { position: relative; z-index: 1; }
+  .sos.fab { width: 56px; height: 56px; border-radius: 9999px; padding: 0; }
+</style>
+</head>
+<body>
+  <div class="row">
+    <div class="stack">
+      <button class="sos">🆘 Нажмите и держите</button>
+      <span class="label">Idle</span>
+    </div>
+    <div class="stack">
+      <button class="sos charging"><span>Удерживайте · 1.2с</span></button>
+      <span class="label">Charging (hold)</span>
+    </div>
+    <div class="stack">
+      <button class="sos fab" aria-label="SOS">🆘</button>
+      <span class="label">Floating FAB</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/radii.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/radii.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Radii</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+  .item { text-align: center; }
+  .box { height: 76px; background: hsl(0 0% 96%); border: 1px solid hsl(var(--border)); margin-bottom: 8px; }
+  .name { font: 600 11px/1.2 var(--font-sans); }
+  .px { font: 500 10px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 2px; }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <div class="item"><div class="box" style="border-radius:4px"></div><div class="name">sm</div><div class="px">4px · tags</div></div>
+    <div class="item"><div class="box" style="border-radius:6px"></div><div class="name">md</div><div class="px">6px · inputs</div></div>
+    <div class="item"><div class="box" style="border-radius:10px"></div><div class="name">lg · default</div><div class="px">10px · cards</div></div>
+    <div class="item"><div class="box" style="border-radius:16px"></div><div class="name">xl</div><div class="px">16px · modals</div></div>
+    <div class="item"><div class="box" style="border-radius:9999px"></div><div class="name">full</div><div class="px">pill / FAB</div></div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/shadows.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/shadows.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Shadows</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 28px 24px; background: hsl(0 0% 98%); }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .item { text-align: center; }
+  .box { height: 64px; background: hsl(var(--card)); border-radius: 10px; margin-bottom: 10px; }
+  .sh-sm { box-shadow: var(--shadow-sm); }
+  .sh-md { box-shadow: var(--shadow-md); }
+  .sh-lg { box-shadow: var(--shadow-lg); }
+  .sh-xl { box-shadow: var(--shadow-xl); }
+  .name { font: 600 12px/1.2 var(--font-sans); }
+  .px { font: 500 10px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); margin-top: 2px; }
+</style>
+</head>
+<body>
+  <div class="grid">
+    <div class="item"><div class="box sh-sm"></div><div class="name">sm</div><div class="px">subtle separation</div></div>
+    <div class="item"><div class="box sh-md"></div><div class="name">md</div><div class="px">card hover</div></div>
+    <div class="item"><div class="box sh-lg"></div><div class="name">lg</div><div class="px">modals · popovers</div></div>
+    <div class="item"><div class="box sh-xl"></div><div class="name">xl</div><div class="px">SOS · elevated CTA</div></div>
+  </div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/spacing-scale.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/spacing-scale.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Spacing — 4px grid</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: grid; grid-template-columns: 60px 1fr 80px; gap: 12px; align-items: center; padding: 6px 0; }
+  .label { font: 500 11px/1 var(--font-mono); color: hsl(var(--muted-foreground)); }
+  .bar { height: 14px; background: hsl(24 95% 53%); border-radius: 3px; }
+  .px { font: 500 11px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-align: right; }
+</style>
+</head>
+<body>
+  <div class="row"><span class="label">space-2</span><div class="bar" style="width:8px"></div><span class="px">8px</span></div>
+  <div class="row"><span class="label">space-3</span><div class="bar" style="width:12px"></div><span class="px">12px</span></div>
+  <div class="row"><span class="label">space-4</span><div class="bar" style="width:16px"></div><span class="px">16px</span></div>
+  <div class="row"><span class="label">space-6</span><div class="bar" style="width:24px"></div><span class="px">24px</span></div>
+  <div class="row"><span class="label">space-8</span><div class="bar" style="width:32px"></div><span class="px">32px</span></div>
+  <div class="row"><span class="label">space-12</span><div class="bar" style="width:48px"></div><span class="px">48px</span></div>
+  <div class="row"><span class="label">space-16</span><div class="bar" style="width:64px"></div><span class="px">64px</span></div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/type-body.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/type-body.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Type — Body & Caption</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: grid; grid-template-columns: 110px 1fr 130px; gap: 14px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid hsl(var(--border)); }
+  .row:last-child { border: none; }
+  .label { font: 500 11px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.08em; }
+  .meta { font: 400 11px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); text-align: right; }
+</style>
+</head>
+<body>
+  <div class="row"><span class="label">h4</span><span class="t-h4">Завтрак, отель Lazylagoon</span><span class="meta">18 / 1.35 / 500</span></div>
+  <div class="row"><span class="label">body-lg</span><span class="t-body-lg">Lead-параграф для премиум-секций — landing, оферта.</span><span class="meta">16 / 1.5 / 400</span></div>
+  <div class="row"><span class="label">body</span><span class="t-body">Основной текст в Trip Dashboard, формах и UI. Inter в кириллице читается чисто.</span><span class="meta">14 / 1.5 / 400</span></div>
+  <div class="row"><span class="label">body-sm</span><span class="t-body-sm">Captions, helper text, timestamps</span><span class="meta">12 / 1.4 / 400</span></div>
+  <div class="row"><span class="label">caption</span><span class="t-caption">Phase 3 · Bootstrap</span><span class="meta">12 / 0.15em / 500</span></div>
+  <div class="row"><span class="label">mono · nums</span><span class="t-mono" style="font-size:14px;">42&nbsp;000&nbsp;₽ · 25&nbsp;апр&nbsp;2026, 14:30</span><span class="meta">tabular-nums</span></div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/preview/type-headings.html
+++ b/docs/UX/prototypes/from-claude-design/project/preview/type-headings.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Type — Display & Headings</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  body { margin: 0; padding: 20px; background: hsl(var(--background)); }
+  .row { display: grid; grid-template-columns: 90px 1fr 130px; gap: 14px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid hsl(var(--border)); }
+  .row:last-child { border: none; }
+  .label { font: 500 11px/1 var(--font-mono); color: hsl(var(--muted-foreground)); text-transform: uppercase; letter-spacing: 0.08em; }
+  .meta { font: 400 11px/1.3 var(--font-mono); color: hsl(var(--muted-foreground)); text-align: right; }
+</style>
+</head>
+<body>
+  <div class="row"><span class="label">display</span><span class="t-display">Индия без хаоса</span><span class="meta">48 / 1.1 / 700</span></div>
+  <div class="row"><span class="label">h1</span><span class="t-h1">День 3 в Гоа</span><span class="meta">36 / 1.15 / 600</span></div>
+  <div class="row"><span class="label">h2</span><span class="t-h2">Сейчас и следующее</span><span class="meta">24 / 1.25 / 600</span></div>
+  <div class="row"><span class="label">h3</span><span class="t-h3">Йога-урок на пляже</span><span class="meta">20 / 1.3 / 600</span></div>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx
@@ -1,0 +1,339 @@
+// AuthScreens.jsx — IndiaHorizone #135 (B-010 + B-008 + B-011)
+// Login / Register / 2FA-setup / 2FA-challenge / Forgot / Reset / Suspicious
+
+const ihAuthStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%', display: 'flex', flexDirection: 'column' },
+  container: { padding: '24px 20px 32px', flex: 1, display: 'flex', flexDirection: 'column' },
+  brand: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 },
+  mark: { width: 32, height: 32, borderRadius: 8, background: 'hsl(24 95% 53%)', color: '#fff', font: '700 14px/1 Inter', display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  word: { font: '600 17px/1 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.02em' },
+  title: { font: '600 24px/1.2 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.015em', marginBottom: 6 },
+  sub: { font: '400 14px/1.5 Inter', color: 'hsl(0 0% 45%)', marginBottom: 20 },
+  field: { marginBottom: 14 },
+  label: { display: 'block', font: '500 13px/1.2 Inter', color: 'hsl(0 0% 9%)', marginBottom: 6 },
+  input: { width: '100%', boxSizing: 'border-box', font: '400 15px/1.4 Inter', padding: '12px 14px', border: '1px solid hsl(0 0% 90%)', borderRadius: 10, background: '#fff', outline: 'none' },
+  helper: { font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginTop: 6 },
+  primaryBtn: { width: '100%', padding: '14px', borderRadius: 10, background: 'hsl(24 95% 53%)', color: '#fff', border: 'none', font: '500 15px/1 Inter', cursor: 'pointer', marginTop: 8 },
+  ghostBtn: { width: '100%', padding: '12px', borderRadius: 10, background: 'transparent', color: 'hsl(0 0% 9%)', border: 'none', font: '500 14px/1 Inter', cursor: 'pointer', marginTop: 8 },
+  outlineBtn: { width: '100%', padding: '12px', borderRadius: 10, background: 'transparent', color: 'hsl(0 0% 9%)', border: '1px solid hsl(0 0% 90%)', font: '500 14px/1 Inter', cursor: 'pointer', marginTop: 8 },
+  switcher: { display: 'flex', gap: 4, padding: 4, background: 'hsl(0 0% 96%)', borderRadius: 12, marginBottom: 20 },
+  tab: { flex: 1, padding: '8px 12px', borderRadius: 8, border: 'none', background: 'transparent', font: '500 13px/1 Inter', color: 'hsl(0 0% 45%)', cursor: 'pointer' },
+  tabActive: { background: '#fff', color: 'hsl(0 0% 9%)', boxShadow: '0 1px 2px hsl(0 0% 0% / 0.05)' },
+  errBanner: { background: 'hsl(0 84% 60% / 0.08)', border: '1px solid hsl(0 84% 60% / 0.25)', color: 'hsl(0 70% 35%)', padding: '10px 12px', borderRadius: 10, font: '500 12px/1.4 Inter', marginBottom: 14 },
+  okBanner: { background: 'hsl(142 71% 45% / 0.08)', border: '1px solid hsl(142 71% 45% / 0.25)', color: 'hsl(142 71% 25%)', padding: '10px 12px', borderRadius: 10, font: '500 12px/1.4 Inter', marginBottom: 14 },
+};
+
+function IHPasswordMeter({ value }) {
+  const score = (() => {
+    let s = 0;
+    if (value.length >= 8) s++;
+    if (value.length >= 12) s++;
+    if (/[A-ZА-Я]/.test(value) && /[a-zа-я]/.test(value)) s++;
+    if (/\d/.test(value) && /[^A-Za-zА-Яа-я0-9]/.test(value)) s++;
+    return Math.min(4, s);
+  })();
+  const labels = ['', 'Слабый', 'Средний', 'Хороший', 'Отличный'];
+  const colors = ['hsl(0 0% 90%)', 'hsl(0 84% 60%)', 'hsl(38 92% 50%)', 'hsl(48 90% 50%)', 'hsl(142 71% 45%)'];
+  return (
+    <div style={{ marginTop: 6 }}>
+      <div style={{ display: 'flex', gap: 4 }}>
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} style={{ flex: 1, height: 4, borderRadius: 2, background: i <= score ? colors[score] : 'hsl(0 0% 92%)' }} />
+        ))}
+      </div>
+      {value && <div style={{ font: '400 12px/1.4 Inter', color: colors[score], marginTop: 6 }}>{labels[score]} пароль · мин. 12 символов</div>}
+    </div>
+  );
+}
+
+function IHAuthBrand() {
+  return (
+    <div style={ihAuthStyles.brand}>
+      <div style={ihAuthStyles.mark}>IH</div>
+      <div style={ihAuthStyles.word}>India<span style={{ color: 'hsl(24 95% 53%)' }}>Horizone</span></div>
+    </div>
+  );
+}
+
+function IHCodeInput({ length = 6, value, onChange }) {
+  const refs = React.useRef([]);
+  const arr = (value + '......').slice(0, length).split('').map(c => c === '.' ? '' : c);
+  return (
+    <div style={{ display: 'flex', gap: 6 }}>
+      {arr.map((c, i) => (
+        <input key={i} ref={el => refs.current[i] = el} maxLength={1} value={c}
+          onChange={e => {
+            const v = e.target.value.replace(/\D/g, '').slice(0, 1);
+            const next = (value + ' '.repeat(length)).slice(0, length).split('');
+            next[i] = v || '';
+            onChange(next.join('').replace(/ /g, ''));
+            if (v && i < length - 1) refs.current[i + 1]?.focus();
+          }}
+          style={{ ...ihAuthStyles.input, textAlign: 'center', font: '600 18px/1.2 ui-monospace, "JetBrains Mono", monospace', padding: '12px 0' }} />
+      ))}
+    </div>
+  );
+}
+
+function IHLoginScreen({ onSwitch, onSubmit }) {
+  const [email, setEmail] = React.useState('');
+  const [pw, setPw] = React.useState('');
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>С возвращением</div>
+      <div style={ihAuthStyles.sub}>Войдите в Trip Dashboard</div>
+      <div style={ihAuthStyles.switcher}>
+        <button style={{ ...ihAuthStyles.tab, ...ihAuthStyles.tabActive }}>Вход</button>
+        <button style={ihAuthStyles.tab} onClick={() => onSwitch('register')}>Регистрация</button>
+      </div>
+      <div style={ihAuthStyles.field}>
+        <label style={ihAuthStyles.label}>Email</label>
+        <input style={ihAuthStyles.input} type="email" placeholder="вы@почта.рф" value={email} onChange={e => setEmail(e.target.value)} />
+      </div>
+      <div style={ihAuthStyles.field}>
+        <label style={ihAuthStyles.label}>Пароль</label>
+        <input style={ihAuthStyles.input} type="password" placeholder="••••••••" value={pw} onChange={e => setPw(e.target.value)} />
+        <a style={{ ...ihAuthStyles.helper, color: 'hsl(24 95% 38%)', textDecoration: 'none', display: 'inline-block', marginTop: 8 }} href="#" onClick={e => { e.preventDefault(); onSwitch('forgot'); }}>Забыли пароль?</a>
+      </div>
+      <button style={ihAuthStyles.primaryBtn} onClick={() => onSubmit && onSubmit({ email, pw })}>Войти</button>
+      <button style={ihAuthStyles.ghostBtn} onClick={() => onSwitch('register')}>У меня ещё нет аккаунта</button>
+    </div>
+  );
+}
+
+function IHRegisterScreen({ onSwitch, onSubmit }) {
+  const [d, setD] = React.useState({ name: '', email: '', pw: '' });
+  const upd = (k, v) => setD(s => ({ ...s, [k]: v }));
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Создайте аккаунт</div>
+      <div style={ihAuthStyles.sub}>Доступ к маршруту, документам, concierge</div>
+      <div style={ihAuthStyles.switcher}>
+        <button style={ihAuthStyles.tab} onClick={() => onSwitch('login')}>Вход</button>
+        <button style={{ ...ihAuthStyles.tab, ...ihAuthStyles.tabActive }}>Регистрация</button>
+      </div>
+      <div style={ihAuthStyles.field}><label style={ihAuthStyles.label}>Имя</label><input style={ihAuthStyles.input} placeholder="Анна" value={d.name} onChange={e => upd('name', e.target.value)} /></div>
+      <div style={ihAuthStyles.field}><label style={ihAuthStyles.label}>Email</label><input style={ihAuthStyles.input} type="email" placeholder="вы@почта.рф" value={d.email} onChange={e => upd('email', e.target.value)} /></div>
+      <div style={ihAuthStyles.field}>
+        <label style={ihAuthStyles.label}>Пароль</label>
+        <input style={ihAuthStyles.input} type="password" placeholder="Минимум 12 символов" value={d.pw} onChange={e => upd('pw', e.target.value)} />
+        <IHPasswordMeter value={d.pw} />
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginTop: 8 }}>
+        <input type="checkbox" defaultChecked style={{ marginTop: 3 }} />
+        <div style={{ font: '400 12px/1.5 Inter', color: 'hsl(0 0% 45%)' }}>
+          Принимаю <a href="#" style={{ color: 'hsl(24 95% 38%)' }}>оферту</a> и <a href="#" style={{ color: 'hsl(24 95% 38%)' }}>политику данных</a>
+        </div>
+      </div>
+      <button style={ihAuthStyles.primaryBtn} onClick={() => onSubmit && onSubmit(d)}>Создать аккаунт</button>
+    </div>
+  );
+}
+
+// 2FA setup (B-007): QR + recovery codes (одноразовый показ + скачать)
+function IH2FASetupScreen({ onDone }) {
+  const [step, setStep] = React.useState('qr'); // qr → verify → codes
+  const [code, setCode] = React.useState('');
+  const codes = ['4f8a-c2d1', '9b3e-7a05', '1c4d-ee82', '6f70-12bb', 'aa39-d840', 'b215-65fc', 'd942-ab10', '5e8c-3f29', '7102-cd44', 'fe1a-9b88'];
+  const downloadCodes = () => {
+    const blob = new Blob([codes.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'indiahorizone-recovery.txt'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  if (step === 'codes') {
+    return (
+      <div style={ihAuthStyles.container}>
+        <IHAuthBrand />
+        <div style={ihAuthStyles.title}>Recovery-коды</div>
+        <div style={ihAuthStyles.sub}>10 одноразовых кодов. Покажем один раз — сохраните сейчас.</div>
+        <div style={ihAuthStyles.errBanner}>
+          ⚠ После закрытия экрана коды нельзя будет посмотреть снова. Сгенерируйте новые в настройках, если потеряете.
+        </div>
+        <div style={{ background: 'hsl(0 0% 96%)', borderRadius: 10, padding: 14, marginBottom: 12, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, font: '500 13px/1.6 ui-monospace, "JetBrains Mono", monospace' }}>
+          {codes.map(c => <span key={c}>{c}</span>)}
+        </div>
+        <button style={ihAuthStyles.outlineBtn} onClick={downloadCodes}>📥 Скачать .txt</button>
+        <button style={ihAuthStyles.primaryBtn} onClick={() => onDone && onDone()}>Я сохранил коды</button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Настройка 2FA</div>
+      <div style={ihAuthStyles.sub}>Отсканируйте QR в Google Authenticator / Authy и введите код</div>
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 18 }}>
+        <div style={{ width: 168, height: 168, background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 12, padding: 12, display: 'grid', gridTemplateColumns: 'repeat(15, 1fr)', gap: 1 }}>
+          {Array.from({ length: 225 }).map((_, i) => {
+            const seed = (i * 17 + (i % 7) * 13) % 100;
+            const corner = (i < 31 || (i % 15) < 4 || (i % 15) > 10 || (i > 195 && i < 226 && (i % 15) < 4));
+            return <div key={i} style={{ background: (seed > 50 || corner) ? '#000' : 'transparent' }} />;
+          })}
+        </div>
+      </div>
+      <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', textAlign: 'center', marginBottom: 14 }}>
+        Или введите вручную: <span style={{ font: '500 12px/1 ui-monospace, "JetBrains Mono", monospace', color: 'hsl(0 0% 9%)' }}>JBSWY3DPEHPK3PXP</span>
+      </div>
+      <div style={ihAuthStyles.field}>
+        <label style={ihAuthStyles.label}>Код из приложения</label>
+        <IHCodeInput value={code} onChange={setCode} />
+      </div>
+      <button style={ihAuthStyles.primaryBtn} onClick={() => setStep('codes')} disabled={code.length < 6}>Подтвердить и получить recovery-коды</button>
+    </div>
+  );
+}
+
+// 2FA challenge (B-008): после login, если включён 2FA
+function IH2FAChallengeScreen({ onVerify, onSwitch }) {
+  const [code, setCode] = React.useState('');
+  const [recovery, setRecovery] = React.useState(false);
+  const [recCode, setRecCode] = React.useState('');
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Подтвердите вход</div>
+      <div style={ihAuthStyles.sub}>{recovery ? 'Введите recovery-код' : 'Введите 6-значный код из вашего authenticator'}</div>
+      {!recovery ? (
+        <>
+          <div style={ihAuthStyles.field}>
+            <label style={ihAuthStyles.label}>Код</label>
+            <IHCodeInput value={code} onChange={setCode} />
+            <div style={ihAuthStyles.helper}>Срок действия challenge — 5 минут</div>
+          </div>
+          <button style={ihAuthStyles.primaryBtn} onClick={() => onVerify && onVerify(code)} disabled={code.length < 6}>Войти</button>
+          <button style={ihAuthStyles.ghostBtn} onClick={() => setRecovery(true)}>Использовать recovery-код</button>
+        </>
+      ) : (
+        <>
+          <div style={ihAuthStyles.field}>
+            <label style={ihAuthStyles.label}>Recovery-код (например, 4f8a-c2d1)</label>
+            <input style={{ ...ihAuthStyles.input, font: '500 14px/1.4 ui-monospace, monospace' }} placeholder="xxxx-xxxx" value={recCode} onChange={e => setRecCode(e.target.value)} />
+            <div style={ihAuthStyles.helper}>Код одноразовый — после использования будет недействителен</div>
+          </div>
+          <button style={ihAuthStyles.primaryBtn} onClick={() => onVerify && onVerify(recCode)}>Войти</button>
+          <button style={ihAuthStyles.ghostBtn} onClick={() => setRecovery(false)}>Назад к коду из приложения</button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Forgot password (B-009): запрос email
+function IHForgotScreen({ onSwitch, onSent }) {
+  const [email, setEmail] = React.useState('');
+  const [sent, setSent] = React.useState(false);
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Восстановление пароля</div>
+      <div style={ihAuthStyles.sub}>Отправим ссылку на email. Действительна 30 минут.</div>
+      {sent ? (
+        <>
+          <div style={ihAuthStyles.okBanner}>
+            ✓ Если такой email зарегистрирован — письмо со ссылкой уже в пути. Проверьте почту и спам.
+          </div>
+          <button style={ihAuthStyles.outlineBtn} onClick={() => onSwitch('login')}>Вернуться ко входу</button>
+        </>
+      ) : (
+        <>
+          <div style={ihAuthStyles.field}>
+            <label style={ihAuthStyles.label}>Email от аккаунта</label>
+            <input style={ihAuthStyles.input} type="email" placeholder="вы@почта.рф" value={email} onChange={e => setEmail(e.target.value)} />
+          </div>
+          <button style={ihAuthStyles.primaryBtn} onClick={() => setSent(true)} disabled={!email.includes('@')}>Отправить ссылку</button>
+          <button style={ihAuthStyles.ghostBtn} onClick={() => onSwitch('login')}>Вспомнил, вернуться</button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Reset password (B-009): по ссылке из письма
+function IHResetScreen({ onSwitch }) {
+  const [pw, setPw] = React.useState('');
+  const [pw2, setPw2] = React.useState('');
+  const [done, setDone] = React.useState(false);
+  const mismatch = pw && pw2 && pw !== pw2;
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Новый пароль</div>
+      <div style={ihAuthStyles.sub}>После сохранения вы выйдете со всех устройств.</div>
+      {done ? (
+        <>
+          <div style={ihAuthStyles.okBanner}>✓ Пароль обновлён. Все сессии завершены — войдите заново.</div>
+          <button style={ihAuthStyles.primaryBtn} onClick={() => onSwitch('login')}>Войти</button>
+        </>
+      ) : (
+        <>
+          <div style={ihAuthStyles.field}>
+            <label style={ihAuthStyles.label}>Новый пароль</label>
+            <input style={ihAuthStyles.input} type="password" placeholder="Минимум 12 символов" value={pw} onChange={e => setPw(e.target.value)} />
+            <IHPasswordMeter value={pw} />
+          </div>
+          <div style={ihAuthStyles.field}>
+            <label style={ihAuthStyles.label}>Повторите пароль</label>
+            <input style={ihAuthStyles.input} type="password" value={pw2} onChange={e => setPw2(e.target.value)} />
+            {mismatch && <div style={{ ...ihAuthStyles.helper, color: 'hsl(0 70% 45%)' }}>Пароли не совпадают</div>}
+          </div>
+          <button style={ihAuthStyles.primaryBtn} onClick={() => setDone(true)} disabled={pw.length < 12 || mismatch}>Сохранить пароль</button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Suspicious-session (B-011)
+function IHSuspiciousScreen({ onSwitch }) {
+  const [resolved, setResolved] = React.useState(null); // 'me' | 'notme'
+  if (resolved === 'me') {
+    return (
+      <div style={ihAuthStyles.container}>
+        <IHAuthBrand />
+        <div style={ihAuthStyles.okBanner}>✓ Спасибо. Сессия помечена как доверенная.</div>
+        <button style={ihAuthStyles.primaryBtn} onClick={() => onSwitch('login')}>На главную</button>
+      </div>
+    );
+  }
+  if (resolved === 'notme') {
+    return (
+      <div style={ihAuthStyles.container}>
+        <IHAuthBrand />
+        <div style={ihAuthStyles.errBanner}>⚠ Все сессии завершены. Установите новый пароль.</div>
+        <button style={ihAuthStyles.primaryBtn} onClick={() => onSwitch('reset')}>Сменить пароль</button>
+      </div>
+    );
+  }
+  return (
+    <div style={ihAuthStyles.container}>
+      <IHAuthBrand />
+      <div style={ihAuthStyles.title}>Новый вход в аккаунт</div>
+      <div style={ihAuthStyles.sub}>Мы заметили необычный вход — это были вы?</div>
+      <div style={{ background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 12, padding: 14, marginBottom: 16 }}>
+        {[
+          { l: 'Когда', v: 'Сегодня в 14:32 МСК' },
+          { l: 'Откуда', v: '🇮🇳 Гоа, Индия · IP 49.205.xx.xx' },
+          { l: 'Устройство', v: 'iPhone · Safari 17' },
+          { l: 'Прежний вход', v: '🇷🇺 Москва, 3 дня назад' },
+        ].map((r, i, a) => (
+          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: i < a.length - 1 ? '1px solid hsl(0 0% 96%)' : 'none' }}>
+            <span style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)' }}>{r.l}</span>
+            <span style={{ font: '500 13px/1.4 Inter', color: 'hsl(0 0% 9%)', textAlign: 'right' }}>{r.v}</span>
+          </div>
+        ))}
+      </div>
+      <button style={ihAuthStyles.primaryBtn} onClick={() => setResolved('me')}>Это был я</button>
+      <button style={{ ...ihAuthStyles.outlineBtn, borderColor: 'hsl(0 84% 60%)', color: 'hsl(0 70% 35%)' }} onClick={() => setResolved('notme')}>Это не я — заблокировать</button>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IHLoginScreen, IHRegisterScreen, IH2FASetupScreen, IH2FAChallengeScreen,
+  IHForgotScreen, IHResetScreen, IHSuspiciousScreen, IHPasswordMeter,
+});

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ChatScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ChatScreen.jsx
@@ -1,0 +1,111 @@
+// ChatScreen.jsx — IndiaHorizone #170
+// «Realtime чат как в Telegram: bubbles, typing indicator, read-receipts, attachments, offline indicator»
+
+const ihChatStyles = {
+  page: { background: 'hsl(28 30% 96%)', minHeight: '100%', display: 'flex', flexDirection: 'column' },
+  header: { padding: '10px 16px', background: '#fff', borderBottom: '1px solid hsl(0 0% 90%)', display: 'flex', alignItems: 'center', gap: 12 },
+  back: { width: 28, height: 28, border: 'none', background: 'transparent', font: '500 18px/1 Inter', color: 'hsl(0 0% 9%)', cursor: 'pointer' },
+  avatar: { width: 36, height: 36, borderRadius: 9999, background: 'hsl(24 95% 53% / 0.18)', color: 'hsl(24 95% 38%)', display: 'flex', alignItems: 'center', justifyContent: 'center', font: '600 13px/1 Inter' },
+  hMain: { flex: 1, minWidth: 0 },
+  hName: { font: '600 14px/1.2 Inter', color: 'hsl(0 0% 9%)' },
+  hStatus: { font: '400 11px/1.4 Inter', color: 'hsl(142 71% 35%)', marginTop: 2 },
+  hStatusOff: { color: 'hsl(0 0% 55%)' },
+  hAction: { width: 32, height: 32, border: 'none', background: 'transparent', cursor: 'pointer', font: '500 16px/1 Inter' },
+  thread: { flex: 1, overflowY: 'auto', padding: '14px 14px 8px', display: 'flex', flexDirection: 'column', gap: 6 },
+  daySep: { alignSelf: 'center', font: '500 11px/1 Inter', color: 'hsl(0 0% 50%)', background: 'hsl(0 0% 100% / 0.7)', padding: '4px 10px', borderRadius: 9999, margin: '4px 0' },
+  bubbleWrap: { display: 'flex', flexDirection: 'column', maxWidth: '78%' },
+  bubbleWrapMe: { alignSelf: 'flex-end', alignItems: 'flex-end' },
+  bubbleWrapThem: { alignSelf: 'flex-start' },
+  bubble: { padding: '8px 12px', borderRadius: 14, font: '400 14px/1.4 Inter', wordWrap: 'break-word' },
+  bubbleMe: { background: 'hsl(24 95% 53%)', color: '#fff', borderBottomRightRadius: 4 },
+  bubbleThem: { background: '#fff', color: 'hsl(0 0% 9%)', borderBottomLeftRadius: 4, border: '1px solid hsl(0 0% 92%)' },
+  meta: { display: 'flex', gap: 4, alignItems: 'center', marginTop: 3, font: '400 10px/1 Inter', color: 'hsl(0 0% 55%)' },
+  attach: { width: 200, height: 130, background: 'linear-gradient(135deg, hsl(24 70% 60%), hsl(0 60% 50%))', borderRadius: 10, marginBottom: 4, display: 'flex', alignItems: 'flex-end', padding: 10, boxSizing: 'border-box', font: '500 11px/1 Inter', color: '#fff', textShadow: '0 1px 2px rgba(0,0,0,0.4)' },
+  typing: { alignSelf: 'flex-start', background: '#fff', border: '1px solid hsl(0 0% 92%)', padding: '10px 14px', borderRadius: 14, borderBottomLeftRadius: 4, display: 'flex', gap: 3 },
+  dot: { width: 6, height: 6, borderRadius: 9999, background: 'hsl(0 0% 60%)' },
+  composer: { background: '#fff', borderTop: '1px solid hsl(0 0% 90%)', padding: 10, display: 'flex', gap: 8, alignItems: 'flex-end' },
+  attachBtn: { width: 36, height: 36, border: 'none', background: 'hsl(0 0% 96%)', borderRadius: 9999, cursor: 'pointer', font: '500 16px/1 Inter', color: 'hsl(0 0% 35%)', flexShrink: 0 },
+  input: { flex: 1, font: '400 14px/1.4 Inter', padding: '9px 14px', border: '1px solid hsl(0 0% 90%)', borderRadius: 18, outline: 'none', resize: 'none', maxHeight: 100 },
+  sendBtn: { width: 36, height: 36, border: 'none', background: 'hsl(24 95% 53%)', color: '#fff', borderRadius: 9999, cursor: 'pointer', font: '500 16px/1 Inter', flexShrink: 0 },
+  offlineBanner: { background: 'hsl(38 92% 50% / 0.15)', color: 'hsl(38 92% 25%)', font: '500 12px/1.2 Inter', padding: '6px 14px', textAlign: 'center', borderBottom: '1px solid hsl(38 92% 50% / 0.3)' },
+};
+
+function IHReadReceipt({ status }) {
+  if (status === 'sent') return <span style={{ opacity: 0.7 }}>✓</span>;
+  if (status === 'delivered') return <span style={{ opacity: 0.7 }}>✓✓</span>;
+  if (status === 'read') return <span style={{ color: 'hsl(195 90% 60%)' }}>✓✓</span>;
+  return null;
+}
+
+function IHTypingDots() {
+  return (
+    <div style={ihChatStyles.typing}>
+      {[0, 1, 2].map(i => (
+        <div key={i} style={{
+          ...ihChatStyles.dot,
+          animation: `ihTypingDot 1.2s ${i * 0.18}s infinite ease-in-out`,
+        }} />
+      ))}
+    </div>
+  );
+}
+
+const IH_THREAD = [
+  { day: 'Сегодня' },
+  { from: 'them', text: 'Доброе утро, Анна! Прия на связи. Как прошла ночь в Imperial?', t: '08:42', s: 'read' },
+  { from: 'me', text: 'Спасибо, замечательно! Готовы выезжать к 10:30?', t: '08:51', s: 'read' },
+  { from: 'them', text: 'Да, водитель уже в пути. На обед забронировала Pinch of Spice в Агре — рейтинг 4.8.', t: '08:53', s: 'read' },
+  { from: 'me', attach: 'Селфи у бассейна', text: 'А я пока завтракаю 🌞', t: '09:04', s: 'read' },
+  { from: 'them', text: 'Прекрасное место! Кстати, на закат в Тадж-Махал у нас слот 17:00 — по индийскому времени восход полной луны. Учтём?', t: '09:11', s: 'delivered' },
+  { from: 'me', text: 'Конечно, давайте 🙏', t: 'сейчас', s: 'sent' },
+];
+
+function IHChatScreen({ offline = false, typing = true }) {
+  const [text, setText] = React.useState('');
+  return (
+    <div style={ihChatStyles.page}>
+      <style>{`@keyframes ihTypingDot { 0%, 60%, 100% { opacity: 0.3; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }`}</style>
+      <div style={ihChatStyles.header}>
+        <button style={ihChatStyles.back}>←</button>
+        <div style={ihChatStyles.avatar}>ПР</div>
+        <div style={ihChatStyles.hMain}>
+          <div style={ihChatStyles.hName}>Прия · concierge</div>
+          <div style={{ ...ihChatStyles.hStatus, ...(offline ? ihChatStyles.hStatusOff : {}) }}>
+            {offline ? '⚠ нет связи — отправим, когда появится' : typing ? 'печатает…' : 'в сети'}
+          </div>
+        </div>
+        <button style={ihChatStyles.hAction}>📞</button>
+        <button style={ihChatStyles.hAction}>⋯</button>
+      </div>
+      {offline && <div style={ihChatStyles.offlineBanner}>Без соединения · сообщения уйдут после восстановления</div>}
+
+      <div style={ihChatStyles.thread}>
+        {IH_THREAD.map((m, i) => {
+          if (m.day) return <div key={i} style={ihChatStyles.daySep}>{m.day}</div>;
+          const me = m.from === 'me';
+          return (
+            <div key={i} style={{ ...ihChatStyles.bubbleWrap, ...(me ? ihChatStyles.bubbleWrapMe : ihChatStyles.bubbleWrapThem) }}>
+              {m.attach && <div style={ihChatStyles.attach}>📷 {m.attach}</div>}
+              <div style={{ ...ihChatStyles.bubble, ...(me ? ihChatStyles.bubbleMe : ihChatStyles.bubbleThem) }}>
+                {m.text}
+              </div>
+              <div style={ihChatStyles.meta}>
+                <span>{m.t}</span>
+                {me && <IHReadReceipt status={m.s} />}
+              </div>
+            </div>
+          );
+        })}
+        {typing && !offline && <IHTypingDots />}
+      </div>
+
+      <div style={ihChatStyles.composer}>
+        <button style={ihChatStyles.attachBtn}>📎</button>
+        <textarea style={ihChatStyles.input} placeholder="Написать concierge…" rows={1} value={text} onChange={e => setText(e.target.value)} />
+        <button style={ihChatStyles.sendBtn}>↑</button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IHChatScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/FeedbackScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/FeedbackScreen.jsx
@@ -1,0 +1,130 @@
+// FeedbackScreen.jsx — IndiaHorizone #190 (rev2)
+// «Кружок — primary action. Текст и фото — secondary. Photo upload + thumbnails»
+
+const ihFbStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%', display: 'flex', flexDirection: 'column' },
+  header: { padding: '16px 20px 14px', borderBottom: '1px solid hsl(0 0% 90%)', background: '#fff' },
+  title: { font: '600 22px/1.2 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.015em' },
+  sub: { font: '400 13px/1.5 Inter', color: 'hsl(0 0% 45%)', marginTop: 4 },
+  body: { padding: 20, flex: 1, display: 'flex', flexDirection: 'column' },
+
+  // Primary: кружок
+  primaryCard: { background: 'linear-gradient(160deg, hsl(0 0% 12%), hsl(0 0% 4%))', borderRadius: 20, padding: '28px 22px', textAlign: 'center', color: '#fff', position: 'relative', overflow: 'hidden', marginBottom: 14 },
+  primaryEyebrow: { font: '500 11px/1 Inter', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'hsl(24 95% 65%)', marginBottom: 14 },
+  primaryShutter: { width: 96, height: 96, borderRadius: 9999, background: 'transparent', border: '4px solid #fff', margin: '0 auto 16px', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', padding: 0, position: 'relative' },
+  primaryShutterCore: { width: 76, height: 76, borderRadius: 9999, background: 'hsl(0 84% 60%)' },
+  primaryShutterPulse: { position: 'absolute', inset: -8, borderRadius: 9999, border: '2px solid hsl(0 84% 60%)', opacity: 0.4, animation: 'ihShutterPulse 2s infinite ease-out' },
+  primaryTitle: { font: '600 18px/1.3 Inter', letterSpacing: '-0.01em', marginBottom: 6 },
+  primaryDesc: { font: '400 13px/1.5 Inter', color: 'rgba(255,255,255,0.7)', maxWidth: 280, margin: '0 auto' },
+
+  // Mood (всегда виден)
+  moodLabel: { font: '500 13px/1.2 Inter', color: 'hsl(0 0% 9%)', marginBottom: 10, marginTop: 4 },
+  moodRow: { display: 'flex', justifyContent: 'space-between', marginBottom: 18 },
+  mood: { width: 52, height: 52, borderRadius: 9999, border: '1.5px solid hsl(0 0% 90%)', background: '#fff', cursor: 'pointer', fontSize: 26, padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all .15s' },
+  moodOn: { borderColor: 'hsl(24 95% 53%)', background: 'hsl(24 95% 53% / 0.1)', transform: 'scale(1.08)' },
+
+  // Secondary section: текст + фото
+  secondaryLabel: { font: '500 12px/1 Inter', color: 'hsl(0 0% 45%)', marginBottom: 10, letterSpacing: '0.04em', textTransform: 'uppercase' },
+  textarea: { width: '100%', boxSizing: 'border-box', font: '400 14px/1.5 Inter', padding: 14, border: '1px solid hsl(0 0% 90%)', borderRadius: 12, background: '#fff', minHeight: 96, resize: 'none', outline: 'none' },
+  counter: { font: '400 12px/1.2 Inter', color: 'hsl(0 0% 55%)', textAlign: 'right', marginTop: 4, marginBottom: 14 },
+
+  // Photo strip
+  photoStrip: { display: 'flex', gap: 8, marginBottom: 18, flexWrap: 'wrap' },
+  photoTile: { width: 64, height: 64, borderRadius: 10, position: 'relative', overflow: 'hidden' },
+  photoRemove: { position: 'absolute', top: 3, right: 3, width: 18, height: 18, borderRadius: 9999, background: 'rgba(0,0,0,0.65)', color: '#fff', border: 'none', font: '500 10px/1 Inter', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 0 },
+  photoAdd: { width: 64, height: 64, borderRadius: 10, border: '1.5px dashed hsl(0 0% 75%)', background: 'hsl(0 0% 96%)', color: 'hsl(0 0% 35%)', font: '500 11px/1.2 Inter', cursor: 'pointer', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 4, padding: 0 },
+  photoAddIcon: { fontSize: 22, lineHeight: 1 },
+
+  submit: { width: '100%', padding: 16, borderRadius: 12, background: 'hsl(24 95% 53%)', color: '#fff', border: 'none', font: '500 15px/1 Inter', cursor: 'pointer', marginTop: 'auto' },
+};
+
+const IH_MOODS = [
+  { e: '😞', l: 'Плохо' },
+  { e: '😐', l: 'Так себе' },
+  { e: '🙂', l: 'Норм' },
+  { e: '😊', l: 'Хорошо' },
+  { e: '🤩', l: 'Восторг' },
+];
+
+const IH_PHOTO_TINTS = [
+  'linear-gradient(135deg, hsl(28 80% 60%), hsl(14 70% 45%))',
+  'linear-gradient(135deg, hsl(195 60% 55%), hsl(220 50% 35%))',
+  'linear-gradient(135deg, hsl(45 90% 60%), hsl(28 80% 45%))',
+  'linear-gradient(135deg, hsl(140 40% 55%), hsl(160 30% 30%))',
+];
+
+function IHFeedbackScreen() {
+  const [mood, setMood] = React.useState(3);
+  const [text, setText] = React.useState('');
+  const [photos, setPhotos] = React.useState([0, 1]); // pre-attached demo
+  const fileRef = React.useRef(null);
+
+  const addPhotos = () => fileRef.current && fileRef.current.click();
+  const onFile = (e) => {
+    const n = e.target.files ? e.target.files.length : 1;
+    setPhotos(p => [...p, ...Array.from({ length: n }).map((_, i) => p.length + i)]);
+    e.target.value = '';
+  };
+  const removePhoto = (i) => setPhotos(p => p.filter((_, k) => k !== i));
+
+  return (
+    <div style={ihFbStyles.page}>
+      <style>{`@keyframes ihShutterPulse { 0% { transform: scale(1); opacity: 0.5 } 100% { transform: scale(1.4); opacity: 0 } }`}</style>
+      <div style={ihFbStyles.header}>
+        <div style={ihFbStyles.title}>Как прошёл день?</div>
+        <div style={ihFbStyles.sub}>Расскажите своими словами — это лучшая благодарность команде</div>
+      </div>
+      <div style={ihFbStyles.body}>
+
+        {/* Primary: кружок */}
+        <div style={ihFbStyles.primaryCard}>
+          <div style={ihFbStyles.primaryEyebrow}>● Главное</div>
+          <button style={ihFbStyles.primaryShutter}>
+            <div style={ihFbStyles.primaryShutterPulse} />
+            <div style={ihFbStyles.primaryShutterCore} />
+          </button>
+          <div style={ihFbStyles.primaryTitle}>Записать кружок</div>
+          <div style={ihFbStyles.primaryDesc}>До 60 секунд. Самый живой формат — мы видим вас, слышим интонацию.</div>
+        </div>
+
+        {/* Mood */}
+        <div style={ihFbStyles.moodLabel}>Настроение дня</div>
+        <div style={ihFbStyles.moodRow}>
+          {IH_MOODS.map((m, i) => (
+            <button key={i} onClick={() => setMood(i)}
+              style={{ ...ihFbStyles.mood, ...(mood === i ? ihFbStyles.moodOn : {}) }}
+              title={m.l}>
+              {m.e}
+            </button>
+          ))}
+        </div>
+
+        {/* Secondary: photo + text */}
+        <div style={ihFbStyles.secondaryLabel}>Можно добавить ↓</div>
+
+        <div style={ihFbStyles.photoStrip}>
+          {photos.map((p, i) => (
+            <div key={i} style={{ ...ihFbStyles.photoTile, background: IH_PHOTO_TINTS[p % IH_PHOTO_TINTS.length] }}>
+              <button style={ihFbStyles.photoRemove} onClick={() => removePhoto(i)}>✕</button>
+            </div>
+          ))}
+          <button style={ihFbStyles.photoAdd} onClick={addPhotos}>
+            <span style={ihFbStyles.photoAddIcon}>＋</span>
+            <span>Фото</span>
+          </button>
+          <input ref={fileRef} type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={onFile} />
+        </div>
+
+        <textarea style={ihFbStyles.textarea}
+          placeholder="Несколько слов, если хочется добавить…"
+          maxLength={500}
+          value={text} onChange={e => setText(e.target.value)} />
+        <div style={ihFbStyles.counter}>{text.length} / 500</div>
+
+        <button style={ihFbStyles.submit}>Отправить фидбек</button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IHFeedbackScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ItineraryScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ItineraryScreen.jsx
@@ -1,0 +1,130 @@
+// ItineraryScreen.jsx — IndiaHorizone #156
+// «Список 12 дней путешествия, expandable items со временем/адресом/контактом, прогресс "вы прошли 3/12"»
+
+const ihItinStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%' },
+  header: { padding: '14px 20px 16px', background: '#fff', borderBottom: '1px solid hsl(0 0% 90%)' },
+  title: { font: '600 22px/1.2 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.015em', marginBottom: 4 },
+  sub: { font: '400 13px/1.4 Inter', color: 'hsl(0 0% 45%)' },
+  progress: { marginTop: 12 },
+  progressTrack: { height: 6, background: 'hsl(0 0% 92%)', borderRadius: 9999, overflow: 'hidden' },
+  progressBar: { height: '100%', background: 'hsl(24 95% 53%)', borderRadius: 9999 },
+  progressLabel: { display: 'flex', justifyContent: 'space-between', marginTop: 6, font: '500 12px/1.2 Inter', color: 'hsl(0 0% 45%)' },
+  list: { padding: '12px 16px 32px' },
+  day: { background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 14, marginBottom: 10, overflow: 'hidden' },
+  dayHead: { padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer', background: '#fff', border: 'none', width: '100%', textAlign: 'left' },
+  dayBadge: { width: 36, height: 36, borderRadius: 9999, background: 'hsl(0 0% 96%)', font: '600 13px/1 Inter', color: 'hsl(0 0% 35%)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
+  dayBadgeOn: { background: 'hsl(24 95% 53%)', color: '#fff' },
+  dayBadgeDone: { background: 'hsl(142 71% 45% / 0.15)', color: 'hsl(142 71% 30%)' },
+  dayMain: { flex: 1, minWidth: 0 },
+  dayTitle: { font: '600 14px/1.3 Inter', color: 'hsl(0 0% 9%)', marginBottom: 2 },
+  dayMeta: { font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)' },
+  chev: { font: '500 16px/1 Inter', color: 'hsl(0 0% 60%)', transition: 'transform 0.2s' },
+  body: { padding: '0 16px 14px 60px', borderTop: '1px solid hsl(0 0% 94%)' },
+  evt: { display: 'flex', gap: 10, paddingTop: 12 },
+  time: { width: 50, font: '500 12px/1.4 ui-monospace, "JetBrains Mono", monospace', color: 'hsl(0 0% 45%)', flexShrink: 0, paddingTop: 1 },
+  evtBody: { flex: 1, paddingBottom: 12, borderBottom: '1px dashed hsl(0 0% 90%)' },
+  evtTitle: { font: '500 13px/1.3 Inter', color: 'hsl(0 0% 9%)', marginBottom: 2 },
+  evtAddr: { font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)' },
+  evtContact: { display: 'inline-flex', gap: 4, alignItems: 'center', marginTop: 6, font: '500 12px/1 Inter', color: 'hsl(24 95% 38%)', textDecoration: 'none' },
+};
+
+const IH_DAYS = [
+  { date: 'Пн, 5 май', city: 'Дели', status: 'done', events: [
+    { time: '14:30', t: 'Прилёт в Indira Gandhi Intl', a: 'Терминал 3', c: '+91 98765 11122' },
+    { time: '16:00', t: 'Трансфер в отель Imperial', a: 'Janpath Lane', c: 'Водитель Раджеш' },
+    { time: '20:00', t: 'Ужин в Spice Route', a: 'Connaught Place', c: null },
+  ]},
+  { date: 'Вт, 6 май', city: 'Дели → Агра', status: 'done', events: [
+    { time: '08:00', t: 'Завтрак в отеле', a: 'The Imperial', c: null },
+    { time: '10:30', t: 'Выезд в Агру', a: '~3.5 ч', c: 'Гид Прия +91 98765 33344' },
+    { time: '15:00', t: 'Тадж-Махал — sunset слот', a: 'East Gate', c: null },
+  ]},
+  { date: 'Ср, 7 май', city: 'Агра → Джайпур', status: 'today', events: [
+    { time: '09:00', t: 'Форт Агры', a: 'Yamuna Riverbank', c: null },
+    { time: '13:00', t: 'Ланч и выезд в Джайпур', a: '~5 ч', c: 'Гид Прия' },
+    { time: '19:00', t: 'Заселение в Rambagh Palace', a: 'Bhawani Singh Rd', c: '+91 141 221 1919' },
+  ]},
+  { date: 'Чт, 8 май', city: 'Джайпур', status: 'next', events: [
+    { time: '09:30', t: 'Форт Амбер на слоне', a: 'Devisinghpura', c: null },
+    { time: '14:00', t: 'Городской дворец', a: 'Tulsi Marg', c: null },
+  ]},
+  { date: 'Пт, 9 май', city: 'Джайпур → Удайпур', status: 'next', events: [] },
+  { date: 'Сб, 10 май', city: 'Удайпур', status: 'next', events: [] },
+  { date: 'Вс, 11 май', city: 'Удайпур → Кочи', status: 'next', events: [] },
+  { date: 'Пн, 12 май', city: 'Кочи', status: 'next', events: [] },
+  { date: 'Вт, 13 май', city: 'Кочи → Аллеппи', status: 'next', events: [] },
+  { date: 'Ср, 14 май', city: 'Backwaters houseboat', status: 'next', events: [] },
+  { date: 'Чт, 15 май', city: 'Аллеппи → Дели', status: 'next', events: [] },
+  { date: 'Пт, 16 май', city: 'Вылет домой', status: 'next', events: [] },
+];
+
+function IHItineraryScreen() {
+  const [open, setOpen] = React.useState(2);
+  const done = IH_DAYS.filter(d => d.status === 'done').length;
+  const today = IH_DAYS.findIndex(d => d.status === 'today');
+  const passed = today >= 0 ? today : done;
+
+  return (
+    <div style={ihItinStyles.page}>
+      <div style={ihItinStyles.header}>
+        <div style={ihItinStyles.title}>Маршрут</div>
+        <div style={ihItinStyles.sub}>Дели → Раджастан → Керала · 12 дней</div>
+        <div style={ihItinStyles.progress}>
+          <div style={ihItinStyles.progressTrack}>
+            <div style={{ ...ihItinStyles.progressBar, width: `${(passed / IH_DAYS.length) * 100}%` }} />
+          </div>
+          <div style={ihItinStyles.progressLabel}>
+            <span>Вы прошли {passed} из {IH_DAYS.length} дней</span>
+            <span>{Math.round((passed / IH_DAYS.length) * 100)}%</span>
+          </div>
+        </div>
+      </div>
+
+      <div style={ihItinStyles.list}>
+        {IH_DAYS.map((d, i) => {
+          const isOpen = open === i;
+          const badgeStyle = d.status === 'done' ? ihItinStyles.dayBadgeDone : d.status === 'today' ? ihItinStyles.dayBadgeOn : {};
+          return (
+            <div key={i} style={ihItinStyles.day}>
+              <button onClick={() => setOpen(isOpen ? -1 : i)} style={ihItinStyles.dayHead}>
+                <div style={{ ...ihItinStyles.dayBadge, ...badgeStyle }}>
+                  {d.status === 'done' ? '✓' : `Д${i + 1}`}
+                </div>
+                <div style={ihItinStyles.dayMain}>
+                  <div style={ihItinStyles.dayTitle}>{d.city}</div>
+                  <div style={ihItinStyles.dayMeta}>
+                    {d.date}{d.events.length > 0 ? ` · ${d.events.length} событ.` : ' · план уточняется'}
+                    {d.status === 'today' && <span style={{ color: 'hsl(24 95% 38%)', fontWeight: 500 }}> · сегодня</span>}
+                  </div>
+                </div>
+                <div style={{ ...ihItinStyles.chev, transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}>›</div>
+              </button>
+              {isOpen && d.events.length > 0 && (
+                <div style={ihItinStyles.body}>
+                  {d.events.map((e, k) => (
+                    <div key={k} style={ihItinStyles.evt}>
+                      <div style={ihItinStyles.time}>{e.time}</div>
+                      <div style={{ ...ihItinStyles.evtBody, borderBottom: k === d.events.length - 1 ? 'none' : ihItinStyles.evtBody.borderBottom }}>
+                        <div style={ihItinStyles.evtTitle}>{e.t}</div>
+                        <div style={ihItinStyles.evtAddr}>{e.a}</div>
+                        {e.c && <a href="#" style={ihItinStyles.evtContact}>📞 {e.c}</a>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {isOpen && d.events.length === 0 && (
+                <div style={{ padding: '8px 16px 14px 60px', font: '400 12px/1.4 Inter', color: 'hsl(0 0% 60%)' }}>
+                  Concierge добавит события за 48 ч до начала дня
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IHItineraryScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/JournalScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/JournalScreen.jsx
@@ -1,0 +1,97 @@
+// JournalScreen.jsx — IndiaHorizone #184
+// «Таймлайн дней с фото-сетками + кружками-плеерами, кнопка "поделиться приватной ссылкой"»
+
+const ihJrnStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%' },
+  header: { padding: '14px 20px 14px', background: '#fff', borderBottom: '1px solid hsl(0 0% 90%)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
+  title: { font: '600 22px/1.2 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.015em' },
+  shareBtn: { font: '500 12px/1 Inter', color: 'hsl(24 95% 38%)', background: 'hsl(24 95% 53% / 0.1)', border: 'none', padding: '8px 12px', borderRadius: 9999, cursor: 'pointer' },
+  body: { padding: '12px 16px 32px' },
+  dayCard: { background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 14, marginBottom: 14, overflow: 'hidden' },
+  dayHead: { padding: '12px 14px', borderBottom: '1px solid hsl(0 0% 94%)' },
+  dayDate: { font: '500 12px/1 Inter', color: 'hsl(0 0% 45%)' },
+  dayTitle: { font: '600 15px/1.3 Inter', color: 'hsl(0 0% 9%)', marginTop: 2 },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 2, padding: 2 },
+  cell: { aspectRatio: '1 / 1', borderRadius: 4, background: 'hsl(0 0% 85%)', overflow: 'hidden', position: 'relative' },
+  circleRow: { padding: '12px 14px', display: 'flex', gap: 10, overflowX: 'auto', borderTop: '1px solid hsl(0 0% 94%)' },
+  circle: { width: 76, height: 76, borderRadius: 9999, flexShrink: 0, background: 'linear-gradient(135deg, hsl(28 50% 35%), hsl(0 60% 30%))', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', position: 'relative', border: '2px solid hsl(24 95% 53%)' },
+  playIcon: { width: 26, height: 26, borderRadius: 9999, background: 'rgba(255,255,255,0.9)', display: 'flex', alignItems: 'center', justifyContent: 'center', font: '500 11px/1 Inter', color: '#000', paddingLeft: 2 },
+  circleTime: { position: 'absolute', bottom: 4, right: 4, font: '500 9px/1 ui-monospace, "JetBrains Mono", monospace', color: '#fff', background: 'rgba(0,0,0,0.5)', padding: '2px 4px', borderRadius: 4 },
+  shareModal: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'flex-end', zIndex: 50 },
+  sheet: { background: '#fff', width: '100%', borderRadius: '20px 20px 0 0', padding: '20px', boxSizing: 'border-box' },
+  sheetTitle: { font: '600 17px/1.2 Inter', marginBottom: 6 },
+  sheetDesc: { font: '400 13px/1.5 Inter', color: 'hsl(0 0% 45%)', marginBottom: 16 },
+  linkBox: { display: 'flex', gap: 6, padding: '10px 12px', background: 'hsl(0 0% 96%)', borderRadius: 10, font: '500 12px/1.2 ui-monospace, "JetBrains Mono", monospace', color: 'hsl(0 0% 9%)', wordBreak: 'break-all', marginBottom: 12 },
+  copyBtn: { padding: '4px 10px', borderRadius: 6, border: 'none', background: 'hsl(24 95% 53%)', color: '#fff', font: '500 11px/1 Inter', cursor: 'pointer', flexShrink: 0 },
+  toggleRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '12px 0', borderTop: '1px solid hsl(0 0% 94%)' },
+};
+
+const IH_DAYS_J = [
+  { date: 'Чт, 8 май', city: 'Джайпур · Форт Амбер', photos: 6, circles: [{ t: '0:42', g: 'hsl(28 60% 40%)' }, { t: '1:00', g: 'hsl(0 50% 35%)' }] },
+  { date: 'Ср, 7 май', city: 'Тадж-Махал на закате', photos: 9, circles: [{ t: '0:55', g: 'hsl(20 70% 45%)' }] },
+  { date: 'Вт, 6 май', city: 'Дорога Дели → Агра', photos: 4, circles: [] },
+  { date: 'Пн, 5 май', city: 'Прилёт в Дели', photos: 3, circles: [{ t: '0:28', g: 'hsl(28 40% 30%)' }] },
+];
+
+const photoTints = ['hsl(28 50% 65%)', 'hsl(0 50% 60%)', 'hsl(40 60% 70%)', 'hsl(15 55% 55%)', 'hsl(28 35% 45%)', 'hsl(8 60% 50%)', 'hsl(38 70% 65%)', 'hsl(20 45% 40%)', 'hsl(0 40% 35%)'];
+
+function IHJournalScreen() {
+  const [shareOpen, setShareOpen] = React.useState(false);
+  const [includeCircles, setIncludeCircles] = React.useState(true);
+  return (
+    <div style={ihJrnStyles.page}>
+      <div style={ihJrnStyles.header}>
+        <div style={ihJrnStyles.title}>Дневник</div>
+        <button style={ihJrnStyles.shareBtn} onClick={() => setShareOpen(true)}>🔗 Приватная ссылка</button>
+      </div>
+      <div style={ihJrnStyles.body}>
+        {IH_DAYS_J.map((d, i) => (
+          <div key={i} style={ihJrnStyles.dayCard}>
+            <div style={ihJrnStyles.dayHead}>
+              <div style={ihJrnStyles.dayDate}>{d.date}</div>
+              <div style={ihJrnStyles.dayTitle}>{d.city}</div>
+            </div>
+            <div style={ihJrnStyles.grid}>
+              {Array.from({ length: d.photos }).map((_, k) => (
+                <div key={k} style={{ ...ihJrnStyles.cell, background: `linear-gradient(135deg, ${photoTints[(i * 3 + k) % photoTints.length]}, hsl(0 0% 25%))` }} />
+              ))}
+            </div>
+            {d.circles.length > 0 && (
+              <div style={ihJrnStyles.circleRow}>
+                {d.circles.map((c, k) => (
+                  <button key={k} style={{ ...ihJrnStyles.circle, background: `linear-gradient(135deg, ${c.g}, hsl(0 0% 15%))` }}>
+                    <div style={ihJrnStyles.playIcon}>▶</div>
+                    <div style={ihJrnStyles.circleTime}>{c.t}</div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {shareOpen && (
+        <div style={ihJrnStyles.shareModal} onClick={() => setShareOpen(false)}>
+          <div style={ihJrnStyles.sheet} onClick={e => e.stopPropagation()}>
+            <div style={ihJrnStyles.sheetTitle}>Приватная ссылка</div>
+            <div style={ihJrnStyles.sheetDesc}>Видна только тем, у кого есть ссылка. Можно отозвать в любой момент.</div>
+            <div style={ihJrnStyles.linkBox}>
+              <span style={{ flex: 1 }}>indiahorizone.ru/j/anna-may26/9b3e7a05</span>
+              <button style={ihJrnStyles.copyBtn}>Копировать</button>
+            </div>
+            <div style={ihJrnStyles.toggleRow}>
+              <span style={{ font: '400 13px/1.4 Inter' }}>Включить кружки</span>
+              <button onClick={() => setIncludeCircles(v => !v)}
+                style={{ width: 38, height: 22, borderRadius: 9999, border: 'none', background: includeCircles ? 'hsl(24 95% 53%)' : 'hsl(0 0% 85%)', position: 'relative', cursor: 'pointer' }}>
+                <div style={{ position: 'absolute', top: 2, left: includeCircles ? 18 : 2, width: 18, height: 18, borderRadius: 9999, background: '#fff', transition: 'left .15s' }} />
+              </button>
+            </div>
+            <button style={{ width: '100%', marginTop: 12, padding: 14, borderRadius: 10, background: 'hsl(0 0% 9%)', color: '#fff', border: 'none', font: '500 14px/1 Inter', cursor: 'pointer' }} onClick={() => setShareOpen(false)}>Готово</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { IHJournalScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ProfileScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ProfileScreen.jsx
@@ -1,0 +1,228 @@
+// ProfileScreen.jsx — IndiaHorizone #147
+// «Экран профиля с табами: личные данные, согласия (4 уровня для photo_video, A/B/C/D для geo), emergency contacts, паспорт»
+
+const ihProfStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%' },
+  header: { padding: '14px 20px 12px', borderBottom: '1px solid hsl(0 0% 90%)', background: '#fff', display: 'flex', alignItems: 'center', gap: 12 },
+  back: { width: 32, height: 32, borderRadius: 9999, border: 'none', background: 'hsl(0 0% 96%)', font: '500 16px/1 Inter', color: 'hsl(0 0% 9%)', cursor: 'pointer' },
+  title: { font: '600 17px/1.2 Inter', color: 'hsl(0 0% 9%)', letterSpacing: '-0.01em' },
+  tabs: { display: 'flex', gap: 0, padding: '0 12px', background: '#fff', borderBottom: '1px solid hsl(0 0% 90%)', overflowX: 'auto' },
+  tab: { flexShrink: 0, padding: '14px 12px', font: '500 13px/1 Inter', color: 'hsl(0 0% 45%)', background: 'transparent', border: 'none', cursor: 'pointer', borderBottom: '2px solid transparent' },
+  tabOn: { color: 'hsl(0 0% 9%)', borderBottomColor: 'hsl(24 95% 53%)' },
+  body: { padding: '16px 20px 32px' },
+  field: { marginBottom: 14 },
+  label: { display: 'block', font: '500 13px/1.2 Inter', color: 'hsl(0 0% 9%)', marginBottom: 6 },
+  input: { width: '100%', boxSizing: 'border-box', font: '400 14px/1.4 Inter', padding: '10px 12px', border: '1px solid hsl(0 0% 90%)', borderRadius: 8, background: '#fff' },
+  card: { background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 14, padding: 14, marginBottom: 12 },
+  consentTitle: { font: '600 14px/1.3 Inter', color: 'hsl(0 0% 9%)', marginBottom: 4 },
+  consentDesc: { font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginBottom: 10 },
+  level: { display: 'flex', gap: 8, alignItems: 'flex-start', padding: '10px 12px', borderRadius: 10, border: '1px solid hsl(0 0% 90%)', marginBottom: 6, cursor: 'pointer', background: '#fff' },
+  levelOn: { borderColor: 'hsl(24 95% 53%)', background: 'hsl(24 95% 53% / 0.06)' },
+  radio: { width: 16, height: 16, borderRadius: 9999, border: '1.5px solid hsl(0 0% 70%)', flexShrink: 0, marginTop: 2, position: 'relative' },
+  radioOn: { borderColor: 'hsl(24 95% 53%)' },
+  radioInner: { position: 'absolute', inset: 3, borderRadius: 9999, background: 'hsl(24 95% 53%)' },
+  saveBtn: { width: '100%', padding: '14px', borderRadius: 10, background: 'hsl(24 95% 53%)', color: '#fff', border: 'none', font: '500 15px/1 Inter', cursor: 'pointer', marginTop: 12 },
+};
+
+function IHRadioRow({ on, title, desc, onClick }) {
+  return (
+    <button onClick={onClick} style={{ ...ihProfStyles.level, ...(on ? ihProfStyles.levelOn : {}), width: '100%', textAlign: 'left' }}>
+      <div style={{ ...ihProfStyles.radio, ...(on ? ihProfStyles.radioOn : {}) }}>
+        {on && <div style={ihProfStyles.radioInner} />}
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ font: '500 13px/1.3 Inter', color: 'hsl(0 0% 9%)' }}>{title}</div>
+        <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginTop: 2 }}>{desc}</div>
+      </div>
+    </button>
+  );
+}
+
+function IHProfileScreen() {
+  const [tab, setTab] = React.useState('personal');
+  const [photoConsent, setPhotoConsent] = React.useState(2);
+  const [geoConsent, setGeoConsent] = React.useState('B');
+
+  const tabs = [
+    { id: 'personal', label: 'Личные данные' },
+    { id: 'consents', label: 'Согласия' },
+    { id: 'emergency', label: 'Контакты' },
+    { id: 'passport', label: 'Паспорт' },
+  ];
+
+  return (
+    <div style={ihProfStyles.page}>
+      <div style={ihProfStyles.header}>
+        <button style={ihProfStyles.back}>←</button>
+        <div style={ihProfStyles.title}>Профиль</div>
+      </div>
+      <div style={ihProfStyles.tabs}>
+        {tabs.map(t => (
+          <button key={t.id} onClick={() => setTab(t.id)}
+            style={{ ...ihProfStyles.tab, ...(tab === t.id ? ihProfStyles.tabOn : {}) }}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div style={ihProfStyles.body}>
+        {tab === 'personal' && (
+          <>
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 18 }}>
+              <div style={{ width: 64, height: 64, borderRadius: 9999, background: 'hsl(24 95% 53% / 0.15)', color: 'hsl(24 95% 38%)', display: 'flex', alignItems: 'center', justifyContent: 'center', font: '600 22px/1 Inter' }}>АК</div>
+              <button style={{ font: '500 13px/1 Inter', color: 'hsl(24 95% 38%)', background: 'transparent', border: '1px solid hsl(0 0% 90%)', borderRadius: 9999, padding: '8px 14px', cursor: 'pointer' }}>Изменить фото</button>
+            </div>
+            <div style={ihProfStyles.field}><label style={ihProfStyles.label}>Имя и фамилия</label><input style={ihProfStyles.input} defaultValue="Анна Кузнецова" /></div>
+            <div style={ihProfStyles.field}><label style={ihProfStyles.label}>Дата рождения</label><input style={ihProfStyles.input} defaultValue="14.06.1987" /></div>
+            <div style={ihProfStyles.field}><label style={ihProfStyles.label}>Телефон</label><input style={ihProfStyles.input} defaultValue="+7 916 123-45-67" /></div>
+            <div style={ihProfStyles.field}><label style={ihProfStyles.label}>Email</label><input style={ihProfStyles.input} defaultValue="anna.k@почта.рф" /></div>
+            <button style={ihProfStyles.saveBtn}>Сохранить</button>
+          </>
+        )}
+
+        {tab === 'consents' && (
+          <>
+            <div style={ihProfStyles.card}>
+              <div style={ihProfStyles.consentTitle}>📸 Фото и видео</div>
+              <div style={ihProfStyles.consentDesc}>Как мы можем использовать ваши снимки и кружки</div>
+              {[
+                { lvl: 1, t: 'Уровень 1 — только мне', d: 'Фото и видео видны только вам в дневнике' },
+                { lvl: 2, t: 'Уровень 2 — команде concierge', d: 'Чтобы помогать делать поездку лучше' },
+                { lvl: 3, t: 'Уровень 3 — другим клиентам с тегом', d: 'В групповых поездках по согласию' },
+                { lvl: 4, t: 'Уровень 4 — публично, анонимно', d: 'В маркетинге IndiaHorizone без имени' },
+              ].map(o => (
+                <IHRadioRow key={o.lvl} on={photoConsent === o.lvl} title={o.t} desc={o.d} onClick={() => setPhotoConsent(o.lvl)} />
+              ))}
+            </div>
+
+            <div style={ihProfStyles.card}>
+              <div style={ihProfStyles.consentTitle}>📍 Геолокация</div>
+              <div style={ihProfStyles.consentDesc}>Как часто и зачем мы знаем, где вы</div>
+              {[
+                { lvl: 'A', t: 'A — никогда', d: 'Только если вы сами поделитесь' },
+                { lvl: 'B', t: 'B — при SOS и активных трансферах', d: 'Рекомендуем — для экстренной помощи' },
+                { lvl: 'C', t: 'C — весь день поездки', d: 'Concierge может предложить место рядом' },
+                { lvl: 'D', t: 'D — всегда, включая фоновое', d: 'Максимум поддержки, минимум приватности' },
+              ].map(o => (
+                <IHRadioRow key={o.lvl} on={geoConsent === o.lvl} title={o.t} desc={o.d} onClick={() => setGeoConsent(o.lvl)} />
+              ))}
+            </div>
+
+            <button style={ihProfStyles.saveBtn}>Сохранить согласия</button>
+          </>
+        )}
+
+        {tab === 'emergency' && (
+          <>
+            <div style={{ font: '400 13px/1.5 Inter', color: 'hsl(0 0% 45%)', marginBottom: 14 }}>
+              Кому позвонить, если вы нажали SOS и не отвечаете
+            </div>
+            {[
+              { name: 'Сергей (муж)', phone: '+7 916 555-12-34', primary: true },
+              { name: 'Мама', phone: '+7 921 222-99-01', primary: false },
+            ].map((c, i) => (
+              <div key={i} style={ihProfStyles.card}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <div style={{ font: '600 14px/1.3 Inter' }}>{c.name}</div>
+                    <div style={{ font: '500 13px/1.4 ui-monospace, "JetBrains Mono", monospace', color: 'hsl(0 0% 45%)', marginTop: 3 }}>{c.phone}</div>
+                  </div>
+                  {c.primary && <span style={{ font: '500 11px/1 Inter', padding: '4px 8px', borderRadius: 9999, background: 'hsl(24 95% 53% / 0.12)', color: 'hsl(24 95% 38%)' }}>Главный</span>}
+                </div>
+              </div>
+            ))}
+            <button style={{ ...ihProfStyles.saveBtn, background: 'transparent', color: 'hsl(0 0% 9%)', border: '1px solid hsl(0 0% 90%)' }}>+ Добавить контакт</button>
+          </>
+        )}
+
+        {tab === 'passport' && (
+          <>
+            {/* OCR-распознанная карточка паспорта */}
+            <div style={{ ...ihProfStyles.card, padding: 0, overflow: 'hidden' }}>
+              <div style={{ display: 'flex', gap: 12, padding: 14, borderBottom: '1px solid hsl(0 0% 94%)', alignItems: 'center' }}>
+                <div style={{ width: 56, height: 72, borderRadius: 8, background: 'linear-gradient(135deg, hsl(24 95% 53%), hsl(24 95% 40%))', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 24, flexShrink: 0 }}>🛂</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ font: '600 14px/1.3 Inter' }}>Загранпаспорт RU</div>
+                  <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginTop: 2 }}>Распознан 14 мар 2026</div>
+                </div>
+                <span style={{ font: '500 11px/1 Inter', padding: '4px 8px', borderRadius: 9999, background: 'hsl(142 71% 45% / 0.12)', color: 'hsl(142 71% 30%)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <span style={{ fontSize: 10 }}>●</span> OCR 98%
+                </span>
+              </div>
+
+              {/* Распознанные поля */}
+              <div style={{ padding: '6px 14px 12px' }}>
+                <div style={{ font: '500 11px/1 Inter', color: 'hsl(0 0% 45%)', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '12px 0 8px' }}>Распознанные данные</div>
+                {[
+                  { l: 'Серия и номер', v: '75 1234567', mono: true },
+                  { l: 'Фамилия (lat.)', v: 'KUZNETSOVA' },
+                  { l: 'Имя (lat.)', v: 'ANNA' },
+                  { l: 'Пол', v: 'F / Жен.' },
+                  { l: 'Дата рождения', v: '14.06.1987' },
+                  { l: 'Место рождения', v: 'Г. МОСКВА' },
+                  { l: 'Дата выдачи', v: '15.08.2021' },
+                  { l: 'Действителен до', v: '14.08.2031', accent: true },
+                  { l: 'Кем выдан', v: 'ФМС 770-094' },
+                  { l: 'Гражданство', v: 'РОССИЯ / RUS' },
+                ].map((f, i) => (
+                  <div key={i} style={{
+                    display: 'flex', justifyContent: 'space-between', gap: 12,
+                    padding: '8px 0', borderBottom: i < 9 ? '1px solid hsl(0 0% 96%)' : 'none',
+                  }}>
+                    <span style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', flexShrink: 0 }}>{f.l}</span>
+                    <span style={{
+                      font: f.mono
+                        ? '500 13px/1.4 ui-monospace, "JetBrains Mono", monospace'
+                        : '500 13px/1.4 Inter',
+                      color: f.accent ? 'hsl(24 95% 38%)' : 'hsl(0 0% 9%)',
+                      textAlign: 'right',
+                    }}>{f.v}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div style={{ display: 'flex', gap: 8, padding: '0 14px 14px' }}>
+                <button style={{ flex: 1, padding: '10px', borderRadius: 8, background: 'transparent', border: '1px solid hsl(0 0% 90%)', font: '500 12px/1 Inter', color: 'hsl(0 0% 9%)', cursor: 'pointer' }}>Исправить</button>
+                <button style={{ flex: 1, padding: '10px', borderRadius: 8, background: 'transparent', border: '1px solid hsl(0 0% 90%)', font: '500 12px/1 Inter', color: 'hsl(0 0% 9%)', cursor: 'pointer' }}>Просмотр скана</button>
+              </div>
+            </div>
+
+            {/* Виза */}
+            <div style={ihProfStyles.card}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10 }}>
+                <div>
+                  <div style={{ font: '600 14px/1.3 Inter' }}>Виза India e-Tourist</div>
+                  <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginTop: 2 }}>Распознана 18 мар 2026</div>
+                </div>
+                <span style={{ font: '500 11px/1 Inter', padding: '4px 8px', borderRadius: 9999, background: 'hsl(142 71% 45% / 0.12)', color: 'hsl(142 71% 30%)', alignSelf: 'flex-start' }}>✓ Активна</span>
+              </div>
+              {[
+                { l: 'Номер визы', v: 'VN8473921', mono: true },
+                { l: 'Тип', v: 'e-Tourist (30 дней)' },
+                { l: 'Выдана', v: '18.03.2026' },
+                { l: 'Истекает', v: '07.05.2026', accent: true },
+                { l: 'Въездов', v: 'Двукратная' },
+              ].map((f, i, a) => (
+                <div key={i} style={{
+                  display: 'flex', justifyContent: 'space-between', gap: 12,
+                  padding: '7px 0', borderBottom: i < a.length - 1 ? '1px solid hsl(0 0% 96%)' : 'none',
+                }}>
+                  <span style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)' }}>{f.l}</span>
+                  <span style={{
+                    font: f.mono
+                      ? '500 13px/1.4 ui-monospace, "JetBrains Mono", monospace'
+                      : '500 13px/1.4 Inter',
+                    color: f.accent ? 'hsl(24 95% 38%)' : 'hsl(0 0% 9%)',
+                  }}>{f.v}</span>
+                </div>
+              ))}
+            </div>
+
+            <button style={{ ...ihProfStyles.saveBtn, background: 'transparent', color: 'hsl(0 0% 9%)', border: '1px solid hsl(0 0% 90%)' }}>+ Загрузить документ</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IHProfileScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/README.md
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/README.md
@@ -1,0 +1,20 @@
+# UI Kit — Trip Dashboard
+
+Mobile-first клиентский кабинет IndiaHorizone. Главный экран по спецификации [`docs/UX/FEATURES/CORE.md`](https://github.com/Rivega42/indiahorizone/blob/main/docs/UX/FEATURES/CORE.md).
+
+## Состав
+- **`IHPageHeader`** — флаг страны + локация + «День N из M» + аватар
+- **`IHTimelineCard`** — Сейчас + Следующее с countdown
+- **`IHQuickActions`** — 4-up grid: Документы / Маршрут / Concierge / Гид
+- **`IHCircleCard`** — приглашение записать кружок дня
+- **`IHSosButton`** — hold-to-trigger SOS (2 сек заполнение, можно отменить отпусканием)
+- **`IHBottomSheet`** — sheet с handle bar и close, для документов / маршрута / чата
+- **`IHDocRow`** — строка документа с offline-бейджем
+
+## Как открыть
+`index.html` → mobile preview 420×820. Тапы на quick actions открывают bottom sheets. Hold на SOS активирует через 2 сек. Запись кружка → toast → status «отправлено».
+
+## Заметки
+- Все цвета — через `colors_and_type.css` CSS-переменные.
+- Иконки текущей версии — emoji (быстрые маркеры из спеки CORE.md). В production-коде заменяются на Lucide.
+- Статус-бар и home-indicator нарисованы простой обёрткой phone shell — для production используйте `ios-frame.jsx` стартер.

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/RecorderScreen.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/RecorderScreen.jsx
@@ -1,0 +1,132 @@
+// RecorderScreen.jsx — IndiaHorizone #179
+// «Полноэкранный recorder с фронтальной камерой, hold-to-record / tap-start, 60sec countdown, preview + retake»
+
+const ihRecStyles = {
+  page: { background: '#000', height: '100%', position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column' },
+  viewfinder: { flex: 1, position: 'relative', overflow: 'hidden' },
+  fakeFeed: { position: 'absolute', inset: 0, background: 'radial-gradient(120% 80% at 50% 30%, hsl(28 60% 50%), hsl(28 30% 18%) 60%, #000 100%)' },
+  fakeSilhouette: { position: 'absolute', left: '50%', top: '34%', width: 180, height: 220, transform: 'translateX(-50%)', background: 'radial-gradient(ellipse at 50% 30%, hsl(28 40% 30% / 0.6), transparent 70%)', borderRadius: '50% 50% 45% 45%' },
+  topBar: { position: 'absolute', top: 0, left: 0, right: 0, padding: '14px 18px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', zIndex: 5 },
+  closeBtn: { width: 36, height: 36, borderRadius: 9999, background: 'rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.18)', color: '#fff', font: '500 16px/1 Inter', cursor: 'pointer' },
+  flipBtn: { width: 36, height: 36, borderRadius: 9999, background: 'rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.18)', color: '#fff', font: '500 14px/1 Inter', cursor: 'pointer' },
+  countdown: { position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)', background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', color: '#fff', font: '500 13px/1 ui-monospace, "JetBrains Mono", monospace', padding: '6px 12px', borderRadius: 9999, display: 'flex', alignItems: 'center', gap: 6, zIndex: 5 },
+  recDot: { width: 8, height: 8, borderRadius: 9999, background: 'hsl(0 84% 60%)', animation: 'ihRecBlink 1.4s infinite ease-in-out' },
+  hint: { position: 'absolute', bottom: 160, left: '50%', transform: 'translateX(-50%)', color: '#fff', font: '500 13px/1.4 Inter', textAlign: 'center', textShadow: '0 1px 4px rgba(0,0,0,0.6)', maxWidth: 240, opacity: 0.85 },
+  controls: { padding: '20px 0 32px', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 32, position: 'relative', zIndex: 5 },
+  shutter: { width: 72, height: 72, borderRadius: 9999, background: 'transparent', border: '4px solid #fff', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', position: 'relative', padding: 0 },
+  shutterCore: { width: 56, height: 56, borderRadius: 9999, background: 'hsl(0 84% 60%)', transition: 'all .2s' },
+  shutterCoreOn: { width: 28, height: 28, borderRadius: 6 },
+  ringSvg: { position: 'absolute', inset: -6, transform: 'rotate(-90deg)' },
+  modeRow: { position: 'absolute', bottom: 130, left: 0, right: 0, display: 'flex', justifyContent: 'center', gap: 16, zIndex: 5 },
+  modeBtn: { font: '500 12px/1 Inter', color: '#fff', background: 'transparent', border: 'none', cursor: 'pointer', padding: '6px 10px', borderRadius: 9999, opacity: 0.6 },
+  modeBtnOn: { background: 'rgba(255,255,255,0.18)', opacity: 1 },
+  // preview
+  preview: { position: 'absolute', inset: 0, background: '#000', display: 'flex', flexDirection: 'column', zIndex: 10 },
+  previewVideo: { flex: 1, position: 'relative', background: 'radial-gradient(120% 80% at 50% 30%, hsl(28 60% 50%), hsl(28 30% 18%) 60%, #000 100%)', display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  playBtn: { width: 64, height: 64, borderRadius: 9999, background: 'rgba(255,255,255,0.85)', border: 'none', font: '500 22px/1 Inter', color: '#000', cursor: 'pointer' },
+  prevBar: { position: 'absolute', bottom: 16, left: 16, right: 16, height: 4, background: 'rgba(255,255,255,0.25)', borderRadius: 9999, overflow: 'hidden' },
+  prevFill: { height: '100%', width: '40%', background: '#fff', borderRadius: 9999 },
+  prevActions: { padding: '20px 20px 32px', display: 'flex', gap: 12, background: '#000' },
+  retake: { flex: 1, padding: '14px', borderRadius: 12, background: 'transparent', border: '1px solid rgba(255,255,255,0.25)', color: '#fff', font: '500 14px/1 Inter', cursor: 'pointer' },
+  send: { flex: 1, padding: '14px', borderRadius: 12, background: 'hsl(24 95% 53%)', border: 'none', color: '#fff', font: '500 14px/1 Inter', cursor: 'pointer' },
+};
+
+function IHCircleProgress({ progress }) {
+  const r = 38;
+  const c = 2 * Math.PI * r;
+  return (
+    <svg style={ihRecStyles.ringSvg} width="84" height="84" viewBox="0 0 84 84">
+      <circle cx="42" cy="42" r={r} fill="none" stroke="rgba(255,255,255,0.2)" strokeWidth="3" />
+      <circle cx="42" cy="42" r={r} fill="none" stroke="hsl(0 84% 60%)" strokeWidth="3"
+        strokeDasharray={c} strokeDashoffset={c - c * progress} strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IHRecorderScreen({ initial = 'idle', mode = 'tap' }) {
+  const [state, setState] = React.useState(initial); // idle | recording | preview
+  const [secs, setSecs] = React.useState(0);
+  const [recMode, setRecMode] = React.useState(mode);
+
+  React.useEffect(() => {
+    if (state !== 'recording') return;
+    const id = setInterval(() => setSecs(s => {
+      if (s >= 60) { clearInterval(id); setState('preview'); return 60; }
+      return s + 1;
+    }), 1000);
+    return () => clearInterval(id);
+  }, [state]);
+
+  const start = () => { setSecs(0); setState('recording'); };
+  const stop = () => setState('preview');
+  const retake = () => { setSecs(0); setState('idle'); };
+
+  return (
+    <div style={ihRecStyles.page}>
+      <style>{`@keyframes ihRecBlink { 0%, 100% { opacity: 1 } 50% { opacity: 0.3 } }`}</style>
+
+      <div style={ihRecStyles.viewfinder}>
+        <div style={ihRecStyles.fakeFeed} />
+        <div style={ihRecStyles.fakeSilhouette} />
+
+        <div style={ihRecStyles.topBar}>
+          <button style={ihRecStyles.closeBtn}>✕</button>
+          <button style={ihRecStyles.flipBtn}>↺</button>
+        </div>
+
+        {state === 'recording' && (
+          <div style={ihRecStyles.countdown}>
+            <div style={ihRecStyles.recDot} />
+            <span>0:{String(secs).padStart(2, '0')} / 1:00</span>
+          </div>
+        )}
+
+        {state === 'idle' && (
+          <div style={ihRecStyles.hint}>
+            {recMode === 'hold' ? 'Зажмите кнопку, чтобы записать кружок' : 'Нажмите, чтобы начать. До 60 секунд.'}
+          </div>
+        )}
+
+        <div style={ihRecStyles.modeRow}>
+          {[{ id: 'tap', l: 'Tap-start' }, { id: 'hold', l: 'Hold' }].map(m => (
+            <button key={m.id} onClick={() => setRecMode(m.id)}
+              style={{ ...ihRecStyles.modeBtn, ...(recMode === m.id ? ihRecStyles.modeBtnOn : {}) }}>
+              {m.l}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={ihRecStyles.controls}>
+        <button
+          style={ihRecStyles.shutter}
+          onClick={() => { if (recMode === 'tap') state === 'idle' ? start() : stop(); }}
+          onMouseDown={() => { if (recMode === 'hold') start(); }}
+          onMouseUp={() => { if (recMode === 'hold') stop(); }}
+        >
+          {state === 'recording' && <IHCircleProgress progress={secs / 60} />}
+          <div style={{ ...ihRecStyles.shutterCore, ...(state === 'recording' ? ihRecStyles.shutterCoreOn : {}) }} />
+        </button>
+      </div>
+
+      {state === 'preview' && (
+        <div style={ihRecStyles.preview}>
+          <div style={ihRecStyles.topBar}>
+            <button style={ihRecStyles.closeBtn} onClick={retake}>✕</button>
+            <div style={{ font: '500 13px/1 Inter', color: '#fff', opacity: 0.8 }}>0:{String(secs).padStart(2, '0')}</div>
+          </div>
+          <div style={ihRecStyles.previewVideo}>
+            <button style={ihRecStyles.playBtn}>▶</button>
+            <div style={ihRecStyles.prevBar}><div style={ihRecStyles.prevFill} /></div>
+          </div>
+          <div style={ihRecStyles.prevActions}>
+            <button style={ihRecStyles.retake} onClick={retake}>Перезаписать</button>
+            <button style={ihRecStyles.send}>Отправить</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { IHRecorderScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/SOSScreens.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/SOSScreens.jsx
@@ -1,0 +1,164 @@
+// SOSScreens.jsx — IndiaHorizone #198 + #199
+// #198: «Floating-button SOS, hold 2sec заполняет круг, после trigger показ "Помощь идёт. Дежурный — X. ETA ~60sec"»
+// #199: «После trigger: live-обновление статуса (sent → ack → дежурный X на связи), open chat»
+
+const ihSosStyles = {
+  page: { background: 'hsl(0 0% 98%)', minHeight: '100%', position: 'relative', display: 'flex', flexDirection: 'column' },
+  header: { padding: '14px 20px', background: '#fff', borderBottom: '1px solid hsl(0 0% 90%)' },
+  title: { font: '600 18px/1.2 Inter', color: 'hsl(0 0% 9%)' },
+  body: { padding: 20, flex: 1 },
+  hint: { background: 'hsl(0 84% 60% / 0.08)', border: '1px solid hsl(0 84% 60% / 0.25)', padding: 14, borderRadius: 12, color: 'hsl(0 84% 35%)', font: '400 13px/1.5 Inter', marginBottom: 20 },
+  fab: { position: 'absolute', right: 24, bottom: 90, width: 80, height: 80, borderRadius: 9999, background: 'hsl(0 84% 60%)', border: 'none', color: '#fff', font: '700 16px/1 Inter', cursor: 'pointer', boxShadow: '0 8px 24px rgba(220, 38, 38, 0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', userSelect: 'none', touchAction: 'none' },
+  fabHint: { position: 'absolute', right: 110, bottom: 110, font: '500 12px/1.3 Inter', color: 'hsl(0 0% 35%)', textAlign: 'right' },
+
+  // active screen
+  activePage: { background: 'linear-gradient(180deg, hsl(0 84% 60%) 0%, hsl(0 70% 45%) 100%)', minHeight: '100%', color: '#fff', display: 'flex', flexDirection: 'column' },
+  activeHeader: { padding: '16px 20px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
+  cancelBtn: { background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.3)', color: '#fff', padding: '6px 12px', borderRadius: 9999, font: '500 12px/1 Inter', cursor: 'pointer' },
+  liveBadge: { display: 'flex', alignItems: 'center', gap: 6, font: '500 12px/1 Inter' },
+  liveDot: { width: 8, height: 8, borderRadius: 9999, background: '#fff', animation: 'ihPulse 1.4s infinite' },
+  hero: { textAlign: 'center', padding: '40px 24px 24px' },
+  heroTitle: { font: '700 28px/1.2 Inter', letterSpacing: '-0.02em', marginBottom: 8 },
+  heroSub: { font: '400 14px/1.5 Inter', opacity: 0.92 },
+  pulseRing: { width: 140, height: 140, borderRadius: 9999, margin: '32px auto', position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.15)', border: '3px solid rgba(255,255,255,0.4)' },
+  pulseInner: { width: 80, height: 80, borderRadius: 9999, background: '#fff', color: 'hsl(0 84% 60%)', font: '700 30px/1 Inter', display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  steps: { padding: '0 24px', marginTop: 12 },
+  step: { display: 'flex', gap: 12, alignItems: 'flex-start', padding: '12px 0' },
+  stepDot: { width: 22, height: 22, borderRadius: 9999, border: '2px solid rgba(255,255,255,0.4)', flexShrink: 0, marginTop: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', font: '500 12px/1 Inter' },
+  stepDotOn: { background: '#fff', color: 'hsl(0 84% 45%)', borderColor: '#fff' },
+  stepBody: { flex: 1 },
+  stepTitle: { font: '500 14px/1.3 Inter' },
+  stepTime: { font: '400 12px/1.4 Inter', opacity: 0.75, marginTop: 2 },
+  duty: { background: 'rgba(0,0,0,0.18)', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 14, margin: '20px 24px', display: 'flex', gap: 12, alignItems: 'center' },
+  dutyAv: { width: 48, height: 48, borderRadius: 9999, background: 'rgba(255,255,255,0.25)', display: 'flex', alignItems: 'center', justifyContent: 'center', font: '600 16px/1 Inter', flexShrink: 0 },
+  dutyName: { font: '600 14px/1.3 Inter' },
+  dutyRole: { font: '400 12px/1.4 Inter', opacity: 0.85, marginTop: 2 },
+  bottomActions: { padding: 20, display: 'flex', gap: 10, marginTop: 'auto' },
+  callBtn: { flex: 1, padding: 14, borderRadius: 12, background: '#fff', color: 'hsl(0 84% 45%)', border: 'none', font: '600 14px/1 Inter', cursor: 'pointer' },
+  chatBtn: { flex: 1, padding: 14, borderRadius: 12, background: 'rgba(0,0,0,0.25)', color: '#fff', border: '1px solid rgba(255,255,255,0.3)', font: '500 14px/1 Inter', cursor: 'pointer' },
+};
+
+function IHSosCharge({ progress, size = 80 }) {
+  const r = (size - 8) / 2;
+  const c = 2 * Math.PI * r;
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ position: 'absolute', inset: 0, transform: 'rotate(-90deg)', pointerEvents: 'none' }}>
+      <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(255,255,255,0.35)" strokeWidth="4" />
+      <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="#fff" strokeWidth="4" strokeLinecap="round"
+        strokeDasharray={c} strokeDashoffset={c - c * progress} />
+    </svg>
+  );
+}
+
+function IHSosTriggerScreen({ onTrigger }) {
+  const [progress, setProgress] = React.useState(0);
+  const startRef = React.useRef(0);
+  const rafRef = React.useRef(0);
+
+  const tick = () => {
+    const elapsed = (performance.now() - startRef.current) / 2000;
+    const p = Math.min(1, elapsed);
+    setProgress(p);
+    if (p >= 1) { onTrigger && onTrigger(); return; }
+    rafRef.current = requestAnimationFrame(tick);
+  };
+  const start = (e) => { e.preventDefault(); startRef.current = performance.now(); rafRef.current = requestAnimationFrame(tick); };
+  const stop = () => { cancelAnimationFrame(rafRef.current); setProgress(0); };
+
+  return (
+    <div style={ihSosStyles.page}>
+      <div style={ihSosStyles.header}><div style={ihSosStyles.title}>Экстренная помощь</div></div>
+      <div style={ihSosStyles.body}>
+        <div style={ihSosStyles.hint}>
+          <strong>Как это работает.</strong> Зажмите красную кнопку на 2 секунды.
+          Дежурный concierge получит ваше местоположение и свяжется в течение минуты.
+        </div>
+        <div style={{ font: '400 14px/1.6 Inter', color: 'hsl(0 0% 35%)' }}>
+          <p>Используйте, если:</p>
+          <ul style={{ paddingLeft: 18, margin: 0 }}>
+            <li>вам срочно нужна помощь, и вы не успеваете писать;</li>
+            <li>заблудились или потеряли документы;</li>
+            <li>возникла медицинская ситуация.</li>
+          </ul>
+          <p style={{ marginTop: 16, color: 'hsl(0 0% 55%)', font: '400 12px/1.5 Inter' }}>
+            При нажатии передаются: имя, координаты (по согласию B+), номер поездки.
+          </p>
+        </div>
+      </div>
+      <div style={ihSosStyles.fabHint}>Зажмите →<br/>2 секунды</div>
+      <button
+        style={ihSosStyles.fab}
+        onMouseDown={start} onMouseUp={stop} onMouseLeave={stop}
+        onTouchStart={start} onTouchEnd={stop} onTouchCancel={stop}
+      >
+        <IHSosCharge progress={progress} size={80} />
+        <span style={{ position: 'relative', zIndex: 1 }}>SOS</span>
+      </button>
+    </div>
+  );
+}
+
+function IHSosActiveScreen({ stage = 'sent', onCancel }) {
+  // stage: sent | ack | connected
+  const stages = [
+    { id: 'sent', t: 'Сигнал отправлен', sub: 'Сейчас · координаты получены' },
+    { id: 'ack', t: 'Дежурный принял заявку', sub: '~12 сек назад' },
+    { id: 'connected', t: 'Прия на связи', sub: 'Прочла ваше местоположение' },
+  ];
+  const order = ['sent', 'ack', 'connected'];
+  const idx = order.indexOf(stage);
+
+  return (
+    <div style={ihSosStyles.activePage}>
+      <style>{`@keyframes ihPulse { 0%, 100% { opacity: 1 } 50% { opacity: 0.3 } } @keyframes ihRingPulse { 0% { box-shadow: 0 0 0 0 rgba(255,255,255,0.5) } 100% { box-shadow: 0 0 0 28px rgba(255,255,255,0) } }`}</style>
+      <div style={ihSosStyles.activeHeader}>
+        <div style={ihSosStyles.liveBadge}>
+          <div style={ihSosStyles.liveDot} />
+          <span>Помощь в пути</span>
+        </div>
+        <button style={ihSosStyles.cancelBtn} onClick={onCancel}>Отменить</button>
+      </div>
+
+      <div style={ihSosStyles.hero}>
+        <div style={ihSosStyles.heroTitle}>Помощь идёт</div>
+        <div style={ihSosStyles.heroSub}>Дежурный — Прия. ETA ~60 сек.</div>
+      </div>
+
+      <div style={{ ...ihSosStyles.pulseRing, animation: 'ihRingPulse 2s infinite' }}>
+        <div style={ihSosStyles.pulseInner}>!</div>
+      </div>
+
+      <div style={ihSosStyles.steps}>
+        {stages.map((s, i) => {
+          const done = i <= idx;
+          return (
+            <div key={s.id} style={ihSosStyles.step}>
+              <div style={{ ...ihSosStyles.stepDot, ...(done ? ihSosStyles.stepDotOn : {}) }}>
+                {done ? '✓' : ''}
+              </div>
+              <div style={ihSosStyles.stepBody}>
+                <div style={{ ...ihSosStyles.stepTitle, opacity: done ? 1 : 0.6 }}>{s.t}</div>
+                <div style={ihSosStyles.stepTime}>{done ? s.sub : 'ожидание…'}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={ihSosStyles.duty}>
+        <div style={ihSosStyles.dutyAv}>ПР</div>
+        <div style={{ flex: 1 }}>
+          <div style={ihSosStyles.dutyName}>Прия Шарма</div>
+          <div style={ihSosStyles.dutyRole}>Дежурный concierge · Дели</div>
+        </div>
+      </div>
+
+      <div style={ihSosStyles.bottomActions}>
+        <button style={ihSosStyles.callBtn}>📞 Позвонить</button>
+        <button style={ihSosStyles.chatBtn}>💬 Открыть чат</button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { IHSosTriggerScreen, IHSosActiveScreen });

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/TripDashboard.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/TripDashboard.jsx
@@ -1,0 +1,269 @@
+// TripDashboard.jsx — IndiaHorizone Trip Dashboard mobile UI components.
+// All visuals follow docs/UX/DESIGN_SYSTEM.md. Saffron primary, Inter, true-grayscale neutrals.
+
+const ihTokens = {
+  primary: 'hsl(24 95% 53%)',
+  primaryFg: '#fff',
+  primaryTint: 'hsl(24 95% 53% / 0.10)',
+  primaryTintStrong: 'hsl(24 95% 53% / 0.15)',
+  primaryDeep: 'hsl(24 95% 38%)',
+  bg: 'hsl(0 0% 100%)',
+  bgSubtle: 'hsl(0 0% 98%)',
+  card: '#fff',
+  fg: 'hsl(0 0% 9%)',
+  mutedFg: 'hsl(0 0% 45%)',
+  border: 'hsl(0 0% 90%)',
+  muted: 'hsl(0 0% 96%)',
+  destructive: 'hsl(0 84% 60%)',
+  destructiveDeep: 'hsl(0 70% 45%)',
+  success: 'hsl(142 71% 45%)',
+  warning: 'hsl(38 92% 50%)',
+  info: 'hsl(217 91% 60%)',
+  font: 'Inter, system-ui, -apple-system, sans-serif',
+  mono: 'ui-monospace, "JetBrains Mono", Consolas, monospace',
+};
+
+// ─── Page header ─────────────────────────────────────────────
+function IHPageHeader({ flag = '🇮🇳', location = 'Гоа', dayN = 3, dayTotal = 12 }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '14px 20px 12px', borderBottom: `1px solid ${ihTokens.border}`,
+      background: ihTokens.bg,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span style={{ fontSize: 20, lineHeight: 1 }}>{flag}</span>
+        <div>
+          <div style={{ font: `600 15px/1.2 ${ihTokens.font}`, color: ihTokens.fg, letterSpacing: '-0.01em' }}>{location}</div>
+          <div style={{ font: `500 11px/1.2 ${ihTokens.mono}`, color: ihTokens.mutedFg, marginTop: 2, letterSpacing: '0.04em' }}>
+            ДЕНЬ {dayN} ИЗ {dayTotal}
+          </div>
+        </div>
+      </div>
+      <button aria-label="Профиль" style={{
+        width: 36, height: 36, borderRadius: 9999, border: `1px solid ${ihTokens.border}`,
+        background: ihTokens.muted, font: `600 13px/1 ${ihTokens.font}`, color: ihTokens.fg, cursor: 'pointer',
+      }}>АК</button>
+    </div>
+  );
+}
+
+// ─── Now / Next timeline card ───────────────────────────────
+function IHTimelineCard({ now, next }) {
+  return (
+    <div style={{
+      background: ihTokens.card, border: `1px solid ${ihTokens.border}`,
+      borderRadius: 16, padding: 16, display: 'flex', flexDirection: 'column', gap: 14,
+    }}>
+      {/* NOW */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+          <span style={{ width: 6, height: 6, borderRadius: 9999, background: ihTokens.primary, animation: 'ihPulse 2s ease-in-out infinite' }} />
+          <span style={{ font: `500 11px/1 ${ihTokens.font}`, color: ihTokens.primaryDeep, letterSpacing: '0.12em', textTransform: 'uppercase' }}>Сейчас</span>
+        </div>
+        <div style={{ font: `600 17px/1.3 ${ihTokens.font}`, color: ihTokens.fg, letterSpacing: '-0.01em' }}>{now.title}</div>
+        <div style={{ font: `400 13px/1.4 ${ihTokens.font}`, color: ihTokens.mutedFg, marginTop: 4 }}>{now.subtitle}</div>
+      </div>
+
+      {/* divider with countdown */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ flex: 1, height: 1, background: ihTokens.border }} />
+        <span style={{ font: `500 12px/1 ${ihTokens.mono}`, color: ihTokens.mutedFg, fontVariantNumeric: 'tabular-nums' }}>
+          ↓ через {next.in}
+        </span>
+        <div style={{ flex: 1, height: 1, background: ihTokens.border }} />
+      </div>
+
+      {/* NEXT */}
+      <div>
+        <div style={{ font: `500 11px/1 ${ihTokens.font}`, color: ihTokens.mutedFg, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 6 }}>Следующее</div>
+        <div style={{ font: `600 16px/1.3 ${ihTokens.font}`, color: ihTokens.fg, letterSpacing: '-0.01em' }}>{next.title}</div>
+        <div style={{ font: `400 13px/1.4 ${ihTokens.font}`, color: ihTokens.mutedFg, marginTop: 4 }}>{next.subtitle}</div>
+      </div>
+
+      <button style={{
+        marginTop: 2, padding: '10px 12px', borderRadius: 10,
+        background: 'transparent', border: `1px solid ${ihTokens.border}`,
+        font: `500 13px/1 ${ihTokens.font}`, color: ihTokens.fg, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <span>Посмотреть весь день</span>
+        <span style={{ color: ihTokens.mutedFg }}>→</span>
+      </button>
+    </div>
+  );
+}
+
+// ─── Quick actions grid ──────────────────────────────────────
+function IHQuickActions({ onAction }) {
+  const items = [
+    { id: 'docs', icon: '📂', label: 'Документы' },
+    { id: 'route', icon: '🗺️', label: 'Маршрут' },
+    { id: 'concierge', icon: '💬', label: 'Concierge' },
+    { id: 'guide', icon: '📞', label: 'Гид' },
+  ];
+  return (
+    <div>
+      <div style={{ font: `500 11px/1 ${ihTokens.font}`, color: ihTokens.mutedFg, letterSpacing: '0.15em', textTransform: 'uppercase', marginBottom: 10, display:'flex', alignItems:'center', gap: 6 }}>
+        <span>⚡</span><span>Быстро</span>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+        {items.map(it => (
+          <button key={it.id} onClick={() => onAction && onAction(it.id)} style={{
+            background: ihTokens.card, border: `1px solid ${ihTokens.border}`,
+            borderRadius: 14, padding: '12px 4px', display: 'flex', flexDirection: 'column',
+            alignItems: 'center', gap: 6, cursor: 'pointer', transition: 'all 100ms ease-out',
+          }}>
+            <div style={{
+              width: 36, height: 36, borderRadius: 10, background: ihTokens.primaryTint,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18,
+            }}>{it.icon}</div>
+            <div style={{ font: `500 12px/1.2 ${ihTokens.font}`, color: ihTokens.fg }}>{it.label}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Кружок prompt card ──────────────────────────────────────
+function IHCircleCard({ onRecord, onText }) {
+  return (
+    <div style={{
+      background: ihTokens.card, border: `1px solid ${ihTokens.border}`,
+      borderRadius: 16, padding: 16,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+        <div style={{
+          width: 44, height: 44, borderRadius: 9999, background: ihTokens.primaryTint,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20,
+        }}>🎬</div>
+        <div style={{ flex: 1 }}>
+          <div style={{ font: `600 15px/1.3 ${ihTokens.font}`, color: ihTokens.fg }}>Как прошёл день?</div>
+          <div style={{ font: `400 12px/1.4 ${ihTokens.font}`, color: ihTokens.mutedFg, marginTop: 2 }}>Запишите кружок до 60 секунд</div>
+        </div>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+        <button onClick={onRecord} style={{
+          padding: '10px 12px', borderRadius: 10, background: ihTokens.primary, color: ihTokens.primaryFg,
+          border: 'none', font: `500 13px/1 ${ihTokens.font}`, cursor: 'pointer',
+        }}>🎬 Записать кружок</button>
+        <button onClick={onText} style={{
+          padding: '10px 12px', borderRadius: 10, background: 'transparent', color: ihTokens.fg,
+          border: `1px solid ${ihTokens.border}`, font: `500 13px/1 ${ihTokens.font}`, cursor: 'pointer',
+        }}>📝 Текстом</button>
+      </div>
+    </div>
+  );
+}
+
+// ─── SOS hold-to-trigger button ──────────────────────────────
+function IHSosButton({ onActivate }) {
+  const [progress, setProgress] = React.useState(0);
+  const [holding, setHolding] = React.useState(false);
+  const rafRef = React.useRef(null);
+  const startRef = React.useRef(0);
+
+  const tick = () => {
+    const elapsed = (performance.now() - startRef.current) / 2000;
+    const p = Math.min(1, elapsed);
+    setProgress(p);
+    if (p < 1) rafRef.current = requestAnimationFrame(tick);
+    else { setHolding(false); onActivate && onActivate(); }
+  };
+
+  const start = () => {
+    setHolding(true);
+    startRef.current = performance.now();
+    rafRef.current = requestAnimationFrame(tick);
+  };
+  const cancel = () => {
+    cancelAnimationFrame(rafRef.current);
+    setHolding(false);
+    setProgress(0);
+  };
+
+  return (
+    <button
+      onMouseDown={start} onMouseUp={cancel} onMouseLeave={cancel}
+      onTouchStart={start} onTouchEnd={cancel}
+      style={{
+        width: '100%', height: 60, borderRadius: 16, border: 'none',
+        background: ihTokens.destructive, color: '#fff', position: 'relative', overflow: 'hidden',
+        font: `600 15px/1 ${ihTokens.font}`, cursor: 'pointer',
+        boxShadow: '0 8px 20px hsl(0 84% 60% / 0.35), 0 2px 6px hsl(0 84% 40% / 0.25)',
+        userSelect: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+      }}>
+      <div style={{
+        position: 'absolute', inset: 0, background: 'hsl(0 84% 50%)',
+        width: `${progress * 100}%`, transition: holding ? 'none' : 'width 200ms ease-out',
+      }} />
+      <span style={{ position: 'relative', zIndex: 1 }}>
+        🆘 {holding ? `Удерживайте · ${(progress * 2).toFixed(1)}с` : 'SOS — нажмите и держите'}
+      </span>
+    </button>
+  );
+}
+
+// ─── Bottom sheet (used for Документы / Маршрут / Concierge) ──
+function IHBottomSheet({ open, title, onClose, children }) {
+  if (!open) return null;
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 50 }}>
+      <div onClick={onClose} style={{
+        position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.32)',
+        animation: 'ihFadeIn 200ms ease-out',
+      }} />
+      <div style={{
+        position: 'absolute', left: 0, right: 0, bottom: 0,
+        background: ihTokens.card, borderTopLeftRadius: 20, borderTopRightRadius: 20,
+        padding: '8px 16px 24px', boxShadow: '0 -10px 30px rgba(0,0,0,0.15)',
+        animation: 'ihSlideUp 250ms cubic-bezier(0.4,0,0.2,1)',
+        maxHeight: '85%', overflowY: 'auto',
+      }}>
+        <div style={{ width: 36, height: 4, borderRadius: 9999, background: ihTokens.border, margin: '6px auto 16px' }} />
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+          <div style={{ font: `600 18px/1.2 ${ihTokens.font}`, color: ihTokens.fg, letterSpacing: '-0.01em' }}>{title}</div>
+          <button onClick={onClose} aria-label="Закрыть" style={{
+            width: 32, height: 32, borderRadius: 9999, border: 'none', background: ihTokens.muted,
+            font: `500 15px/1 ${ihTokens.font}`, color: ihTokens.fg, cursor: 'pointer',
+          }}>✕</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─── Document row (for Документы sheet) ──────────────────────
+function IHDocRow({ icon, title, subtitle, status }) {
+  return (
+    <button style={{
+      width: '100%', display: 'flex', alignItems: 'center', gap: 12,
+      padding: '12px 12px', borderRadius: 12, border: `1px solid ${ihTokens.border}`,
+      background: ihTokens.card, marginBottom: 8, cursor: 'pointer', textAlign: 'left',
+    }}>
+      <div style={{
+        width: 40, height: 40, borderRadius: 10, background: ihTokens.muted,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20,
+      }}>{icon}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ font: `500 14px/1.3 ${ihTokens.font}`, color: ihTokens.fg }}>{title}</div>
+        <div style={{ font: `400 12px/1.3 ${ihTokens.font}`, color: ihTokens.mutedFg, marginTop: 2 }}>{subtitle}</div>
+      </div>
+      {status === 'cached' && (
+        <span style={{
+          font: `500 11px/1 ${ihTokens.font}`, padding: '4px 8px', borderRadius: 9999,
+          background: 'hsl(142 71% 45% / 0.12)', color: 'hsl(142 71% 30%)',
+        }}>оффлайн</span>
+      )}
+      <span style={{ color: ihTokens.mutedFg, marginLeft: 4 }}>→</span>
+    </button>
+  );
+}
+
+// Export
+Object.assign(window, {
+  ihTokens, IHPageHeader, IHTimelineCard, IHQuickActions,
+  IHCircleCard, IHSosButton, IHBottomSheet, IHDocRow,
+});

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/auth.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/auth.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Auth — #135 (B-008/010/011)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .scroll{flex:1;overflow-y:auto;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;}
+  .switcher{position:absolute;top:18px;right:14px;display:flex;gap:3px;background:hsl(0 0% 9% / 0.06);padding:3px;border-radius:9999px;z-index:10;flex-wrap:wrap;max-width:230px;justify-content:flex-end;}
+  .switcher button{border:none;background:transparent;font:500 10px/1 Inter;color:hsl(0 0% 35%);padding:5px 8px;border-radius:9999px;cursor:pointer;}
+  .switcher button.on{background:#fff;color:hsl(0 0% 9%);box-shadow:0 1px 2px rgba(0,0,0,.06);}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="AuthScreens.jsx"></script>
+<script type="text/babel">
+  function App(){
+    const [view, setView] = React.useState('login');
+    const labels = { login:'Login', register:'Register', '2fa-setup':'2FA setup', '2fa-ch':'2FA login', forgot:'Forgot', reset:'Reset', suspicious:'Suspicious' };
+    return (
+      <div data-screen-label={`02 Auth — ${view}`} className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="switcher">
+          {Object.keys(labels).map(v => (
+            <button key={v} className={view===v?'on':''} onClick={()=>setView(v)}>{labels[v]}</button>
+          ))}
+        </div>
+        <div className="scroll">
+          {view==='login' && <IHLoginScreen onSwitch={setView} onSubmit={()=>setView('2fa-ch')} />}
+          {view==='register' && <IHRegisterScreen onSwitch={setView} onSubmit={()=>setView('2fa-setup')} />}
+          {view==='2fa-setup' && <IH2FASetupScreen onDone={()=>setView('login')} />}
+          {view==='2fa-ch' && <IH2FAChallengeScreen onVerify={()=>setView('login')} onSwitch={setView}/>}
+          {view==='forgot' && <IHForgotScreen onSwitch={setView}/>}
+          {view==='reset' && <IHResetScreen onSwitch={setView}/>}
+          {view==='suspicious' && <IHSuspiciousScreen onSwitch={setView}/>}
+        </div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/chat.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/chat.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Chat — #170</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .stage{flex:1;overflow:hidden;display:flex;flex-direction:column;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;}
+  .switcher{position:absolute;top:18px;right:20px;display:flex;gap:4px;background:hsl(0 0% 9% / 0.06);padding:3px;border-radius:9999px;z-index:10;}
+  .switcher button{border:none;background:transparent;font:500 11px/1 Inter;color:hsl(0 0% 35%);padding:6px 10px;border-radius:9999px;cursor:pointer;}
+  .switcher button.on{background:#fff;color:hsl(0 0% 9%);box-shadow:0 1px 2px rgba(0,0,0,.06);}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="ChatScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    const [mode, setMode] = React.useState('online');
+    return (
+      <div data-screen-label={`05 Chat — ${mode}`} className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="switcher">
+          {['online','typing','offline'].map(v => (
+            <button key={v} className={mode===v?'on':''} onClick={()=>setMode(v)}>{v}</button>
+          ))}
+        </div>
+        <div className="stage">
+          <IHChatScreen offline={mode==='offline'} typing={mode==='typing'} />
+        </div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/feedback.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/feedback.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Feedback — #190</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .scroll{flex:1;display:flex;flex-direction:column;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="FeedbackScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    return (
+      <div data-screen-label="08 Feedback" className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="scroll"><IHFeedbackScreen/></div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/index.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>IndiaHorizone — Trip Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html, body { margin: 0; padding: 0; background: hsl(0 0% 96%); height: 100%; font-family: Inter, system-ui, sans-serif; }
+  body { display: flex; align-items: flex-start; justify-content: center; padding: 24px 12px; min-height: 100vh; box-sizing: border-box; }
+  #root { width: 100%; max-width: 420px; }
+
+  @keyframes ihPulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+  @keyframes ihFadeIn { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes ihSlideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+
+  /* phone shell */
+  .phone {
+    background: #fff; border-radius: 32px; overflow: hidden;
+    border: 1px solid hsl(0 0% 88%);
+    box-shadow: 0 30px 60px -20px rgba(0,0,0,0.25), 0 10px 20px -10px rgba(0,0,0,0.15);
+    position: relative;
+    height: 760px;
+    display: flex; flex-direction: column;
+  }
+  .status-bar {
+    display: flex; justify-content: space-between; padding: 12px 22px 4px;
+    font: 600 14px/1 Inter; color: #000;
+  }
+  .scroll {
+    flex: 1; overflow-y: auto; padding: 4px 16px 92px;
+    background: hsl(0 0% 98%);
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .scroll::-webkit-scrollbar { display: none; }
+  .home-indicator {
+    position: absolute; left: 50%; transform: translateX(-50%); bottom: 7px;
+    width: 134px; height: 5px; background: #000; border-radius: 9999px; opacity: 0.85;
+  }
+  .sos-bar {
+    position: absolute; left: 16px; right: 16px; bottom: 18px;
+  }
+</style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="TripDashboard.jsx"></script>
+  <script type="text/babel">
+    function App() {
+      const [sheet, setSheet] = React.useState(null); // 'docs' | 'route' | 'concierge' | 'guide' | null
+      const [toast, setToast] = React.useState(null);
+      const [feedback, setFeedback] = React.useState('idle'); // idle|recording|sent
+
+      const showToast = (msg) => {
+        setToast(msg);
+        setTimeout(() => setToast(null), 3500);
+      };
+
+      const labels = { docs: 'Документы', route: 'Маршрут', concierge: 'Concierge', guide: 'Гид' };
+
+      return (
+        <div data-screen-label="01 Trip Dashboard" className="phone">
+          <div className="status-bar">
+            <span>9:41</span>
+            <span style={{ display:'flex', gap:6, alignItems:'center', fontSize: 13 }}>
+              <span>📶</span><span>📡</span><span>🔋</span>
+            </span>
+          </div>
+
+          <IHPageHeader location="Гоа" dayN={3} dayTotal={12} />
+
+          <div className="scroll">
+            <IHTimelineCard
+              now={{ title: 'Завтрак, отель Lazylagoon', subtitle: '8:30 – 10:00 · ресторан у бассейна' }}
+              next={{ title: 'Йога-урок, пляж Палолем', subtitle: 'с инструктором Раджем · 1.2 км', in: '1ч 45м' }}
+            />
+            <IHQuickActions onAction={(id) => setSheet(id)} />
+            {feedback === 'sent' ? (
+              <div style={{
+                background: '#fff', border: '1px solid hsl(0 0% 90%)', borderRadius: 16, padding: 16,
+                display: 'flex', alignItems: 'center', gap: 10,
+              }}>
+                <span style={{ fontSize: 18 }}>✅</span>
+                <div style={{ flex: 1 }}>
+                  <div style={{ font: '500 14px/1.3 Inter', color: 'hsl(0 0% 9%)' }}>День 3 — отправлено</div>
+                  <div style={{ font: '400 12px/1.3 Inter', color: 'hsl(0 0% 45%)', marginTop: 2 }}>Concierge получил ваш кружок 💚</div>
+                </div>
+              </div>
+            ) : (
+              <IHCircleCard
+                onRecord={() => { setFeedback('sent'); showToast('Кружок отправлен'); }}
+                onText={() => { setFeedback('sent'); showToast('Фидбэк отправлен'); }}
+              />
+            )}
+          </div>
+
+          <div className="sos-bar">
+            <IHSosButton onActivate={() => showToast('🆘 Помощь идёт. Дежурный — Мария')} />
+          </div>
+
+          <div className="home-indicator" />
+
+          {/* Bottom sheets */}
+          <IHBottomSheet open={sheet === 'docs'} title="Документы" onClose={() => setSheet(null)}>
+            <IHDocRow icon="🛂" title="Паспорт + виза" subtitle="Скан, доступен оффлайн" status="cached" />
+            <IHDocRow icon="✈️" title="Авиабилеты" subtitle="Москва → Гоа · 25 апр" status="cached" />
+            <IHDocRow icon="🏨" title="Ваучер · Lazylagoon" subtitle="Гоа · 25 апр – 7 май" status="cached" />
+            <IHDocRow icon="🛡️" title="Полис страховки" subtitle="Ассистанс +7 495 ..." status="cached" />
+          </IHBottomSheet>
+          <IHBottomSheet open={sheet === 'route'} title="Маршрут" onClose={() => setSheet(null)}>
+            <div style={{ font: '400 13px/1.5 Inter', color: 'hsl(0 0% 45%)', padding: '4px 0 12px' }}>
+              12 дней · 4 локации · карты загружены оффлайн
+            </div>
+            {[
+              { d: 'День 1–4', loc: 'Гоа · Палолем', txt: 'Отдых, йога, рынки' },
+              { d: 'День 5–7', loc: 'Хампи', txt: 'Древние храмы, скалы' },
+              { d: 'День 8–10', loc: 'Майсур', txt: 'Дворцы, специи' },
+              { d: 'День 11–12', loc: 'Бангалор', txt: 'Возврат, шопинг' },
+            ].map((r, i) => (
+              <div key={i} style={{ display: 'flex', gap: 12, padding: '10px 0', borderBottom: '1px solid hsl(0 0% 92%)' }}>
+                <div style={{ font: '500 11px/1.4 Inter', color: 'hsl(0 0% 45%)', minWidth: 56, textTransform: 'uppercase', letterSpacing: '0.08em' }}>{r.d}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ font: '600 14px/1.3 Inter', color: 'hsl(0 0% 9%)' }}>{r.loc}</div>
+                  <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)', marginTop: 2 }}>{r.txt}</div>
+                </div>
+              </div>
+            ))}
+          </IHBottomSheet>
+          <IHBottomSheet open={sheet === 'concierge'} title="Concierge" onClose={() => setSheet(null)}>
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', padding: '4px 0 14px' }}>
+              <div style={{ width: 40, height: 40, borderRadius: 9999, background: 'hsl(24 95% 53% / 0.15)', display:'flex', alignItems:'center', justifyContent:'center', font: '600 14px/1 Inter', color: 'hsl(24 95% 38%)' }}>МК</div>
+              <div>
+                <div style={{ font: '600 14px/1.3 Inter' }}>Мария — на связи</div>
+                <div style={{ font: '400 12px/1.3 Inter', color: 'hsl(142 71% 30%)' }}>● Онлайн · отвечает ~2 мин</div>
+              </div>
+            </div>
+            <div style={{ background: 'hsl(0 0% 96%)', borderRadius: 14, padding: 12, font: '400 13px/1.5 Inter', marginBottom: 8 }}>
+              Привет! Завтра в 6:30 заберём вас в отеле — попросите ресепшн собрать завтрак с собой 🌅
+            </div>
+            <button style={{
+              width: '100%', padding: '12px', borderRadius: 10, background: 'hsl(24 95% 53%)',
+              color: '#fff', border: 'none', font: '500 14px/1 Inter', cursor: 'pointer',
+            }}>Открыть чат</button>
+          </IHBottomSheet>
+          <IHBottomSheet open={sheet === 'guide'} title="Гид · Радж" onClose={() => setSheet(null)}>
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', padding: '4px 0 14px' }}>
+              <div style={{ width: 48, height: 48, borderRadius: 9999, background: 'hsl(0 0% 92%)', display:'flex', alignItems:'center', justifyContent:'center', fontSize: 22 }}>👨🏽</div>
+              <div>
+                <div style={{ font: '600 15px/1.3 Inter' }}>Радж Менон</div>
+                <div style={{ font: '400 12px/1.4 Inter', color: 'hsl(0 0% 45%)' }}>Гид по Гоа · говорит по-русски</div>
+              </div>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              <button style={{ padding: '12px', borderRadius: 10, background: 'hsl(24 95% 53%)', color: '#fff', border: 'none', font: '500 13px/1 Inter', cursor:'pointer' }}>📞 Позвонить</button>
+              <button style={{ padding: '12px', borderRadius: 10, background: 'transparent', color: 'hsl(0 0% 9%)', border: '1px solid hsl(0 0% 90%)', font: '500 13px/1 Inter', cursor:'pointer' }}>💬 Написать</button>
+            </div>
+          </IHBottomSheet>
+
+          {toast && (
+            <div style={{
+              position: 'absolute', left: 16, right: 16, top: 70, zIndex: 60,
+              background: 'hsl(0 0% 9%)', color: '#fff', borderRadius: 12, padding: '12px 14px',
+              font: '500 13px/1.4 Inter', boxShadow: '0 10px 25px rgba(0,0,0,0.25)',
+              animation: 'ihSlideUp 250ms ease-out',
+            }}>{toast}</div>
+          )}
+        </div>
+      );
+    }
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ios-frame.jsx
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/itinerary.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/itinerary.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Itinerary — #156</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .scroll{flex:1;overflow-y:auto;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="ItineraryScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    return (
+      <div data-screen-label="04 Itinerary" className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="scroll"><IHItineraryScreen/></div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/journal.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/journal.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Journal — #184</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .scroll{flex:1;overflow-y:auto;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;z-index:60;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="JournalScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    return (
+      <div data-screen-label="07 Journal" className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="scroll"><IHJournalScreen/></div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/profile.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/profile.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Profile — #147</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;}
+  .scroll{flex:1;overflow-y:auto;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="ProfileScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    return (
+      <div data-screen-label="03 Profile" className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="scroll"><IHProfileScreen/></div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/recorder.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/recorder.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>Recorder — #179</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#000;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{position:absolute;top:0;left:0;right:0;display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#fff;z-index:20;mix-blend-mode:difference;}
+  .stage{flex:1;display:flex;flex-direction:column;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#fff;border-radius:9999px;opacity:.85;z-index:30;}
+  .switcher{position:absolute;top:54px;right:20px;display:flex;gap:4px;background:rgba(0,0,0,0.4);padding:3px;border-radius:9999px;z-index:30;border:1px solid rgba(255,255,255,0.15);}
+  .switcher button{border:none;background:transparent;font:500 11px/1 Inter;color:rgba(255,255,255,0.6);padding:6px 10px;border-radius:9999px;cursor:pointer;}
+  .switcher button.on{background:rgba(255,255,255,0.2);color:#fff;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="RecorderScreen.jsx"></script>
+<script type="text/babel">
+  function App(){
+    const [view, setView] = React.useState('idle');
+    return (
+      <div data-screen-label={`06 Recorder — ${view}`} className="phone">
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="switcher">
+          {['idle','recording','preview'].map(v => (
+            <button key={v} className={view===v?'on':''} onClick={()=>setView(v)}>{v}</button>
+          ))}
+        </div>
+        <div className="stage" key={view}><IHRecorderScreen initial={view}/></div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/sos.html
+++ b/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/sos.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<title>SOS — #198 + #199</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../colors_and_type.css">
+<style>
+  html,body{margin:0;padding:0;background:hsl(0 0% 96%);min-height:100%;font-family:Inter,system-ui,sans-serif;}
+  body{display:flex;align-items:flex-start;justify-content:center;padding:24px 12px;}
+  #root{width:100%;max-width:420px;}
+  .phone{background:#fff;border-radius:32px;overflow:hidden;border:1px solid hsl(0 0% 88%);box-shadow:0 30px 60px -20px rgba(0,0,0,0.25);height:760px;display:flex;flex-direction:column;position:relative;}
+  .status-bar{display:flex;justify-content:space-between;padding:12px 22px 4px;font:600 14px/1 Inter;color:#000;position:relative;z-index:5;}
+  .stage{flex:1;overflow-y:auto;display:flex;flex-direction:column;}
+  .home-indicator{position:absolute;left:50%;transform:translateX(-50%);bottom:7px;width:134px;height:5px;background:#000;border-radius:9999px;opacity:.85;z-index:80;}
+  .switcher{position:absolute;top:12px;right:18px;display:flex;gap:4px;background:rgba(0,0,0,0.06);padding:3px;border-radius:9999px;z-index:80;}
+  .switcher button{border:none;background:transparent;font:500 11px/1 Inter;color:hsl(0 0% 35%);padding:6px 10px;border-radius:9999px;cursor:pointer;}
+  .switcher button.on{background:#fff;color:hsl(0 0% 9%);box-shadow:0 1px 2px rgba(0,0,0,.06);}
+  .phone.dark .status-bar{color:#fff;}
+  .phone.dark .home-indicator{background:#fff;}
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="SOSScreens.jsx"></script>
+<script type="text/babel">
+  function App(){
+    const [view, setView] = React.useState('trigger');
+    const [stage, setStage] = React.useState('sent');
+
+    React.useEffect(() => {
+      if (view !== 'active') return;
+      const t1 = setTimeout(() => setStage('ack'), 1500);
+      const t2 = setTimeout(() => setStage('connected'), 3500);
+      return () => { clearTimeout(t1); clearTimeout(t2); };
+    }, [view]);
+
+    const goActive = () => { setStage('sent'); setView('active'); };
+    const dark = view === 'active';
+
+    return (
+      <div data-screen-label={`09 SOS — ${view}`} className={`phone ${dark?'dark':''}`}>
+        <div className="status-bar"><span>9:41</span><span style={{fontSize:13}}>📶 📡 🔋</span></div>
+        <div className="switcher">
+          {['trigger','active'].map(v => (
+            <button key={v} className={view===v?'on':''} onClick={()=>{ if(v==='active') goActive(); else setView(v); }}>
+              {v==='trigger'?'#198 hold':'#199 active'}
+            </button>
+          ))}
+        </div>
+        <div className="stage" key={view+stage}>
+          {view==='trigger' && <IHSosTriggerScreen onTrigger={goActive}/>}
+          {view==='active' && <IHSosActiveScreen stage={stage} onCancel={()=>setView('trigger')}/>}
+        </div>
+        <div className="home-indicator"/>
+      </div>
+    );
+  }
+  ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,8 @@ export default tseslint.config(
       '**/.next/**',
       '**/coverage/**',
       '**/*.tsbuildinfo',
+      // AI-generated prototypes from Claude Design — не для lint'а, только для визуального референса
+      'docs/UX/prototypes/from-claude-design/**',
     ],
   },
 


### PR DESCRIPTION
## Summary

Roman/founders прислали bundle от Claude Design — **все 11 ключевых экранов MVP-1 + MVP-2**, не только auth. Закоммичиваем как single source of truth для prototype-фазы.

## Содержание bundle (~310KB, 45 файлов)

| Группа | Файлы |
|---|---|
| Тексты | `README.md`, `chats/chat1.md` (intent founders), `project/SKILL.md` |
| Tokens | `colors_and_type.css` — 1:1 совпадает с нашими DS tokens |
| Preview tokens | `project/preview/*.html` — карточки colors/type/spacing/radii/shadows/components |
| Экраны (HTML + JSX) | auth, profile, index (Trip Dashboard), itinerary, chat, recorder, journal, feedback, sos |

## Coverage по issues

| Issue | Экран | Status |
|---|---|---|
| #134, #135, #136 | auth (login + register + 2FA + reset + suspicious — 7 экранов) | 🟡 |
| #147 | profile + 4 granular consents | 🟡 |
| #154 | Trip Dashboard главный | 🟡 |
| #156 | itinerary (день за днём) | 🟡 |
| #170 | chat клиент↔concierge | 🟡 |
| #179 | recorder кружка | 🟡 |
| #184 | journal поездки | 🟡 |
| #190 | feedback (текст / кружок) | 🟡 |
| #198, #199, #200 | SOS trigger + active + concierge dashboard | 🟡 |

**11 экранов 🟡 prototype done** — code-implementation впереди.

## Review результат

✅ **Что Claude Design сделал точно по DESIGN_SYSTEM.md:**
- saffron `hsl(24 95% 53%)` как primary везде
- Anti-enumeration в forgot password
- Recovery codes с однократным показом + Скачать .txt
- Reset password warning «выйдете со всех устройств»
- Suspicious-session с when/where/device + 2 кнопки
- Russian tone (вы + imperative verbs)
- Inline error position (не tooltip)

⚠️ **Полировка для code (assistant закроет, не блокирует):**
- Hard-coded `hsl(24 95% 53%)` в JSX → `var(--primary)` для dark mode
- Password show/hide toggle
- «Recovery-коды» → «Резервные коды»
- toy length-only meter → `@zxcvbn-ts/core` (как backend в #127)
- A11y: `aria-describedby/invalid`, `role=group` для OTP, focus-visible
- OTP: paste-6 + backspace-to-prev (через shadcn `<InputOTP>`)
- shadcn `<Form>` вместо custom inputs

## Защита от tooling-конфликтов

- `.prettierignore` += `docs/UX/prototypes/from-claude-design/`
- `eslint.config.mjs` `ignores` += same path

AI-generated React-prototype — для browser-runtime, не наш idiomatic shadcn. Lint'ить бессмысленно.

## Связанные

- Parent: #255 (Design System v0 + Claude Design integration)
- Sub: #257 (Claude Design подключение — owner Roman, **DONE**)
- Зависит от: #256 (DESIGN_SYSTEM.md merged), #265 (prototypes/ infra merged)
- Разблокирует: 11 code-issues UI-фронта (#135, #147, #154, #156, #170, #179, #184, #190, #198-#200)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_