### PR TITLE
feat(clients): Client + ClientProfile models + auth.user.registered listener (#138)

### DIFF
--- a/apps/api/prisma/migrations/20260427091123_M5_C_001_client_model/migration.sql
+++ b/apps/api/prisma/migrations/20260427091123_M5_C_001_client_model/migration.sql
@@ -1,0 +1,49 @@
+-- Migration: M5.C.001 — Client + ClientProfile models
+-- Issue: #138
+-- Depends on: #126 (users table)
+--
+-- Cross-module rule: userId на таблицу users — soft-reference (без FK).
+-- Это позволяет в фазе 4–5 вынести clients в отдельный сервис/БД.
+
+-- CreateTable: clients
+CREATE TABLE "clients" (
+    "id" UUID NOT NULL,
+    -- Soft-reference на users.id (без FK — cross-module policy)
+    "user_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "clients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: client_profiles
+CREATE TABLE "client_profiles" (
+    "id" UUID NOT NULL,
+    "client_id" UUID NOT NULL,
+    -- ПДн-поля (#139 добавит шифрование)
+    "first_name" TEXT,
+    "last_name" TEXT,
+    "date_of_birth" DATE,
+    -- ISO 3166-1 alpha-2
+    "citizenship" CHAR(2),
+    "phone" TEXT,
+    "telegram_handle" TEXT,
+    -- Свободный JSONB: языки, диеты, предпочтения
+    "preferences" JSONB DEFAULT '{}',
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "client_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: userId уникален (один User → один Client)
+CREATE UNIQUE INDEX "clients_user_id_key" ON "clients"("user_id");
+
+-- CreateIndex: поиск по userId
+CREATE INDEX "idx_clients_user_id" ON "clients"("user_id");
+
+-- CreateIndex: clientId уникален в profiles (1-to-1)
+CREATE UNIQUE INDEX "client_profiles_client_id_key" ON "client_profiles"("client_id");
+
+-- AddForeignKey: client_profiles → clients (внутри модуля — FK разрешён)
+ALTER TABLE "client_profiles" ADD CONSTRAINT "client_profiles_client_id_fkey"
+    FOREIGN KEY ("client_id") REFERENCES "clients"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -132,6 +132,57 @@ model User {
   @@map("users")
 }
 
+// === clients модуль (#138–#148) ===
+//
+// Источник: docs/BACKLOG/M5/C_CLIENTS.md, docs/ARCH/MICROSERVICES.md § clients-svc.
+// clients — персональные данные туристов (ФИО, паспорт, preferences).
+// Создаётся автоматически при auth.user.registered. Cross-module FK запрещены —
+// ссылка на User идёт через soft-reference (userId без FK).
+
+/// Клиент-профиль туриста. Создаётся автоматически при регистрации пользователя.
+/// userId — soft-reference на users.id (без FK, cross-module policy).
+/// Один User → один Client (unique constraint на userId).
+model Client {
+  id          String        @id @default(uuid()) @db.Uuid
+  /// Soft-reference на users.id. Без FK (cross-module policy).
+  userId      String        @unique @map("user_id") @db.Uuid
+  createdAt   DateTime      @default(now()) @map("created_at")
+
+  profile     ClientProfile?
+
+  @@index([userId], map: "idx_clients_user_id")
+  @@map("clients")
+}
+
+/// Персональные данные туриста. ПДн в смысле 152-ФЗ.
+/// Поля с ПДн (firstName, lastName, dateOfBirth, phone) хранятся
+/// в зашифрованном виде (#139 column-level encryption).
+/// preferences — свободный JSONB (языки, диеты, хобби).
+model ClientProfile {
+  id             String    @id @default(uuid()) @db.Uuid
+  clientId       String    @unique @map("client_id") @db.Uuid
+  /// Зашифровано (#139). Хранится как base64(encrypted).
+  firstName      String?   @map("first_name")
+  /// Зашифровано (#139).
+  lastName       String?   @map("last_name")
+  /// Зашифровано (#139).
+  dateOfBirth    DateTime? @map("date_of_birth") @db.Date
+  /// ISO 3166-1 alpha-2, например "RU", "IN".
+  citizenship    String?   @db.Char(2)
+  /// Зашифровано (#139). E.164 формат, например "+79161234567".
+  phone          String?
+  /// Telegram username без @, например "ivan_petrov".
+  telegramHandle String?   @map("telegram_handle")
+  /// Свободный JSONB: языки, диеты, специальные требования.
+  /// Пример: { "languages": ["ru", "en"], "diet": "vegetarian" }
+  preferences    Json?     @default("{}")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+
+  client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
+
+  @@map("client_profiles")
+}
+
 /// Сессия пользователя (refresh-token instance). Один user может иметь
 /// несколько активных сессий — один на устройство.
 ///

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
 import { RedisModule } from './common/redis/redis.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { ClientsModule } from './modules/clients/clients.module';
 import { HealthModule } from './modules/health/health.module';
 
 @Module({
@@ -20,6 +21,7 @@ import { HealthModule } from './modules/health/health.module';
     EventsBusModule,
     OutboxModule,
     AuthModule,
+    ClientsModule,
     CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
     HealthModule,
   ],

--- a/apps/api/src/modules/clients/clients.module.ts
+++ b/apps/api/src/modules/clients/clients.module.ts
@@ -1,0 +1,21 @@
+/**
+ * ClientsModule — управление профилями клиентов (ПДн).
+ *
+ * Создаётся автоматически при auth.user.registered (подписка через EventsBus).
+ * Эндпоинты профиля — в #140 (/clients/me).
+ * Шифрование ПДн — в #139.
+ */
+import { Module } from '@nestjs/common';
+
+import { EventsBusModule } from '../../common/events-bus/events-bus.module';
+import { PrismaModule } from '../../common/prisma/prisma.module';
+
+import { ClientsService } from './clients.service';
+import { ClientsListener } from './listeners/clients.listener';
+
+@Module({
+  imports: [PrismaModule, EventsBusModule],
+  providers: [ClientsService, ClientsListener],
+  exports: [ClientsService],
+})
+export class ClientsModule {}

--- a/apps/api/src/modules/clients/clients.service.ts
+++ b/apps/api/src/modules/clients/clients.service.ts
@@ -1,0 +1,63 @@
+/**
+ * ClientsService — бизнес-логика модуля clients.
+ *
+ * Ответственность:
+ * - Создание Client + пустого ClientProfile при регистрации (#138)
+ * - Чтение/обновление профиля (#140, #141 — следующие issues)
+ *
+ * Cross-module rule: userId — soft-reference, без FK на таблицу users.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+@Injectable()
+export class ClientsService {
+  private readonly logger = new Logger(ClientsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Создать пустой Client + ClientProfile для только что зарегистрированного userId.
+   *
+   * Идемпотентен: если Client с таким userId уже существует — пропускаем.
+   * Это важно для at-least-once delivery от EventsBus.
+   */
+  async provisionForUser(userId: string): Promise<void> {
+    const existing = await this.prisma.client.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (existing) {
+      this.logger.warn({ userId }, 'clients.provision.skipped: client already exists');
+      return;
+    }
+
+    const client = await this.prisma.client.create({
+      data: {
+        userId,
+        profile: {
+          create: {
+            // Пустой профиль — заполняется клиентом позже (#140)
+            preferences: {},
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    this.logger.log({ userId, clientId: client.id }, 'clients.provision.done');
+  }
+
+  /**
+   * Найти Client по userId. Возвращает null если не найден.
+   * Используется для проверки существования и в #140 (/clients/me).
+   */
+  async findByUserId(userId: string) {
+    return this.prisma.client.findUnique({
+      where: { userId },
+      include: { profile: true },
+    });
+  }
+}

--- a/apps/api/src/modules/clients/listeners/clients.listener.ts
+++ b/apps/api/src/modules/clients/listeners/clients.listener.ts
@@ -1,0 +1,59 @@
+/**
+ * ClientsListener — подписчик на domain events для модуля clients.
+ *
+ * Подписывается на auth.user.registered → вызывает ClientsService.provisionForUser().
+ * Consumer group: clients-svc (один на модуль — масштабируемо при extraction в микросервис).
+ *
+ * Idempotency гарантирует EventsBusService — дублирующиеся события пропускаются
+ * через таблицу processed_events.
+ */
+import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
+
+import { EventsBusService } from '../../../common/events-bus/events-bus.service';
+
+import { ClientsService } from '../clients.service';
+
+interface UserRegisteredPayload {
+  userId: string;
+  email: string;
+  role: string;
+  source: string;
+}
+
+const CONSUMER_GROUP = 'clients-svc';
+const CONSUMER_NAME = `clients-svc-${process.env['HOSTNAME'] ?? 'default'}`;
+
+@Injectable()
+export class ClientsListener implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ClientsListener.name);
+  private subscription?: { stop: () => void };
+
+  constructor(
+    private readonly eventsBus: EventsBusService,
+    private readonly clients: ClientsService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscription = this.eventsBus.subscribe<UserRegisteredPayload>(
+      'auth.user.registered',
+      async (event) => {
+        this.logger.log(
+          { eventId: event.id, userId: event.payload.userId },
+          'clients.listener.auth.user.registered',
+        );
+        await this.clients.provisionForUser(event.payload.userId);
+      },
+      {
+        consumerGroup: CONSUMER_GROUP,
+        consumerName: CONSUMER_NAME,
+      },
+    );
+
+    this.logger.log({ group: CONSUMER_GROUP, consumer: CONSUMER_NAME }, 'clients.listener.started');
+  }
+
+  onModuleDestroy(): void {
+    this.subscription?.stop();
+    this.logger.log('clients.listener.stopped');
+  }
+}


### PR DESCRIPTION
## Closes #138

### Что сделано

- **schema.prisma**: добавлены модели `Client` и `ClientProfile`
  - `Client`: id, userId (soft-ref без FK — cross-module policy), createdAt
  - `ClientProfile`: 1-to-1 с Client, поля ПДн (firstName, lastName, dateOfBirth, citizenship, phone, telegramHandle), preferences JSONB
  - Комментарии о шифровании (#139 — следующий issue)

- **Миграция** `20260427091123_M5_C_001_client_model`: SQL вручную (Prisma 7 требует prisma.config.ts)

- **ClientsService**: `provisionForUser(userId)` — идемпотентно создаёт пустой Client+Profile

- **ClientsListener**: подписка на `auth.user.registered` (consumer group: `clients-svc`)
  - Idempotency через EventsBusService (processed_events)

- **ClientsModule**: зарегистрирован в AppModule

### Acceptance criteria
- [x] `Client` (id, userId unique, createdAt)
- [x] `ClientProfile` (clientId, firstName, lastName, dateOfBirth, citizenship, phone, telegramHandle, preferences JSONB)
- [x] Подписан на `auth.user.registered` → создаёт пустой Client
- [ ] Тест: после register → профиль есть *(тест приходит в следующих issues, test-инфра не настроена)*

### Следующий шаг
**#139** — column-level encryption для ПДн полей (firstName, lastName, dateOfBirth, phone)