### PR TITLE
[M5.A.13] chore(web): React Query + axios + correlation-id (#123)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,10 @@ NODE_ENV=development
 API_HOST=0.0.0.0
 API_PORT=4000
 
-# === Web (apps/web, Next.js) — задаётся отдельно через next dev ===
-# WEB_PORT=3000
-# NEXT_PUBLIC_API_URL=http://localhost:4000
+# === Web (apps/web, Next.js) ===
+# Публичные переменные (NEXT_PUBLIC_*) встраиваются в bundle на этапе build,
+# поэтому не должны содержать секреты.
+NEXT_PUBLIC_API_URL=http://localhost:4000
 
 # === База данных ===
 # PostgreSQL — основная БД (database-per-service в фазе 4, см. issue #62)

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 
+import { Providers } from '../lib/providers';
+
 import './globals.css';
 
 const inter = Inter({
@@ -41,7 +43,9 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="ru" className={inter.variable}>
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -1,0 +1,121 @@
+import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+
+const API_BASE_URL =
+  typeof process !== 'undefined' && process.env['NEXT_PUBLIC_API_URL']
+    ? process.env['NEXT_PUBLIC_API_URL']
+    : 'http://localhost:4000';
+
+/**
+ * Генерирует UUID v4. Используется для X-Correlation-Id.
+ * crypto.randomUUID() доступен в современных браузерах (90%+ users по statcounter)
+ * и в Node 19+. Fallback не делаем — если браузер не поддерживает, лучше
+ * чтобы клиент обновился.
+ */
+function newCorrelationId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+/**
+ * Хранилище access-токена. Не сохраняем в localStorage — XSS-уязвимо.
+ * Refresh-токен хранится в httpOnly cookie (set серверной частью), access —
+ * в memory. При reload страницы — refresh через POST /auth/refresh.
+ *
+ * В фазе 4 — переход на полностью cookie-based (samesite=strict + httpOnly).
+ * Сейчас memory-only access + cookie refresh — компромисс между UX и security.
+ */
+class AccessTokenStore {
+  private token: string | null = null;
+
+  set(token: string): void {
+    this.token = token;
+  }
+
+  get(): string | null {
+    return this.token;
+  }
+
+  clear(): void {
+    this.token = null;
+  }
+}
+
+export const accessTokenStore = new AccessTokenStore();
+
+/**
+ * Создаёт настроенный axios-инстанс.
+ *
+ * Фичи:
+ * - baseURL из NEXT_PUBLIC_API_URL (default localhost:4000)
+ * - X-Correlation-Id на каждый запрос (UUID v4) — для трейсинга backend↔frontend
+ * - Authorization: Bearer <accessToken> auto-attach из accessTokenStore
+ * - 30-сек timeout
+ * - Идемпотентные ретраи в #221 (не сейчас)
+ *
+ * Refresh-flow: при 401 — пробуем POST /auth/refresh (через httpOnly cookie),
+ * получаем новый access, повторяем оригинальный запрос. Реализуется
+ * отдельно в auth-hooks (#135), чтобы не привязывать infra-слой к auth-логике.
+ */
+function createApiClient(): AxiosInstance {
+  const instance = axios.create({
+    baseURL: API_BASE_URL,
+    timeout: 30_000,
+    withCredentials: true, // для refresh-cookie в фазе 4
+  });
+
+  instance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+    config.headers.set('X-Correlation-Id', newCorrelationId());
+
+    const token = accessTokenStore.get();
+    if (token) {
+      config.headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (response) => response,
+    (error: AxiosError) => {
+      // Логируем correlation-id из request на серверные ошибки — для дебага
+      if (error.response && error.response.status >= 500) {
+        const corrId = error.config?.headers?.['X-Correlation-Id'];
+        // eslint-disable-next-line no-console
+        console.error('[api]', error.response.status, corrId, error.config?.url);
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  return instance;
+}
+
+export const apiClient = createApiClient();
+
+/**
+ * Тип ответа об ошибке от NestJS ValidationPipe.
+ * Используется в catch-блоках для извлечения user-friendly сообщения.
+ */
+export interface ApiErrorResponse {
+  statusCode: number;
+  message: string | string[];
+  error?: string;
+  // Для register: zxcvbn-warnings
+  warning?: string;
+  suggestions?: string[];
+}
+
+export function isApiError(err: unknown): err is AxiosError<ApiErrorResponse> {
+  return axios.isAxiosError(err);
+}
+
+/**
+ * Извлекает user-friendly сообщение из API-ошибки.
+ * Поддерживает массив messages (validation) и одиночный (бизнес).
+ */
+export function getErrorMessage(err: unknown, fallback = 'Что-то пошло не так'): string {
+  if (!isApiError(err)) return fallback;
+  const data = err.response?.data;
+  if (!data) return fallback;
+  if (Array.isArray(data.message)) return data.message[0] ?? fallback;
+  return data.message ?? fallback;
+}

--- a/apps/web/lib/providers.tsx
+++ b/apps/web/lib/providers.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState } from 'react';
+
+import { createQueryClient } from './query';
+
+/**
+ * Top-level providers, оборачивающий всё приложение.
+ * Используется в app/layout.tsx через RSC-friendly подход:
+ * QueryClient создаётся один раз через useState (не реинициализируется
+ * между renders) — это рекомендованный pattern для Next.js App Router.
+ */
+export function Providers({ children }: { children: React.ReactNode }): React.ReactElement {
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+      )}
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/lib/query.ts
+++ b/apps/web/lib/query.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Создаёт QueryClient с дефолтами IndiaHorizone.
+ *
+ * - staleTime 5 мин — для оффлайн-friendly UX (данные считаются свежими 5 минут,
+ *   за это время offline cache работает без warning'а)
+ * - retry: 1 для queries (избегаем retry-storm на 5xx); mutations не ретраим автоматически
+ *   (idempotency-key через каждый POST в #221)
+ * - refetchOnWindowFocus: false (раздражает в travel-сценариях)
+ * - networkMode: 'offlineFirst' — для PWA (#122 service worker подхватит)
+ *
+ * Соответствует docs/ARCH/OFFLINE.md § Pull (server → client).
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+        networkMode: 'offlineFirst',
+      },
+      mutations: {
+        retry: 0,
+        networkMode: 'online',
+      },
+    },
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,15 +12,18 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.59.16",
+    "axios": "^1.7.7",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.453.0",
     "next": "14.2.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^2.5.4",
-    "class-variance-authority": "^0.7.0",
-    "lucide-react": "^0.453.0"
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.59.16",
     "@types/node": "^20.16.13",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary

Closes #123 (M5.A.13) — frontend infra для всех будущих API-вызовов: React Query 5 + axios с auto-correlation-id + access-token store.

## Что сделано

### `lib/api/client.ts`
- axios instance, baseURL из `NEXT_PUBLIC_API_URL`
- **`X-Correlation-Id` interceptor** — UUID v4 на каждый запрос для frontend↔backend трейсинга (корреляция с Pino-логами #124)
- **`Authorization: Bearer`** auto-attach из `accessTokenStore`
- `AccessTokenStore` — **in-memory** хранение access-токена (НЕ localStorage, XSS-уязвимо)
- `withCredentials: true` для refresh-cookie flow
- Helpers: `isApiError`, `getErrorMessage` — для user-friendly сообщений из NestJS ValidationPipe

### `lib/query.ts`
- `createQueryClient()` с travel-friendly дефолтами:
  - `staleTime: 5min`, `gcTime: 30min` — оффлайн-friendly
  - `retry: 1` queries / `retry: 0` mutations
  - `refetchOnWindowFocus: false`
  - `networkMode: 'offlineFirst'` для PWA

### `lib/providers.tsx`
- `'use client'` `Providers` обёртка с `QueryClientProvider` + DevTools (только dev)
- Подключён в `app/layout.tsx`

### Зависимости
- `@tanstack/react-query ^5.59`, `axios ^1.7`
- dev: `@tanstack/react-query-devtools`

## Архитектурные решения

> 1. **access-токен в memory, не localStorage** — localStorage XSS-уязвим. Memory теряется при reload, но восстанавливается через `POST /auth/refresh` с httpOnly refresh-cookie. Стандарт OAuth 2.1 BCP.
> 2. **X-Correlation-Id на каждый запрос** — sturdy цепочка req → Pino log → outbox event → audit. Без него distributed flow невозможно отладить.
> 3. **`networkMode: 'offlineFirst'`** queries — критично для PWA UX. Когда #122 SW подхватит — кеш мгновенно, network в фоне.
> 4. **`networkMode: 'online'`** mutations — мутации НЕ retry'им автоматически в offline, ставим в outbox через #157 (Dexie). Иначе 100 retried POST'ов разом при reconnect.

## Связанные

Closes #123
Зависит от: #121 (Next.js merged)
Разблокирует: #135 (auth UI), все будущие frontend-фичи

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_