### PR TITLE
[M5.B.10 part 1] feat(web): auth UI — login + register + shadcn primitives (#135)

### DIFF
--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+/**
+ * Layout для (auth) route group: login / register / forgot-password / reset-password / suspicious-session.
+ *
+ * Centered card на нейтральном фоне. Mobile-first: padding 16px, max-width 420px.
+ * Соответствует prototype'у в docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/auth.html.
+ */
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <main className="flex min-h-svh flex-col bg-muted/30">
+      <header className="px-4 pt-8 sm:px-6">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-foreground transition-colors hover:text-primary"
+        >
+          <span aria-hidden>🇮🇳</span>
+          <span>IndiaHorizone</span>
+        </Link>
+      </header>
+      <div className="flex flex-1 items-center justify-center px-4 py-8 sm:px-6">
+        <div className="w-full max-w-[420px]">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Eye, EyeOff } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { Alert, AlertDescription } from '../../../components/ui/alert';
+import { Button } from '../../../components/ui/button';
+import { Field } from '../../../components/ui/field';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
+import { getErrorMessage } from '../../../lib/api/client';
+import { useLogin } from '../../../lib/auth/hooks';
+
+/**
+ * Login screen.
+ *
+ * Соответствует prototype:
+ * docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx
+ *
+ * Что улучшено по сравнению с prototype'ом (см. ревью в #257):
+ * - shadcn primitives через CSS-vars (dark-mode работает из коробки)
+ * - password show/hide toggle (mobile + Cyrillic UX)
+ * - aria-invalid + aria-describedby через <Field>
+ * - Generic error message «Неверный email или пароль» (anti-enumeration)
+ *
+ * 2FA challenge редирект (#133) — добавится позже когда login начнёт
+ * возвращать `{ challengeId }` вместо токенов.
+ */
+export default function LoginPage(): React.ReactElement {
+  const router = useRouter();
+  const login = useLogin();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+
+  function handleSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    login.mutate(
+      { email: email.trim().toLowerCase(), password },
+      {
+        onSuccess: () => {
+          router.push('/trips');
+        },
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-6 rounded-xl border border-border bg-card p-6 shadow-sm sm:p-8">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">С возвращением</h1>
+        <p className="text-sm text-muted-foreground">Войдите в Trip Dashboard</p>
+      </div>
+
+      {login.isError && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{getErrorMessage(login.error, 'Не удалось войти')}</AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <Field
+          label="Email"
+          type="email"
+          autoComplete="email"
+          inputMode="email"
+          autoFocus
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="vy@example.com"
+        />
+
+        <div className="space-y-1.5">
+          <div className="flex items-baseline justify-between">
+            <Label htmlFor="password" required>
+              Пароль
+            </Label>
+            <Link
+              href="/forgot-password"
+              className="text-xs font-medium text-primary hover:underline"
+            >
+              Забыли пароль?
+            </Link>
+          </div>
+          <div className="relative">
+            <Input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label={showPassword ? 'Скрыть пароль' : 'Показать пароль'}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+        </div>
+
+        <Button type="submit" width="full" size="lg" disabled={login.isPending}>
+          {login.isPending ? 'Входим…' : 'Войти'}
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Ещё нет аккаунта?{' '}
+        <Link href="/register" className="font-medium text-primary hover:underline">
+          Зарегистрироваться
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { Eye, EyeOff } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+
+import { Alert, AlertDescription } from '../../../components/ui/alert';
+import { Button } from '../../../components/ui/button';
+import { Field } from '../../../components/ui/field';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
+import { getErrorMessage } from '../../../lib/api/client';
+import { useLogin, useRegister } from '../../../lib/auth/hooks';
+import { cn } from '../../../lib/utils';
+
+const PASSWORD_LABELS = ['Очень слабый', 'Слабый', 'Средний', 'Хороший', 'Отличный'];
+const PASSWORD_COLORS = [
+  'bg-destructive',
+  'bg-destructive',
+  'bg-warning',
+  'bg-success',
+  'bg-success',
+];
+
+/**
+ * Простой password strength estimator. Не replaces zxcvbn — это
+ * lightweight feedback для UX. Реальный score проверяется на backend через
+ * zxcvbn (issue #127, PasswordService.checkStrength) — публичный API
+ * вернёт 422 «Пароль слишком слабый» с реальной оценкой.
+ *
+ * TODO (#135 follow-up): подключить @zxcvbn-ts/core с RU dictionary
+ * для совпадения backend↔frontend score.
+ */
+function estimateStrength(password: string): number {
+  if (!password) return 0;
+  let score = 0;
+  if (password.length >= 12) score++;
+  if (password.length >= 16) score++;
+  if (/[A-ZА-Я]/.test(password) && /[a-zа-я]/.test(password)) score++;
+  if (/\d/.test(password)) score++;
+  if (/[^a-zA-Zа-яА-Я0-9]/.test(password)) score++;
+  return Math.min(score, 4);
+}
+
+export default function RegisterPage(): React.ReactElement {
+  const router = useRouter();
+  const register = useRegister();
+  const login = useLogin();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [agreed, setAgreed] = useState(false);
+
+  const strength = useMemo(() => estimateStrength(password), [password]);
+  const passwordTooShort = password.length > 0 && password.length < 12;
+
+  function handleSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    if (!agreed || passwordTooShort) return;
+
+    const cleanEmail = email.trim().toLowerCase();
+    register.mutate(
+      { email: cleanEmail, password },
+      {
+        onSuccess: () => {
+          // Auto-login после успешной регистрации
+          login.mutate(
+            { email: cleanEmail, password },
+            {
+              onSuccess: () => router.push('/trips'),
+            },
+          );
+        },
+      },
+    );
+  }
+
+  const submitting = register.isPending || login.isPending;
+  const error = register.error ?? login.error;
+
+  return (
+    <div className="space-y-6 rounded-xl border border-border bg-card p-6 shadow-sm sm:p-8">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Создать аккаунт</h1>
+        <p className="text-sm text-muted-foreground">
+          Зарегистрируйтесь, чтобы получить доступ к Trip Dashboard
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{getErrorMessage(error, 'Не удалось создать аккаунт')}</AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <Field
+          label="Email"
+          type="email"
+          autoComplete="email"
+          inputMode="email"
+          autoFocus
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="vy@example.com"
+        />
+
+        <div className="space-y-1.5">
+          <Label htmlFor="register-password" required>
+            Пароль
+          </Label>
+          <div className="relative">
+            <Input
+              id="register-password"
+              type={showPassword ? 'text' : 'password'}
+              autoComplete="new-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="pr-10"
+              aria-describedby="register-password-helper"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label={showPassword ? 'Скрыть пароль' : 'Показать пароль'}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+
+          <div className="flex gap-1" aria-hidden>
+            {[0, 1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className={cn(
+                  'h-1 flex-1 rounded-full transition-colors duration-fast',
+                  password.length > 0 && strength > i ? PASSWORD_COLORS[strength] : 'bg-muted',
+                )}
+              />
+            ))}
+          </div>
+
+          <p
+            id="register-password-helper"
+            className={cn(
+              'text-xs',
+              passwordTooShort ? 'text-destructive' : 'text-muted-foreground',
+            )}
+          >
+            {passwordTooShort
+              ? 'Минимум 12 символов'
+              : password
+                ? `${PASSWORD_LABELS[strength]} · мин. 12 символов`
+                : 'Минимум 12 символов. Подсказка: используйте фразу из 3–4 слов'}
+          </p>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            checked={agreed}
+            onChange={(e) => setAgreed(e.target.checked)}
+            className="mt-0.5 h-4 w-4 cursor-pointer rounded border-input text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-describedby="terms-text"
+          />
+          <span id="terms-text" className="text-xs leading-relaxed text-muted-foreground">
+            Я согласен с{' '}
+            <Link href="/legal/offer" className="text-primary hover:underline">
+              офертой
+            </Link>{' '}
+            и{' '}
+            <Link href="/legal/privacy" className="text-primary hover:underline">
+              политикой обработки данных
+            </Link>
+            .
+          </span>
+        </label>
+
+        <Button
+          type="submit"
+          width="full"
+          size="lg"
+          disabled={submitting || !agreed || passwordTooShort}
+        >
+          {submitting ? 'Создаём…' : 'Создать аккаунт'}
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Уже есть аккаунт?{' '}
+        <Link href="/login" className="font-medium text-primary hover:underline">
+          Войти
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/ui/alert.tsx
+++ b/apps/web/components/ui/alert.tsx
@@ -1,0 +1,43 @@
+import { type VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg~*]:pl-7',
+  {
+    variants: {
+      variant: {
+        info: 'border-info/40 bg-info/10 text-info-foreground [&>svg]:text-info',
+        success: 'border-success/40 bg-success/10 text-success-foreground [&>svg]:text-success',
+        warning: 'border-warning/40 bg-warning/10 text-warning-foreground [&>svg]:text-warning',
+        destructive:
+          'border-destructive/40 bg-destructive/10 text-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'info',
+    },
+  },
+);
+
+export interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+export function Alert({ className, variant, role = 'status', ...props }: AlertProps): React.ReactElement {
+  return <div role={role} className={cn(alertVariants({ variant }), className)} {...props} />;
+}
+
+export function AlertTitle({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>): React.ReactElement {
+  return <h3 className={cn('mb-1 font-medium leading-tight', className)} {...props} />;
+}
+
+export function AlertDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>): React.ReactElement {
+  return <p className={cn('text-sm leading-relaxed', className)} {...props} />;
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import { type VariantProps, cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg font-medium transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background text-foreground hover:bg-accent',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'text-foreground hover:bg-accent',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        sm: 'h-9 px-3 text-sm',
+        md: 'h-11 px-4 text-sm',
+        lg: 'h-12 px-6 text-base',
+        icon: 'h-10 w-10',
+      },
+      width: {
+        auto: '',
+        full: 'w-full',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+      width: 'auto',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, width, type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(buttonVariants({ variant, size, width }), className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';
+
+export { buttonVariants };

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+
+import { cn } from '../../lib/utils';
+
+import { Input, type InputProps } from './input';
+import { Label } from './label';
+
+interface FieldProps extends Omit<InputProps, 'id'> {
+  label: string;
+  /** Helper-текст под полем (если нет ошибки). */
+  helper?: string;
+  /** Сообщение ошибки. Если задано — показывается вместо helper. */
+  error?: string;
+  /** Маркер обязательного поля. */
+  required?: boolean;
+}
+
+/**
+ * Composite поле формы: Label + Input + helper/error.
+ *
+ * Use:
+ *   <Field label="Email" type="email" required helper="Только корпоративный" />
+ *   <Field label="Пароль" type="password" error="Слишком короткий" />
+ */
+export function Field({
+  label,
+  helper,
+  error,
+  required,
+  className,
+  ...inputProps
+}: FieldProps): React.ReactElement {
+  const id = useId();
+  const helperId = `${id}-helper`;
+  const errorId = `${id}-error`;
+  const hasError = Boolean(error);
+  const messageId = hasError ? errorId : helper ? helperId : undefined;
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <Label htmlFor={id} required={required}>
+        {label}
+      </Label>
+      <Input
+        id={id}
+        aria-invalid={hasError || undefined}
+        aria-describedby={messageId}
+        aria-required={required || undefined}
+        {...inputProps}
+      />
+      {hasError ? (
+        <p id={errorId} role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : helper ? (
+        <p id={helperId} className="text-xs text-muted-foreground">
+          {helper}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from 'react';
+
+import { cn } from '../../lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => (
+  <input
+    ref={ref}
+    type={type}
+    className={cn(
+      'flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground transition-colors duration-fast placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium aria-invalid:border-destructive aria-invalid:focus-visible:ring-destructive',
+      className,
+    )}
+    {...props}
+  />
+));
+Input.displayName = 'Input';

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -1,0 +1,29 @@
+import { forwardRef } from 'react';
+
+import { cn } from '../../lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  /** Показать визуальный маркер обязательного поля (красная *) */
+  required?: boolean;
+}
+
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, required, children, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium text-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {required && (
+        <span className="ml-0.5 text-destructive" aria-hidden>
+          *
+        </span>
+      )}
+    </label>
+  ),
+);
+Label.displayName = 'Label';

--- a/apps/web/lib/auth/api.ts
+++ b/apps/web/lib/auth/api.ts
@@ -1,0 +1,67 @@
+import { apiClient } from '../api/client';
+
+export type UserRole = 'client' | 'guide' | 'manager' | 'concierge' | 'finance' | 'admin';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface RegisterPayload {
+  email: string;
+  password: string;
+  role?: UserRole;
+}
+
+export interface RegisterResponse {
+  userId: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthUser;
+}
+
+export interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * SDK-клиенты для auth-svc.
+ * Соответствуют контракту backend (apps/api/src/modules/auth/auth.controller.ts).
+ */
+export const authApi = {
+  async register(payload: RegisterPayload): Promise<RegisterResponse> {
+    const { data } = await apiClient.post<RegisterResponse>('/auth/register', payload);
+    return data;
+  },
+
+  async login(payload: LoginPayload): Promise<LoginResponse> {
+    const { data } = await apiClient.post<LoginResponse>('/auth/login', payload);
+    return data;
+  },
+
+  async refresh(refreshToken: string): Promise<RefreshResponse> {
+    const { data } = await apiClient.post<RefreshResponse>('/auth/refresh', { refreshToken });
+    return data;
+  },
+
+  async logout(): Promise<void> {
+    await apiClient.post('/auth/logout');
+  },
+
+  async logoutAll(): Promise<{ revokedCount: number }> {
+    const { data } = await apiClient.post<{ revokedCount: number }>('/auth/logout-all');
+    return data;
+  },
+};

--- a/apps/web/lib/auth/hooks.ts
+++ b/apps/web/lib/auth/hooks.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { authApi, type LoginPayload, type LoginResponse, type RegisterPayload, type RegisterResponse } from './api';
+import { authStore } from './store';
+
+/**
+ * useLogin — мутация POST /auth/login.
+ * onSuccess: пишет токены и user в authStore. После — caller роутит на /trips.
+ */
+export function useLogin(): ReturnType<typeof useMutation<LoginResponse, unknown, LoginPayload>> {
+  return useMutation<LoginResponse, unknown, LoginPayload>({
+    mutationFn: (payload) => authApi.login(payload),
+    onSuccess: (data) => {
+      authStore.setSession({
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
+        user: data.user,
+      });
+    },
+  });
+}
+
+/**
+ * useRegister — мутация POST /auth/register.
+ * Не пишет токены (login отдельно после регистрации).
+ */
+export function useRegister(): ReturnType<
+  typeof useMutation<RegisterResponse, unknown, RegisterPayload>
+> {
+  return useMutation<RegisterResponse, unknown, RegisterPayload>({
+    mutationFn: (payload) => authApi.register(payload),
+  });
+}
+
+/**
+ * useLogout — мутация POST /auth/logout.
+ * onSuccess (или onError): чистит authStore.
+ */
+export function useLogout(): ReturnType<typeof useMutation<void, unknown, void>> {
+  return useMutation<void, unknown, void>({
+    mutationFn: () => authApi.logout(),
+    onSettled: () => {
+      // Чистим токены даже при ошибке — клиент должен забыть session
+      authStore.clear();
+    },
+  });
+}

--- a/apps/web/lib/auth/store.ts
+++ b/apps/web/lib/auth/store.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { accessTokenStore } from '../api/client';
+
+import type { AuthUser } from './api';
+
+const REFRESH_TOKEN_KEY = 'ih.refresh';
+const USER_KEY = 'ih.user';
+
+/**
+ * Lightweight reactive auth store без Zustand/Redux — для текущего объёма
+ * хватит useSyncExternalStore-like подход через простой EventTarget.
+ *
+ * Refresh-токен в localStorage — компромисс фазы 3. В фазе 4 → httpOnly
+ * cookie через серверный route handler. См. lib/api/client.ts.
+ */
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+interface PersistedAuth {
+  refreshToken: string;
+  user: AuthUser;
+}
+
+function readPersisted(): PersistedAuth | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const refresh = window.localStorage.getItem(REFRESH_TOKEN_KEY);
+    const userRaw = window.localStorage.getItem(USER_KEY);
+    if (!refresh || !userRaw) return null;
+    return { refreshToken: refresh, user: JSON.parse(userRaw) as AuthUser };
+  } catch {
+    return null;
+  }
+}
+
+function writePersisted(data: PersistedAuth | null): void {
+  if (typeof window === 'undefined') return;
+  if (data) {
+    window.localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
+    window.localStorage.setItem(USER_KEY, JSON.stringify(data.user));
+  } else {
+    window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+    window.localStorage.removeItem(USER_KEY);
+  }
+}
+
+export const authStore = {
+  setSession(args: { accessToken: string; refreshToken: string; user: AuthUser }): void {
+    accessTokenStore.set(args.accessToken);
+    writePersisted({ refreshToken: args.refreshToken, user: args.user });
+    notify();
+  },
+
+  setAccessToken(token: string): void {
+    accessTokenStore.set(token);
+    notify();
+  },
+
+  setRefreshToken(token: string): void {
+    const persisted = readPersisted();
+    if (!persisted) return;
+    writePersisted({ ...persisted, refreshToken: token });
+    notify();
+  },
+
+  clear(): void {
+    accessTokenStore.clear();
+    writePersisted(null);
+    notify();
+  },
+
+  getRefreshToken(): string | null {
+    return readPersisted()?.refreshToken ?? null;
+  },
+
+  getUser(): AuthUser | null {
+    return readPersisted()?.user ?? null;
+  },
+
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+/**
+ * React hook — current user (reactive).
+ * Возвращает null до hydration на клиенте + если не залогинен.
+ */
+export function useCurrentUser(): AuthUser | null {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  useEffect(() => {
+    setUser(authStore.getUser());
+    return authStore.subscribe(() => setUser(authStore.getUser()));
+  }, []);
+  return user;
+}


### PR DESCRIPTION
## Summary

Closes #135 (M5.B.10) **частично** — login + register + базовые shadcn primitives + auth API client. Forgot/reset/2FA/suspicious — следующим PR.

## Что в этом PR

### shadcn primitives (`components/ui/`)
- `button.tsx` — cva variants (default/destructive/outline/secondary/ghost/link), sizes, width
- `input.tsx` — h-11 (touch target), aria-invalid styling
- `label.tsx` — `required` поддержка (звёздочка `*`)
- `field.tsx` — composite Label+Input+helper/error с правильными aria-связями
- `alert.tsx` — info/success/warning/destructive variants

### auth (`lib/auth/`)
- `api.ts` — SDK для backend контракта (`authApi.register/login/refresh/logout/logoutAll`)
- `store.ts` — lightweight reactive store: access в memory (XSS-safe), refresh+user в localStorage (фаза 3 компромисс), `useCurrentUser()` hook
- `hooks.ts` — `useLogin`/`useRegister`/`useLogout` React Query mutations + onSuccess → authStore

### Pages (`app/(auth)/`)
- **`layout.tsx`** — centered card max-width 420px, IH header
- **`login/page.tsx`** — email + password (Eye/EyeOff toggle), "Забыли пароль?" link, generic error (anti-enumeration)
- **`register/page.tsx`** — email + password + 4-bar strength meter + согласие с офертой/ПДн, после register → auto-login → /trips

## Архитектурные решения

> 1. **shadcn primitives вручную, не CLI** — `pnpm dlx shadcn add` требует серверного pnpm install. Файлы = canonical templates, легко sync с CLI после Викиных миграций.
> 2. **Composite `<Field />`** — DRY: каждая форма иначе копирует aria-boilerplate.
> 3. **Password show/hide toggle обязателен** — mobile + Cyrillic UX (специфически отмечено в review prototype #257).
> 4. **Auto-login после register** — UX-победа, один клик меньше.
> 5. **Error в `<Alert role="alert">`** — screen reader озвучит автоматически (live region).
> 6. **Lightweight strength meter** на frontend, реальная валидация на backend через zxcvbn (#127). Frontend-meter — UX hint, не security.

## Не реализовано в этом PR (TODO)

- 2FA challenge редирект из login — после #133
- `/forgot-password` + `/reset-password/[token]` — после #134
- `/2fa-setup` + `/2fa-verify` — после #132/#133
- `/suspicious-session/[id]` — после #136
- `/trips` роут — login туда редиректит, но `page.tsx` появится в #154
- `@zxcvbn-ts/core` с RU dictionary — match с backend scoring

## Связанные

Closes часть #135 (login + register; полное закрытие после части 2)
Зависит от: #121, #123, #126, #127, #128, #129, #130, #131 — все merged
Разблокирует: визуальное тестирование auth-flow с реальным backend (после #233 Викиных миграций)
Prototype reference: [`docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx`](https://github.com/Rivega42/indiahorizone/blob/main/docs/UX/prototypes/from-claude-design/project/ui_kits/trip_dashboard/AuthScreens.jsx)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_