### PR TITLE
[M5.B.4] feat(auth): refresh-token rotation + reuse-detection (#129)

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -9,11 +9,14 @@ import {
 } from '@nestjs/common';
 
 import { LoginDto } from './dto/login.dto';
+import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
 import { AuthService } from './services/auth.service';
 import { LoginService } from './services/login.service';
+import { RefreshService } from './services/refresh.service';
 
 import type { LoginResponse } from './dto/login.dto';
+import type { RefreshResponse } from './dto/refresh.dto';
 import type { RegisterResponse } from './dto/register.dto';
 
 @Controller('auth')
@@ -21,6 +24,7 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly loginService: LoginService,
+    private readonly refreshService: RefreshService,
   ) {}
 
   /**
@@ -64,5 +68,28 @@ export class AuthController {
   ): Promise<LoginResponse> {
     const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
     return this.loginService.login(dto, { ip: realIp, userAgent });
+  }
+
+  /**
+   * POST /auth/refresh
+   *
+   * Body: { refreshToken: "<sessionId>.<random>" }
+   * Returns 200 + { accessToken, refreshToken } (новая пара) или 401 generic.
+   *
+   * Refresh-rotation: старая Session помечается revokedAt='rotated',
+   * создаётся новая Session с тем же userId. Reuse-detection: если
+   * приходит уже-revoked refresh-token — invalidate ВСЕ сессии user'а
+   * (защита от утечки токена).
+   */
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(
+    @Body() dto: RefreshDto,
+    @Ip() ip: string,
+    @Headers('user-agent') userAgent?: string,
+    @Headers('x-forwarded-for') xForwardedFor?: string,
+  ): Promise<RefreshResponse> {
+    const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
+    return this.refreshService.refresh(dto, { ip: realIp, userAgent });
   }
 }

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthService } from './services/auth.service';
 import { JwtTokenService } from './services/jwt.service';
 import { LoginService } from './services/login.service';
 import { PasswordService } from './services/password.service';
+import { RefreshService } from './services/refresh.service';
 
 /**
  * Auth module — register / login / logout / refresh / 2FA / password-reset.
@@ -26,7 +27,7 @@ import { PasswordService } from './services/password.service';
     JwtModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthService, LoginService, PasswordService, JwtTokenService],
-  exports: [AuthService, LoginService, PasswordService, JwtTokenService],
+  providers: [AuthService, LoginService, RefreshService, PasswordService, JwtTokenService],
+  exports: [AuthService, LoginService, RefreshService, PasswordService, JwtTokenService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/dto/refresh.dto.ts
+++ b/apps/api/src/modules/auth/dto/refresh.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class RefreshDto {
+  @IsString()
+  @MinLength(40, { message: 'Невалидный refresh-токен' })
+  @MaxLength(256, { message: 'Невалидный refresh-токен' })
+  refreshToken!: string;
+}
+
+export interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+}

--- a/apps/api/src/modules/auth/services/jwt.service.ts
+++ b/apps/api/src/modules/auth/services/jwt.service.ts
@@ -89,13 +89,41 @@ export class JwtTokenService {
   }
 
   /**
-   * Сгенерировать random refresh-токен. Возвращает plain токен (для клиента)
-   * и его длительность. Хеширование делается caller'ом через PasswordService.
+   * Сгенерировать random refresh-токен. Возвращает random-часть (для хеша)
+   * и expiresAt. Caller потом composeRefresh(sessionId, random) → клиенту.
    */
-  generateRefresh(): { token: string; expiresAt: Date } {
-    const token = randomBytes(REFRESH_TOKEN_BYTES).toString('hex');
+  generateRefresh(): { random: string; expiresAt: Date } {
+    const random = randomBytes(REFRESH_TOKEN_BYTES).toString('hex');
     const expiresAt = new Date(Date.now() + this.refreshTtlSec * 1000);
-    return { token, expiresAt };
+    return { random, expiresAt };
+  }
+
+  /**
+   * Собирает refresh-token, который видит клиент: `<sessionId>.<random>`.
+   *
+   * sessionId в payload нужен, чтобы при /auth/refresh найти Session
+   * за O(1) (lookup by PK), а не перебирать все сессии × argon2.verify
+   * (DoS-уязвимо). sessionId не секретен — UUID, угадать невозможно.
+   * Хеш в БД argon2(random), не argon2(`${sessionId}.${random}`) — проще.
+   */
+  composeRefresh(sessionId: string, random: string): string {
+    return `${sessionId}.${random}`;
+  }
+
+  /**
+   * Парсит refresh-токен от клиента. Возвращает null если формат неверный.
+   * Не делает verify — только разделяет.
+   */
+  parseRefresh(token: string): { sessionId: string; random: string } | null {
+    const dot = token.indexOf('.');
+    if (dot < 0) return null;
+    const sessionId = token.slice(0, dot);
+    const random = token.slice(dot + 1);
+    // Базовая валидация UUID v4 (8-4-4-4-12 hex) и random (hex 128 chars)
+    if (!/^[0-9a-f-]{36}$/i.test(sessionId) || !/^[0-9a-f]+$/i.test(random)) {
+      return null;
+    }
+    return { sessionId, random };
   }
 
   getRefreshTtlMs(): number {

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -75,11 +75,11 @@ export class LoginService {
 
     const access = this.jwt.signAccess({ userId: user.id, role: user.role });
     const refresh = this.jwt.generateRefresh();
-    const refreshHash = await this.password.hash(refresh.token);
+    const refreshHash = await this.password.hash(refresh.random);
 
     // Транзакция: создаём Session + публикуем auth.user.logged_in
-    await this.prisma.$transaction(async (tx) => {
-      await tx.session.create({
+    const sessionId = await this.prisma.$transaction(async (tx) => {
+      const session = await tx.session.create({
         data: {
           userId: user.id,
           refreshTokenHash: refreshHash,
@@ -87,6 +87,7 @@ export class LoginService {
           userAgent: context.userAgent,
           expiresAt: refresh.expiresAt,
         },
+        select: { id: true },
       });
 
       await this.outbox.add(tx, {
@@ -95,17 +96,20 @@ export class LoginService {
         actor: { type: 'user', id: user.id },
         payload: {
           userId: user.id,
+          sessionId: session.id,
           ip: context.ip,
           userAgent: context.userAgent,
         },
       });
+
+      return session.id;
     });
 
-    this.logger.log({ userId: user.id }, 'auth.user.logged_in');
+    this.logger.log({ userId: user.id, sessionId }, 'auth.user.logged_in');
 
     return {
       accessToken: access,
-      refreshToken: refresh.token,
+      refreshToken: this.jwt.composeRefresh(sessionId, refresh.random),
       user: {
         id: user.id,
         email: user.email,

--- a/apps/api/src/modules/auth/services/refresh.service.ts
+++ b/apps/api/src/modules/auth/services/refresh.service.ts
@@ -1,0 +1,204 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { UserStatus } from '@prisma/client';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import { JwtTokenService } from './jwt.service';
+import { PasswordService } from './password.service';
+
+import type { RefreshDto, RefreshResponse } from '../dto/refresh.dto';
+
+const GENERIC_INVALID = 'Невалидный или истёкший refresh-токен';
+
+/**
+ * RefreshService — refresh-token rotation + reuse-detection.
+ *
+ * Поток:
+ * 1. Парсим refresh-token (формат `<sessionId>.<random>`).
+ * 2. Lookup Session по id (O(1)).
+ * 3. Если session НЕ найдена → 401 generic.
+ * 4. Если session.revokedAt НЕ null → ⚠️ REUSE ATTEMPT:
+ *    - Refresh уже был использован один раз и rotated. Повторное использование
+ *      того же refresh-токена = либо token leak (атака), либо race-condition
+ *      из честного клиента.
+ *    - Стандартная реакция: invalidate ВСЕ активные сессии user'а
+ *      (logout-all). Это жёстко, но единственный способ защититься от
+ *      украденного refresh.
+ *    - Публикуем auth.session.suspicious для алерта (#136).
+ *    - 401 generic.
+ * 5. Если session.expiresAt < now → 401.
+ * 6. Если user.status != active → 401.
+ * 7. argon2.verify(session.refreshTokenHash, random) → 401 generic если invalid.
+ * 8. Транзакция:
+ *    - revoke текущую session (revokedAt + revokeReason='rotated')
+ *    - create новую Session с новым refreshHash, ip, ua
+ *    - outbox auth.session.refreshed
+ * 9. Возврат {accessToken: новый JWT, refreshToken: `<newSessionId>.<newRandom>`}
+ *
+ * Соответствует docs/BACKLOG/M5/B_AUTH.md § B-004.
+ */
+@Injectable()
+export class RefreshService {
+  private readonly logger = new Logger(RefreshService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+    private readonly password: PasswordService,
+    private readonly jwt: JwtTokenService,
+  ) {}
+
+  async refresh(
+    dto: RefreshDto,
+    context: { ip?: string; userAgent?: string },
+  ): Promise<RefreshResponse> {
+    const parsed = this.jwt.parseRefresh(dto.refreshToken);
+    if (!parsed) {
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    const session = await this.prisma.session.findUnique({
+      where: { id: parsed.sessionId },
+      include: { user: { select: { id: true, role: true, status: true } } },
+    });
+
+    if (!session) {
+      this.logger.warn({ sessionId: parsed.sessionId }, 'refresh.session.not-found');
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    // ⚠️ Reuse-detection: revoked session используется снова
+    if (session.revokedAt) {
+      await this.handleReuseAttempt(session.userId, session.id, context);
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    if (session.expiresAt < new Date()) {
+      this.logger.debug({ sessionId: session.id }, 'refresh.session.expired');
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    if (session.user.status !== UserStatus.active) {
+      this.logger.warn(
+        { userId: session.userId, status: session.user.status },
+        'refresh.user.not-active',
+      );
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    const { valid } = await this.password.verify(session.refreshTokenHash, parsed.random);
+    if (!valid) {
+      this.logger.warn({ sessionId: session.id }, 'refresh.token.mismatch');
+      throw new UnauthorizedException(GENERIC_INVALID);
+    }
+
+    // ✓ Все проверки пройдены — rotate
+    const newAccess = this.jwt.signAccess({
+      userId: session.userId,
+      role: session.user.role,
+    });
+    const newRefresh = this.jwt.generateRefresh();
+    const newRefreshHash = await this.password.hash(newRefresh.random);
+
+    const newSessionId = await this.prisma.$transaction(async (tx) => {
+      // Revoke старую
+      await tx.session.update({
+        where: { id: session.id },
+        data: {
+          revokedAt: new Date(),
+          revokeReason: 'rotated',
+        },
+      });
+
+      // Create новую
+      const fresh = await tx.session.create({
+        data: {
+          userId: session.userId,
+          refreshTokenHash: newRefreshHash,
+          ip: context.ip,
+          userAgent: context.userAgent,
+          expiresAt: newRefresh.expiresAt,
+        },
+        select: { id: true },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'auth.session.refreshed',
+        schemaVersion: 1,
+        actor: { type: 'user', id: session.userId },
+        payload: {
+          userId: session.userId,
+          oldSessionId: session.id,
+          newSessionId: fresh.id,
+          ip: context.ip,
+        },
+      });
+
+      return fresh.id;
+    });
+
+    this.logger.log(
+      { userId: session.userId, oldSession: session.id, newSession: newSessionId },
+      'auth.session.refreshed',
+    );
+
+    return {
+      accessToken: newAccess,
+      refreshToken: this.jwt.composeRefresh(newSessionId, newRefresh.random),
+    };
+  }
+
+  /**
+   * Reuse-detection — кто-то использовал refresh-токен второй раз.
+   * Возможные сценарии:
+   * - Атака: refresh-token утёк (XSS, MITM), атакующий пробует rotated токен.
+   * - Race: честный клиент сделал два refresh подряд (редко, но возможно
+   *   при отключении интернета — клиент думает первый запрос упал, шлёт второй).
+   *
+   * В обоих случаях безопасно — invalidate ВСЕ активные сессии user'а.
+   * Честный клиент пере-логинится; атакующий теряет доступ.
+   */
+  private async handleReuseAttempt(
+    userId: string,
+    suspiciousSessionId: string,
+    context: { ip?: string; userAgent?: string },
+  ): Promise<void> {
+    this.logger.warn(
+      {
+        userId,
+        sessionId: suspiciousSessionId,
+        ip: context.ip,
+        ua: context.userAgent,
+      },
+      'auth.refresh.reuse-detected',
+    );
+
+    await this.prisma.$transaction(async (tx) => {
+      const result = await tx.session.updateMany({
+        where: {
+          userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: new Date(),
+          revokeReason: 'reuse-detected',
+        },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'auth.session.suspicious',
+        schemaVersion: 1,
+        actor: { type: 'system' },
+        payload: {
+          userId,
+          reason: 'refresh-token-reuse',
+          suspiciousSessionId,
+          revokedSessionsCount: result.count,
+          ip: context.ip,
+          userAgent: context.userAgent,
+        },
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Closes #129 (M5.B.4) — `POST /auth/refresh` с rotation + reuse-detection.

## Что сделано

### Refresh-token формат: `<sessionId>.<random>`

- `JwtTokenService.generateRefresh()` → `{random, expiresAt}`
- `composeRefresh(sessionId, random)` → собирает токен для клиента
- `parseRefresh(token)` → разделяет с UUID-валидацией

> **Почему `<sessionId>.<random>`:** sessionId в payload даёт O(1) lookup по PK. Альтернатива (только random + перебор всех sessions × argon2.verify) — DoS-уязвимо. sessionId — UUID, угадать невозможно.

### `RefreshService` flow

1. parseRefresh → 401 если invalid format
2. `findUnique(sessionId)` → 401 если не найдена
3. **`session.revokedAt != null` → ⚠️ REUSE ATTEMPT**
   - `handleReuseAttempt()`: updateMany sessions WHERE userId=X AND revokedAt=null SET revokedAt=now, revokeReason='reuse-detected'
   - outbox `auth.session.suspicious` (#136 subscriber отправит email/notification)
   - 401
4. expired check
5. user status check
6. `argon2.verify` → 401 если mismatch
7. **Rotation в транзакции:** revoke старую (`revokeReason='rotated'`) + create новую + outbox `auth.session.refreshed`
8. Возврат `{accessToken, refreshToken: <newSessionId>.<newRandom>}`

### `LoginService` обновлён

- После `session.create` → composeRefresh(session.id, random)
- sessionId добавлен в payload `auth.user.logged_in`

### Controller

- `POST /auth/refresh` — extracted IP + UA для tracking

## Архитектурные решения

> 1. **Reuse-detection** — стандартная практика (Auth0, AWS Cognito). При повторном использовании rotated refresh — либо token leak (XSS/MITM), либо честный клиент с глюками сети. В обоих случаях безопасно invalidate все сессии: честный пере-логинится, атакующий теряет доступ.
> 2. **GENERIC_INVALID для всех 401** — атакующий не должен различать: невалидный формат vs не найдена vs revoked vs expired vs не active vs wrong random. Один message «Невалидный или истёкший refresh-токен».
> 3. **`revokeReason` enum-как-строка**: `'rotated'` / `'reuse-detected'` / `'logout'` (#130) / `'reset-password'` (#134) — для post-incident анализа в audit-svc (#218).

## Test plan

- [x] DTO валидация
- [x] Транзакция корректна (rollback → ничего не изменилось)
- [ ] Playwright e2e в #137: «refresh OK → старая revoked», «reuse → all invalidated + 401», «expired → 401», «invalid format → 401»

## Связанные

Closes #129
Зависит от: #126 (User), #127 (register), #128 (login + Session — merged)
Разблокирует: #130 (logout — также revoke Session с reason='logout'), #136 (suspicious-detection subscriber обработает `auth.session.suspicious`), #131 (RBAC guard для protected endpoints)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_