### PR TITLE
[M5.12.1] feat(catalog): Tour + TourDay + TourMedia Prisma модели + миграция (#294)

### DIFF
--- a/apps/api/prisma/migrations/20260427110000_M5_catalog_tour_models/migration.sql
+++ b/apps/api/prisma/migrations/20260427110000_M5_catalog_tour_models/migration.sql
@@ -1,0 +1,102 @@
+-- Migration: M5 catalog domain — Tour + TourDay + TourMedia
+-- Issue: #294 [12.1]
+-- Эпик: #293
+--
+-- Источник: docs/ARCH/CATALOG.md (создаётся в #311), spec в issue body.
+--
+-- Что добавляем:
+-- - tour_status enum (DRAFT, PUBLISHED, ARCHIVED)
+-- - tours (главная сущность каталога)
+-- - tour_days (1..N дней маршрута, unique по (tour_id, day_number))
+-- - tour_media (фото/видео с order для галерей)
+--
+-- Cross-module rule: НЕТ FK на users / clients. Catalog независим, в фазе 4
+-- может быть extracted в catalog-svc с публичным CDN-кешем.
+--
+-- Hardening:
+-- - Cascade delete: удаление тура → удаление всех дней + медиа.
+-- - costInr* в tour_days НЕ отдаётся в публичный API (CatalogService DTO
+--   mapping исключает; защита от утечки внутренней маржи через bundle).
+
+-- CreateEnum
+CREATE TYPE "tour_status" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "tours" (
+    "id" UUID NOT NULL,
+    "slug" TEXT NOT NULL,
+    "status" "tour_status" NOT NULL DEFAULT 'DRAFT',
+    "title" TEXT NOT NULL,
+    "region" TEXT NOT NULL,
+    "duration_days" INTEGER NOT NULL,
+    "season" TEXT NOT NULL,
+    "price_from_rub" INTEGER NOT NULL,
+    "price_to_rub" INTEGER,
+    "group_size" TEXT NOT NULL,
+    "hero_video_url" TEXT,
+    "hero_poster_url" TEXT NOT NULL,
+    "emotional_hook" TEXT NOT NULL,
+    "inclusions" JSONB NOT NULL,
+    "faq" JSONB NOT NULL,
+    "trust_badges" JSONB NOT NULL,
+    "facts" JSONB NOT NULL,
+    "published_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tours_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_days" (
+    "id" UUID NOT NULL,
+    "tour_id" UUID NOT NULL,
+    "day_number" INTEGER NOT NULL,
+    "location" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "activities" JSONB NOT NULL,
+    "image_url" TEXT NOT NULL,
+    "is_optional" BOOLEAN NOT NULL DEFAULT false,
+    "cost_inr_from" INTEGER,
+    "cost_inr_to" INTEGER,
+
+    CONSTRAINT "tour_days_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_media" (
+    "id" UUID NOT NULL,
+    "tour_id" UUID NOT NULL,
+    "kind" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "caption" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "tour_media_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tours_slug_key" ON "tours"("slug");
+
+-- CreateIndex
+CREATE INDEX "idx_tours_status_published" ON "tours"("status", "published_at");
+
+-- CreateIndex
+CREATE INDEX "idx_tour_days_tour" ON "tour_days"("tour_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_tour_days_tour_day" ON "tour_days"("tour_id", "day_number");
+
+-- CreateIndex
+CREATE INDEX "idx_tour_media_tour_kind" ON "tour_media"("tour_id", "kind");
+
+-- AddForeignKey
+ALTER TABLE "tour_days" ADD CONSTRAINT "tour_days_tour_id_fkey"
+    FOREIGN KEY ("tour_id") REFERENCES "tours"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_media" ADD CONSTRAINT "tour_media_tour_id_fkey"
+    FOREIGN KEY ("tour_id") REFERENCES "tours"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -45,7 +45,7 @@ model OutboxEntry {
   /// Тип события: <service>.<entity>.<verb>, например "auth.user.registered"
   eventType     String    @map("event_type")
   /// Версия схемы payload (DomainEvent.schemaVersion)
-  schemaVersion Int       @map("schema_version") @default(1)
+  schemaVersion Int       @default(1) @map("schema_version")
   /// JSON payload + envelope-метаданные (correlationId, actor)
   payload       Json
   /// UUIDv4 для DomainEvent.id — генерируется на этапе записи, гарантирует
@@ -126,7 +126,7 @@ model User {
   updatedAt    DateTime   @updatedAt @map("updated_at")
 
   /// Backref для CASCADE на logout-all и trip-history.
-  sessions     Session[]
+  sessions Session[]
 
   @@index([email], map: "idx_users_email")
   @@map("users")
@@ -143,12 +143,12 @@ model User {
 /// userId — soft-reference на users.id (без FK, cross-module policy).
 /// Один User → один Client (unique constraint на userId).
 model Client {
-  id          String        @id @default(uuid()) @db.Uuid
+  id        String   @id @default(uuid()) @db.Uuid
   /// Soft-reference на users.id. Без FK (cross-module policy).
-  userId      String        @unique @map("user_id") @db.Uuid
-  createdAt   DateTime      @default(now()) @map("created_at")
+  userId    String   @unique @map("user_id") @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at")
 
-  profile     ClientProfile?
+  profile ClientProfile?
 
   @@index([userId], map: "idx_clients_user_id")
   @@map("clients")
@@ -195,25 +195,136 @@ model ClientProfile {
 /// если revokedAt уже стоит, и снова приходит запрос → атака → invalidate
 /// все сессии user'а.
 model Session {
-  id                String    @id @default(uuid()) @db.Uuid
-  userId            String    @map("user_id") @db.Uuid
+  id               String    @id @default(uuid()) @db.Uuid
+  userId           String    @map("user_id") @db.Uuid
   /// argon2id-хеш refresh-токена. По нему verify при /auth/refresh.
-  refreshTokenHash  String    @map("refresh_token_hash")
+  refreshTokenHash String    @map("refresh_token_hash")
   /// IP при создании. Используется для suspicious-detection (#136).
-  ip                String?
+  ip               String?
   /// User-Agent при создании.
-  userAgent         String?   @map("user_agent")
-  createdAt         DateTime  @default(now()) @map("created_at")
+  userAgent        String?   @map("user_agent")
+  createdAt        DateTime  @default(now()) @map("created_at")
   /// Когда refresh истечёт (createdAt + 30 дней).
-  expiresAt         DateTime  @map("expires_at")
+  expiresAt        DateTime  @map("expires_at")
   /// Установлено при logout / refresh-rotation. NULL = активна.
-  revokedAt         DateTime? @map("revoked_at")
+  revokedAt        DateTime? @map("revoked_at")
   /// Заполняется при revoke — для трейсинга и detection-reuse.
-  revokeReason      String?   @map("revoke_reason")
+  revokeReason     String?   @map("revoke_reason")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, revokedAt], map: "idx_sessions_user_active")
   @@index([expiresAt], map: "idx_sessions_expires_ttl")
   @@map("sessions")
+}
+
+// === catalog модуль (#294 [EPIC 12]) ===
+//
+// Источник: docs/ARCH/CATALOG.md (создаётся в #311), issue #293.
+// catalog — публичный read-only домен туров. Без ПДн, без auth-зависимостей.
+// В фазе 4 — кандидат на extraction в catalog-svc с CDN-кешем.
+//
+// Cross-module rule: НЕТ FK на User/Client. Туры независимы.
+
+enum TourStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+
+  @@map("tour_status")
+}
+
+/// Тур — публикуемая программа путешествия. Источник для tour landing pages
+/// (`/tours/[slug]`).
+///
+/// Поля costInr* в TourDay — internal (не отдаются в публичный API), для
+/// расчёта маржи и аналитики. См. CatalogService DTO mapping.
+model Tour {
+  id            String     @id @default(uuid()) @db.Uuid
+  /// URL slug, например "tury-kerala-oktyabr-2026". РУ-транслит + сезон.
+  slug          String     @unique
+  status        TourStatus @default(DRAFT)
+  title         String
+  /// Свободный текст: "Тривандрум · Варкала · Джатаю".
+  region        String
+  durationDays  Int        @map("duration_days")
+  /// Свободный текст: "Октябрь 2026", "Ноябрь — декабрь 2026".
+  season        String
+  /// Цена в рублях (минимум). Хранится как Int — копейки в фазе 3 не нужны;
+  /// миграция на Decimal — отдельный issue фазы 4 при подключении биллинга.
+  priceFromRub  Int        @map("price_from_rub")
+  /// Верхняя граница ценового коридора. NULL = только "от X".
+  priceToRub    Int?       @map("price_to_rub")
+  groupSize     String     @map("group_size")
+  heroVideoUrl  String?    @map("hero_video_url")
+  heroPosterUrl String     @map("hero_poster_url")
+  /// Короткий emotional hook (3-4 строки в hero).
+  emotionalHook String     @map("emotional_hook")
+  /// JSONB: { included: string[], notIncluded: string[] }.
+  inclusions    Json
+  /// JSONB: { q: string, a: string }[] — для FAQ-секции и Schema.org FAQPage.
+  faq           Json
+  /// JSONB: string[] — 3 trust-бейджа под hero CTA.
+  trustBadges   Json       @map("trust_badges")
+  /// JSONB: { iconKind: string, label: string, value: string }[] — 6 фактов.
+  facts         Json
+  publishedAt   DateTime?  @map("published_at")
+  createdAt     DateTime   @default(now()) @map("created_at")
+  updatedAt     DateTime   @updatedAt @map("updated_at")
+
+  days  TourDay[]
+  media TourMedia[]
+
+  @@index([status, publishedAt], map: "idx_tours_status_published")
+  @@map("tours")
+}
+
+/// День маршрута. Один день = одна карточка в DayTimeline.
+/// costInr* — internal, для аналитики маржи; в публичный API НЕ отдаётся
+/// (исключаем в CatalogService DTO mapping). См. spec в issue #296.
+model TourDay {
+  id          String  @id @default(uuid()) @db.Uuid
+  tourId      String  @map("tour_id") @db.Uuid
+  /// 1..durationDays. Уникален в рамках тура.
+  dayNumber   Int     @map("day_number")
+  location    String
+  title       String
+  /// Markdown допускается.
+  description String
+  /// JSONB: { kind: 'culture'|'nature'|'food'|'water'|'adventure'|'wellness',
+  ///         label: string }[].
+  /// Типизированный набор kind — для consistency между турами и фильтрации.
+  activities  Json
+  imageUrl    String  @map("image_url")
+  /// true = "на выбор" (треккинг ИЛИ СПА). UI выделяет visualно.
+  isOptional  Boolean @default(false) @map("is_optional")
+  /// Internal: нижняя граница стоимости дня в INR. Для аналитики маржи.
+  /// НЕ отдаётся клиенту (CatalogService excludes из DTO).
+  costInrFrom Int?    @map("cost_inr_from")
+  /// Internal: верхняя граница стоимости дня в INR.
+  costInrTo   Int?    @map("cost_inr_to")
+
+  tour Tour @relation(fields: [tourId], references: [id], onDelete: Cascade)
+
+  @@unique([tourId, dayNumber], map: "uq_tour_days_tour_day")
+  @@index([tourId], map: "idx_tour_days_tour")
+  @@map("tour_days")
+}
+
+/// Медиа-ассеты тура: фото, видео, в будущем — кружки-отзывы (V2 после #142
+/// Consent). Order — для порядка отображения в галереях.
+model TourMedia {
+  id      String  @id @default(uuid()) @db.Uuid
+  tourId  String  @map("tour_id") @db.Uuid
+  /// 'photo' | 'video' | 'circle-review' (последнее — после Consent #142).
+  kind    String
+  url     String
+  caption String?
+  /// Порядок отображения. Меньше — раньше.
+  order   Int     @default(0)
+
+  tour Tour @relation(fields: [tourId], references: [id], onDelete: Cascade)
+
+  @@index([tourId, kind], map: "idx_tour_media_tour_kind")
+  @@map("tour_media")
 }


### PR DESCRIPTION
## Summary

Catalog domain — публичный read-only домен туров. База для всех будущих tour landing pages.

- 3 модели: `Tour`, `TourDay`, `TourMedia` + `TourStatus` enum
- Миграция `20260427110000_M5_catalog_tour_models`
- Cross-module rule соблюдён: НЕТ FK на User/Client
- Cascade delete: удаление тура чистит дни + медиа
- `costInr*` поля **internal** (для маржи, исключаем в DTO в #296)

## Что в этом PR

```prisma
enum TourStatus { DRAFT PUBLISHED ARCHIVED }

model Tour {
  slug        String @unique
  status      TourStatus @default(DRAFT)
  ...
  inclusions  Json   // { included: string[], notIncluded: string[] }
  faq         Json   // { q, a }[]
  trustBadges Json   // string[]
  facts       Json   // { iconKind, label, value }[]
  days        TourDay[]
  media       TourMedia[]
}

model TourDay {
  tourId      String
  dayNumber   Int    // unique per tour
  activities  Json   // { kind: 'culture'|..., label }[]
  costInrFrom Int?   // INTERNAL
  costInrTo   Int?   // INTERNAL
  isOptional  Boolean @default(false)
}

model TourMedia {
  tourId String
  kind   String  // 'photo' | 'video' | 'circle-review'
  order  Int     @default(0)
}
```

## Test plan

- [ ] **Vika:** применить миграцию `20260427110000_M5_catalog_tour_models` на dev DB
- [ ] `prisma generate` отрабатывает (проверено локально)
- [ ] `prisma validate` зелёный (проверено локально)
- [ ] Type-check моих файлов чистый (pre-existing main errors не от меня)

## Что дальше

- **[12.2] #295** Seed «Керала» из mock в БД
- **[12.3] #296** GET /tours + /tours/:slug API (catalog-module)
- **[12.4] #297** Lead model + POST /leads (отдельная миграция)

После [12.3] — swap `getTourBySlug` mock на API в `apps/web/lib/mock/tours.ts` (15 мин работы).

Closes #294

https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_