### PR TITLE
[M5.B.6] feat(auth): RBAC guard + @Roles/@Public/@CurrentUser (#131)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { CommonAuthModule } from './common/auth/auth.module';
 import { EventsBusModule } from './common/events-bus/events-bus.module';
 import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
@@ -18,8 +19,9 @@ import { HealthModule } from './modules/health/health.module';
     RedisModule,
     EventsBusModule,
     OutboxModule,
-    HealthModule,
     AuthModule,
+    CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
+    HealthModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/auth/auth.module.ts
+++ b/apps/api/src/common/auth/auth.module.ts
@@ -1,0 +1,32 @@
+import { Global, Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+
+import { AuthModule as AuthFeatureModule } from '../../modules/auth/auth.module';
+
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+/**
+ * Common Auth Module — регистрирует глобальный JwtAuthGuard.
+ *
+ * Импортирует AuthFeatureModule (modules/auth) чтобы получить доступ к
+ * JwtTokenService для verify access-токенов.
+ *
+ * Все controllers по умолчанию защищены этим guard'ом. Public endpoints
+ * (login, register, health) явно помечаются @Public() декоратором.
+ */
+@Global()
+@Module({
+  imports: [AuthFeatureModule],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
+  exports: [],
+})
+export class CommonAuthModule {}
+
+export { JwtAuthGuard } from './jwt-auth.guard';
+export { Public, Roles, CurrentUser, ROLES_KEY, PUBLIC_KEY } from './decorators';
+export type { AuthenticatedUser } from './types';

--- a/apps/api/src/common/auth/decorators.ts
+++ b/apps/api/src/common/auth/decorators.ts
@@ -1,0 +1,42 @@
+import { type ExecutionContext, SetMetadata, createParamDecorator } from '@nestjs/common';
+
+import type { Request } from 'express';
+import type { UserRole } from '@prisma/client';
+
+import type { AuthenticatedUser } from './types';
+
+/**
+ * Метаданные для guards.
+ */
+export const ROLES_KEY = 'roles';
+export const PUBLIC_KEY = 'isPublic';
+
+/**
+ * @Roles('admin', 'concierge') — требует одну из перечисленных ролей.
+ * Если декоратор не применён И @Public() тоже не применён — by default
+ * требуется аутентификация без role-restriction (любой залогиненный).
+ */
+export const Roles = (...roles: UserRole[]): MethodDecorator =>
+  SetMetadata(ROLES_KEY, roles);
+
+/**
+ * @Public() — endpoint доступен без аутентификации.
+ * Используется на /auth/register, /auth/login, /health, /readiness.
+ * При сочетании с @Roles() — @Public() приоритетнее (Roles игнорируются).
+ */
+export const Public = (): MethodDecorator => SetMetadata(PUBLIC_KEY, true);
+
+/**
+ * @CurrentUser() — извлекает req.user в параметре controller-метода.
+ *
+ *   @Get('me')
+ *   me(@CurrentUser() user: AuthenticatedUser) { ... }
+ *
+ * Возвращает null, если endpoint @Public() и токен не приходил.
+ */
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthenticatedUser | null => {
+    const req = ctx.switchToHttp().getRequest<Request>();
+    return req.user ?? null;
+  },
+);

--- a/apps/api/src/common/auth/jwt-auth.guard.ts
+++ b/apps/api/src/common/auth/jwt-auth.guard.ts
@@ -1,0 +1,89 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import type { Request } from 'express';
+import type { UserRole } from '@prisma/client';
+
+import { JwtTokenService } from '../../modules/auth/services/jwt.service';
+
+import { PUBLIC_KEY, ROLES_KEY } from './decorators';
+import type { AuthenticatedUser } from './types';
+
+/**
+ * Глобальный JwtAuthGuard — требует валидный access-token в Authorization
+ * header (формат `Bearer <jwt>`). Учитывает @Public() и @Roles().
+ *
+ * Алгоритм:
+ * 1. Если @Public() — пропускаем без проверки.
+ * 2. Извлекаем Authorization header. Нет → 401.
+ * 3. JwtTokenService.verifyAccess → если null → 401.
+ * 4. attach AuthenticatedUser к req.user.
+ * 5. Если @Roles(...) — проверяем role payload против списка. Не соответствует
+ *    → 403.
+ *
+ * Регистрируется глобально в AppModule — все controllers защищены по умолчанию,
+ * чтобы случайно не оставить unprotected endpoint. Public-endpoints явно
+ * помечаются @Public().
+ *
+ * Соответствует docs/BACKLOG/M5/B_AUTH.md § B-006.
+ */
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  private readonly logger = new Logger(JwtAuthGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly jwt: JwtTokenService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const token = this.extractToken(req);
+    if (!token) {
+      throw new UnauthorizedException('Не передан токен авторизации');
+    }
+
+    const payload = this.jwt.verifyAccess(token);
+    if (!payload) {
+      throw new UnauthorizedException('Невалидный или истёкший токен');
+    }
+
+    const user: AuthenticatedUser = { id: payload.sub, role: payload.role };
+    req.user = user;
+
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (requiredRoles && requiredRoles.length > 0 && !requiredRoles.includes(user.role)) {
+      this.logger.warn(
+        { userId: user.id, role: user.role, required: requiredRoles },
+        'rbac.denied',
+      );
+      throw new ForbiddenException('Недостаточно прав');
+    }
+
+    return true;
+  }
+
+  private extractToken(req: Request): string | null {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith('Bearer ')) return null;
+    return auth.slice('Bearer '.length).trim() || null;
+  }
+}

--- a/apps/api/src/common/auth/types.ts
+++ b/apps/api/src/common/auth/types.ts
@@ -1,0 +1,17 @@
+import type { UserRole } from '@prisma/client';
+
+/**
+ * Структура аутентифицированного пользователя, attached к req.user
+ * после JwtAuthGuard. Содержит только то, что было в JWT-claims —
+ * без лишних DB-lookup'ов.
+ */
+export interface AuthenticatedUser {
+  id: string;
+  role: UserRole;
+}
+
+declare module 'express' {
+  interface Request {
+    user?: AuthenticatedUser;
+  }
+}

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -8,6 +8,8 @@ import {
   Post,
 } from '@nestjs/common';
 
+import { Public } from '../../common/auth/decorators';
+
 import { LoginDto } from './dto/login.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -35,6 +37,7 @@ export class AuthController {
    *
    * Rate-limit: 5 попыток / 15 мин на IP — через throttler (#221).
    */
+  @Public()
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
   async register(
@@ -58,6 +61,7 @@ export class AuthController {
    *
    * Rate-limit: 10 попыток / 15 мин на email — через throttler (#221).
    */
+  @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
   async login(
@@ -81,6 +85,7 @@ export class AuthController {
    * приходит уже-revoked refresh-token — invalidate ВСЕ сессии user'а
    * (защита от утечки токена).
    */
+  @Public()
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   async refresh(

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 
+import { Public } from '../../common/auth/decorators';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RedisService } from '../../common/redis/redis.service';
 
@@ -25,6 +26,7 @@ export class HealthController {
     private readonly redis: RedisService,
   ) {}
 
+  @Public()
   @Get('health')
   health(): HealthStatus {
     return {
@@ -35,6 +37,7 @@ export class HealthController {
     };
   }
 
+  @Public()
   @Get('readiness')
   async readiness(): Promise<ReadinessStatus> {
     const [postgresUp, redisUp] = await Promise.all([


### PR DESCRIPTION
## Summary

Closes #131 (M5.B.6) — глобальный `JwtAuthGuard` через `APP_GUARD` + декораторы `@Public()`, `@Roles()`, `@CurrentUser()`.

## Что сделано

### `common/auth/`

- **`types.ts`** — `AuthenticatedUser {id, role}` + `declare module 'express'` для типизации `req.user`
- **`decorators.ts`** — `@Roles`, `@Public`, `@CurrentUser` param decorator
- **`jwt-auth.guard.ts`** — глобальный guard (default-deny):
  1. Проверка `@Public` → early return true
  2. Extract Bearer token → 401 если нет
  3. `JwtTokenService.verifyAccess` → 401 если invalid
  4. `req.user = AuthenticatedUser`
  5. Проверка `@Roles` (если применён) → 403 если role не подходит
- **`auth.module.ts`** — `@Global` + `APP_GUARD: JwtAuthGuard`

### Public endpoints помечены

- `POST /auth/register, /auth/login, /auth/refresh`
- `GET /health, /readiness`

## Архитектурные решения

> 1. **Default-deny через `APP_GUARD`** — если разработчик забыл декоратор, endpoint **недоступен**, а не открыт всему миру. Противоположность многим NestJS-tutorial'ам, но критично для travel-tech с ПДн.
> 2. **JWT-claims `sub + role`** достаточно — не делаем DB-lookup на каждый request. Если role изменилась (suspend), access-token истечёт через 15 мин и refresh подхватит свежую.
> 3. **`@Roles` как OR-список** — `@Roles('admin', 'finance')` значит «одна из этих». AND-комбинации не нужны — у user одна role.

## Использование (примеры для будущих модулей)

```ts
// Любой залогиненный
@Get('me')
me(@CurrentUser() user: AuthenticatedUser) { ... }

// Только admin или finance
@Roles('admin', 'finance')
@Get('aml/flagged')
flagged() { ... }

// Public
@Public()
@Get('public-info')
info() { ... }
```

## Test plan

- [x] Структура соответствует Acceptance из #131
- [x] TypeScript компилируется
- [ ] e2e в #137: правильная роль → 200, неправильная → 403, нет токена → 401, @Public без токена → 200

## Связанные

Closes #131
Зависит от: #128 (login + JwtTokenService merged)
Разблокирует: **все protected endpoints** во всех будущих модулях (#130 logout, #132–#134 2FA + reset, #138 clients, #149 trips, #167 chat, #173 media, #192 SOS, #202 finance, …)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_