### PR TITLE
[M5.B.5] feat(auth): logout + logout-all + sessionId в JWT-claims (#130)

### DIFF
--- a/apps/api/src/common/auth/jwt-auth.guard.ts
+++ b/apps/api/src/common/auth/jwt-auth.guard.ts
@@ -63,7 +63,11 @@ export class JwtAuthGuard implements CanActivate {
       throw new UnauthorizedException('Невалидный или истёкший токен');
     }
 
-    const user: AuthenticatedUser = { id: payload.sub, role: payload.role };
+    const user: AuthenticatedUser = {
+      id: payload.sub,
+      sessionId: payload.sid,
+      role: payload.role,
+    };
     req.user = user;
 
     const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [

--- a/apps/api/src/common/auth/types.ts
+++ b/apps/api/src/common/auth/types.ts
@@ -7,6 +7,8 @@ import type { UserRole } from '@prisma/client';
  */
 export interface AuthenticatedUser {
   id: string;
+  /** sessionId из JWT-claim. Используется для /auth/logout и audit. */
+  sessionId: string;
   role: UserRole;
 }
 

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -8,15 +8,17 @@ import {
   Post,
 } from '@nestjs/common';
 
-import { Public } from '../../common/auth/decorators';
+import { CurrentUser, Public } from '../../common/auth/decorators';
 
 import { LoginDto } from './dto/login.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
 import { AuthService } from './services/auth.service';
 import { LoginService } from './services/login.service';
+import { LogoutService } from './services/logout.service';
 import { RefreshService } from './services/refresh.service';
 
+import type { AuthenticatedUser } from '../../common/auth/types';
 import type { LoginResponse } from './dto/login.dto';
 import type { RefreshResponse } from './dto/refresh.dto';
 import type { RegisterResponse } from './dto/register.dto';
@@ -27,6 +29,7 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly loginService: LoginService,
     private readonly refreshService: RefreshService,
+    private readonly logoutService: LogoutService,
   ) {}
 
   /**
@@ -55,10 +58,6 @@ export class AuthController {
    * Body: { email, password }
    * Returns 200 + { accessToken, refreshToken, user } или 401 (generic).
    *
-   * 2FA flow (#133) добавится в LoginService позже: при включённой 2FA
-   * вернётся { challengeId } вместо токенов; токены выдаются после
-   * POST /auth/2fa/verify.
-   *
    * Rate-limit: 10 попыток / 15 мин на email — через throttler (#221).
    */
   @Public()
@@ -79,11 +78,6 @@ export class AuthController {
    *
    * Body: { refreshToken: "<sessionId>.<random>" }
    * Returns 200 + { accessToken, refreshToken } (новая пара) или 401 generic.
-   *
-   * Refresh-rotation: старая Session помечается revokedAt='rotated',
-   * создаётся новая Session с тем же userId. Reuse-detection: если
-   * приходит уже-revoked refresh-token — invalidate ВСЕ сессии user'а
-   * (защита от утечки токена).
    */
   @Public()
   @Post('refresh')
@@ -96,5 +90,51 @@ export class AuthController {
   ): Promise<RefreshResponse> {
     const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
     return this.refreshService.refresh(dto, { ip: realIp, userAgent });
+  }
+
+  /**
+   * POST /auth/logout
+   *
+   * Header: Authorization: Bearer <accessToken>
+   * Returns 204 No Content.
+   *
+   * Инвалидирует ТЕКУЩУЮ сессию (sessionId из JWT-claim). Идемпотентен —
+   * повторный вызов не ошибка. Клиент должен сам удалить токены из storage.
+   */
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logout(
+    @CurrentUser() user: AuthenticatedUser,
+    @Ip() ip: string,
+    @Headers('user-agent') userAgent?: string,
+    @Headers('x-forwarded-for') xForwardedFor?: string,
+  ): Promise<void> {
+    const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
+    await this.logoutService.logout(user.id, user.sessionId, {
+      ip: realIp,
+      userAgent,
+    });
+  }
+
+  /**
+   * POST /auth/logout-all
+   *
+   * Header: Authorization: Bearer <accessToken>
+   * Returns 200 + { revokedCount }.
+   *
+   * Инвалидирует ВСЕ active сессии user'а (включая текущую). Используется
+   * при reset password, suspicious «не я», или явно из UI «выйти со всех
+   * устройств».
+   */
+  @Post('logout-all')
+  @HttpCode(HttpStatus.OK)
+  async logoutAll(
+    @CurrentUser() user: AuthenticatedUser,
+    @Ip() ip: string,
+    @Headers('user-agent') userAgent?: string,
+    @Headers('x-forwarded-for') xForwardedFor?: string,
+  ): Promise<{ revokedCount: number }> {
+    const realIp = (xForwardedFor?.split(',')[0]?.trim() ?? ip) || undefined;
+    return this.logoutService.logoutAll(user.id, { ip: realIp, userAgent });
   }
 }

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './services/auth.service';
 import { JwtTokenService } from './services/jwt.service';
 import { LoginService } from './services/login.service';
+import { LogoutService } from './services/logout.service';
 import { PasswordService } from './services/password.service';
 import { RefreshService } from './services/refresh.service';
 
@@ -27,7 +28,21 @@ import { RefreshService } from './services/refresh.service';
     JwtModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthService, LoginService, RefreshService, PasswordService, JwtTokenService],
-  exports: [AuthService, LoginService, RefreshService, PasswordService, JwtTokenService],
+  providers: [
+    AuthService,
+    LoginService,
+    RefreshService,
+    LogoutService,
+    PasswordService,
+    JwtTokenService,
+  ],
+  exports: [
+    AuthService,
+    LoginService,
+    RefreshService,
+    LogoutService,
+    PasswordService,
+    JwtTokenService,
+  ],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/services/jwt.service.ts
+++ b/apps/api/src/modules/auth/services/jwt.service.ts
@@ -10,6 +10,7 @@ const REFRESH_TOKEN_BYTES = 64; // 64 байта = 128 hex-символов = 51
 
 export interface AccessTokenPayload {
   sub: string; // userId
+  sid: string; // sessionId — нужен для /auth/logout (revoke текущую) и audit
   role: UserRole;
   type: 'access';
 }
@@ -56,10 +57,13 @@ export class JwtTokenService {
 
   /**
    * Выпустить access-токен (JWT) для user'а.
+   * sessionId нужен для /auth/logout (revoke текущей session по claim'у),
+   * /auth/me (показать текущую session), audit-events.
    */
-  signAccess(payload: { userId: string; role: UserRole }): string {
+  signAccess(payload: { userId: string; sessionId: string; role: UserRole }): string {
     const claims: AccessTokenPayload = {
       sub: payload.userId,
+      sid: payload.sessionId,
       role: payload.role,
       type: 'access',
     };

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -73,7 +73,6 @@ export class LoginService {
         .catch((err: unknown) => this.logger.warn({ err, userId: user.id }, 'rehash.failed'));
     }
 
-    const access = this.jwt.signAccess({ userId: user.id, role: user.role });
     const refresh = this.jwt.generateRefresh();
     const refreshHash = await this.password.hash(refresh.random);
 
@@ -104,6 +103,9 @@ export class LoginService {
 
       return session.id;
     });
+
+    // sessionId известен после INSERT'а — теперь подписываем JWT с ним
+    const access = this.jwt.signAccess({ userId: user.id, sessionId, role: user.role });
 
     this.logger.log({ userId: user.id, sessionId }, 'auth.user.logged_in');
 

--- a/apps/api/src/modules/auth/services/logout.service.ts
+++ b/apps/api/src/modules/auth/services/logout.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+export interface LogoutContext {
+  ip?: string;
+  userAgent?: string;
+}
+
+/**
+ * LogoutService — инвалидация сессий пользователя.
+ *
+ * - logout(userId, sessionId): revoke только текущую (sessionId из JWT-claim)
+ * - logoutAll(userId): revoke все active sessions user'а (включая текущую)
+ *
+ * Идемпотентность: если session уже revoked — отвечаем 200 без ошибки.
+ * Это защита от race-conditions (клиент мог быстро нажать logout дважды).
+ *
+ * Соответствует docs/BACKLOG/M5/B_AUTH.md § B-005.
+ */
+@Injectable()
+export class LogoutService {
+  private readonly logger = new Logger(LogoutService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  /**
+   * Logout текущего устройства.
+   * Берёт sessionId из JWT-claim — клиенту НЕ нужно передавать refresh-token.
+   */
+  async logout(userId: string, sessionId: string, ctx: LogoutContext = {}): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      const result = await tx.session.updateMany({
+        where: {
+          id: sessionId,
+          userId, // защита: нельзя revoke чужую сессию даже зная её id
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: new Date(),
+          revokeReason: 'logout',
+        },
+      });
+
+      if (result.count === 0) {
+        // session уже revoked или не принадлежит user'у — idempotent, не error
+        return;
+      }
+
+      await this.outbox.add(tx, {
+        type: 'auth.user.logout',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          sessionId,
+          scope: 'current',
+          ip: ctx.ip,
+          userAgent: ctx.userAgent,
+        },
+      });
+    });
+
+    this.logger.log({ userId, sessionId }, 'auth.user.logout.current');
+  }
+
+  /**
+   * Logout со всех устройств. Пользователь должен пере-логиниться везде.
+   * Используется при reset password (#134), suspicious-session «не я» (#136),
+   * или из UI настроек безопасности.
+   */
+  async logoutAll(userId: string, ctx: LogoutContext = {}): Promise<{ revokedCount: number }> {
+    const revokedCount = await this.prisma.$transaction(async (tx) => {
+      const result = await tx.session.updateMany({
+        where: {
+          userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: new Date(),
+          revokeReason: 'logout-all',
+        },
+      });
+
+      if (result.count > 0) {
+        await this.outbox.add(tx, {
+          type: 'auth.user.logout',
+          schemaVersion: 1,
+          actor: { type: 'user', id: userId },
+          payload: {
+            userId,
+            scope: 'all',
+            revokedCount: result.count,
+            ip: ctx.ip,
+            userAgent: ctx.userAgent,
+          },
+        });
+      }
+
+      return result.count;
+    });
+
+    this.logger.log({ userId, revokedCount }, 'auth.user.logout.all');
+    return { revokedCount };
+  }
+}

--- a/apps/api/src/modules/auth/services/refresh.service.ts
+++ b/apps/api/src/modules/auth/services/refresh.service.ts
@@ -94,10 +94,6 @@ export class RefreshService {
     }
 
     // ✓ Все проверки пройдены — rotate
-    const newAccess = this.jwt.signAccess({
-      userId: session.userId,
-      role: session.user.role,
-    });
     const newRefresh = this.jwt.generateRefresh();
     const newRefreshHash = await this.password.hash(newRefresh.random);
 
@@ -136,6 +132,13 @@ export class RefreshService {
       });
 
       return fresh.id;
+    });
+
+    // newSessionId известен после INSERT'а — теперь подписываем JWT
+    const newAccess = this.jwt.signAccess({
+      userId: session.userId,
+      sessionId: newSessionId,
+      role: session.user.role,
     });
 
     this.logger.log(


### PR DESCRIPTION
## Summary

Closes #130 (M5.B.5) — `POST /auth/logout` (текущая) и `POST /auth/logout-all` (все сессии).

## Главное архитектурное решение

**`sid` (sessionId) добавлен в JWT-claims** access-токена. Это даёт:
- `/auth/logout` без body — sessionId из `@CurrentUser().sessionId`
- `/auth/me` (будущее) знает текущую session для UI «выйти из этой сессии»
- audit-trail на каждый request — какая именно session его сделала

> **Trade-off:** +36 chars на токен (~0.5KB на request). Приемлемо для удобства и безопасности.

## Изменения

### `JwtTokenService`
- `AccessTokenPayload.sid` (sessionId)
- `signAccess({userId, sessionId, role})` — требует sessionId

### Login & Refresh
- `signAccess` теперь вызывается **после** INSERT'а Session — sessionId известен
- В Login/Refresh сначала транзакция, затем подпись JWT

### `JwtAuthGuard`
- `req.user.sessionId = payload.sid`

### `LogoutService` (новый)
- `logout(userId, sessionId, ctx)`:
  - `UPDATE sessions SET revokedAt=now, revokeReason='logout' WHERE id=sessionId AND userId=X AND revokedAt IS NULL`
  - Идемпотентен (count=0 не ошибка)
  - Outbox `auth.user.logout {scope:'current'}`
- `logoutAll(userId, ctx)`:
  - `UPDATE` все active sessions
  - Возвращает `{revokedCount}`
  - Outbox `auth.user.logout {scope:'all', count}`

### Controller
- `POST /auth/logout` — protected, no body, 204 No Content
- `POST /auth/logout-all` — protected, возвращает `{revokedCount}`

## Архитектурные решения

> 1. **sessionId в JWT, не в headers/cookies** — атомарно с access. Если токен валиден, sessionId guaranteed-correct.
> 2. **WHERE id=X AND userId=Y** — защита от logout чужой сессии. Стандартный row-level security pattern.
> 3. **scope='current'/'all'** в outbox — разделение для подписчиков. #136 suspicious-detection реагирует только на 'all' как сигнал «возможно reset password».
> 4. **logout идемпотентен** — двойное нажатие кнопки не error.

## Test plan

- [x] DTO/structure валидны
- [x] TypeScript компилируется
- [ ] Playwright e2e в #137: login → logout → access-token больше не valid → logout-all инвалидирует все

## Связанные

Closes #130
Зависит от: #128 (login + Session merged), #129 (refresh — добавил session.id в outbox), #131 (RBAC guard merged)
Разблокирует: #134 (password reset вызывает logoutAll), #136 (suspicious «не я» вызывает logoutAll)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_