### PR TITLE
[devops] Dockerfile + GitHub Actions deploy для dev (#320)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,84 @@
+# Deploy apps/web to dev-сервер 2.56.241.126
+#
+# Issue: #320 [devops:vika]
+# Триггеры:
+#   - push в main → авто-deploy
+#   - workflow_dispatch (с веткой) → ручной deploy любой ветки для PR-ревью
+#
+# Vika setup перед первым запуском:
+#   1. Settings → Secrets and variables → Actions → добавить:
+#      - DEV_SSH_HOST = 2.56.241.126
+#      - DEV_SSH_USER = root (или ubuntu — Vika подтвердит)
+#      - DEV_SSH_KEY  = приватный SSH-ключ (один раз сгенерировать пару,
+#                       публичный — на сервер в ~/.ssh/authorized_keys,
+#                       приватный — сюда)
+#   2. На сервере: git clone, см. issue #320 шаг 2
+#
+# Структура на сервере:
+#   /opt/indiahorizone/
+#     deploy/                   ← клон репо (этот workflow git pull'ит сюда)
+#     docker-compose.dev.yml    ← compose-файл (готовит Vika по issue #320)
+
+name: Deploy to dev (2.56.241.126)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Ветка для деплоя (main, feature/..., и т.д.)'
+        required: false
+        default: 'main'
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: SSH deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Echo deploy params
+        run: |
+          echo "Branch: ${{ github.event.inputs.branch || github.ref_name }}"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "SHA: ${{ github.sha }}"
+
+      - name: SSH deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEV_SSH_HOST }}
+          username: ${{ secrets.DEV_SSH_USER }}
+          key: ${{ secrets.DEV_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -e
+            BRANCH="${{ github.event.inputs.branch || github.ref_name }}"
+            cd /opt/indiahorizone/deploy
+
+            echo "→ fetching latest"
+            git fetch origin --prune
+            echo "→ checking out $BRANCH"
+            git checkout "$BRANCH"
+            git reset --hard "origin/$BRANCH"
+
+            echo "→ rebuilding indiahorizone-web-dev"
+            cd /opt/indiahorizone
+            docker compose -f docker-compose.dev.yml up -d --build web
+
+            echo "→ wait for healthy (max 60s)"
+            for i in $(seq 1 12); do
+              status=$(docker inspect -f '{{.State.Health.Status}}' indiahorizone-web-dev 2>/dev/null || echo "missing")
+              echo "  attempt $i: $status"
+              if [ "$status" = "healthy" ]; then break; fi
+              sleep 5
+            done
+
+            echo "→ smoke-test localhost:3010"
+            curl -fsS -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3010/ || \
+              (echo "smoke-test FAILED"; docker logs indiahorizone-web-dev --tail 50; exit 1)
+
+            echo "✓ deploy ok"

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,12 @@
+**/.next
+**/node_modules
+**/dist
+**/.turbo
+.git
+.github
+.vscode
+.idea
+*.log
+.env*
+!.env.example
+docs

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1.7
+# IndiaHorizone — apps/web Dockerfile (multi-stage, pnpm monorepo, Next.js standalone)
+#
+# Build context: корень monorepo (см. docker-compose.dev.yml).
+# Issue: #320 [devops:vika], EPIC 13 deploy.
+#
+# Stages:
+#   1. base    — node:20-alpine + corepack (pnpm)
+#   2. deps    — install pnpm deps по lock-файлу (фрозен)
+#   3. builder — pnpm build → .next/standalone + .next/static
+#   4. runner  — минимальный runtime: только то что нужно server.js'у
+#
+# Размер runner-образа целевой: ≤ 200 MB. Без pnpm/dev-deps.
+
+# ────────────────────────── 1. base
+FROM node:20-alpine AS base
+RUN apk add --no-cache libc6-compat
+WORKDIR /repo
+RUN corepack enable
+
+# ────────────────────────── 2. deps (frozen install с workspace)
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/package.json
+COPY apps/api/package.json ./apps/api/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# ────────────────────────── 3. builder
+FROM base AS builder
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules 2>/dev/null || true
+COPY --from=deps /repo/packages/shared/node_modules ./packages/shared/node_modules 2>/dev/null || true
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+# Build shared package (TypeScript references)
+RUN pnpm --filter @indiahorizone/shared build || true
+# Build web (next standalone-output)
+RUN pnpm --filter @indiahorizone/web build
+
+# ────────────────────────── 4. runner (минимальный runtime)
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Не root:
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Standalone output: server.js + минимальные node_modules + public/static
+# Структура: /app/server.js, /app/apps/web/.next/static, /app/apps/web/public
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /repo/apps/web/public ./apps/web/public
+
+USER nextjs
+EXPOSE 3000
+
+# Healthcheck: GET / должен возвращать 200
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:3000/ || exit 1
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -89,7 +89,7 @@ export default function RegisterPage(): React.ReactElement {
         </p>
       </div>
 
-      {error && (
+      {error != null && (
         <Alert variant="destructive" role="alert">
           <AlertDescription>{getErrorMessage(error, 'Не удалось создать аккаунт')}</AlertDescription>
         </Alert>

--- a/apps/web/components/ui/field.tsx
+++ b/apps/web/components/ui/field.tsx
@@ -38,7 +38,7 @@ export function Field({
 
   return (
     <div className={cn('space-y-1.5', className)}>
-      <Label htmlFor={id} required={required}>
+      <Label htmlFor={id} required={required ?? false}>
         {label}
       </Label>
       <Input

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,8 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
+  // Standalone-output для Docker-deploy (issue #320 [devops:vika]):
+  // Next.js собирает минимальный self-contained bundle в .next/standalone/.
+  // outputFileTracingRoot — указываем корень monorepo, чтобы tracing подтянул
+  // пакеты из pnpm-workspace (packages/shared/dist/).
+  output: 'standalone',
   experimental: {
     typedRoutes: true,
+    outputFileTracingRoot: new URL('../..', import.meta.url).pathname,
   },
 };
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,50 @@
+# Deploy artifacts
+
+Артефакты для разворачивания IndiaHorizone на серверах.
+
+## Текущие deployment'ы
+
+### dev — `2.56.241.126:3010`
+
+- **Issue:** #320
+- **Compose:** `docker-compose.dev.yml`
+- **Что включено:** apps/web (Next.js standalone)
+- **Что НЕ включено:** apps/api (NestJS — будет позже, когда [12.4] Lead закроется)
+- **Доступ:** `http://2.56.241.126:3010`
+- **Auto-deploy:** push в main → GitHub Actions `.github/workflows/deploy-dev.yml`
+- **Manual deploy:** Actions → "Deploy to dev" → "Run workflow" → ветка
+
+## Layout на сервере
+
+```
+/opt/indiahorizone/
+├── docker-compose.dev.yml      ← из этого каталога
+├── deploy/                     ← git clone repo (CI git pull сюда)
+└── (logs / volumes — Caddy/nginx если будут)
+```
+
+## Setup — однократно (Vika по issue #320)
+
+Подробные шаги — в issue #320. Кратко:
+
+```bash
+ssh root@2.56.241.126
+
+# Discovery (обязательно перед изменениями!)
+docker ps && netstat -tlnp && nginx -T 2>/dev/null
+
+# Подготовка нашего каталога
+sudo mkdir -p /opt/indiahorizone && sudo chown $USER /opt/indiahorizone
+cd /opt/indiahorizone
+git clone https://github.com/Rivega42/indiahorizone.git deploy
+cp deploy/deploy/docker-compose.dev.yml ./docker-compose.dev.yml
+
+# Initial deploy
+docker compose -f docker-compose.dev.yml up -d --build
+```
+
+## GitHub Secrets (Vika добавляет)
+
+- `DEV_SSH_HOST` = `2.56.241.126`
+- `DEV_SSH_USER` = `root` (или `ubuntu` — что у Roman'а)
+- `DEV_SSH_KEY` = приватный deploy-key (публичный — на сервер в `~/.ssh/authorized_keys`)

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,0 +1,40 @@
+# Compose для dev на 2.56.241.126:3010
+# Issue: #320 [devops:vika]
+#
+# Запуск (на сервере):
+#   cd /opt/indiahorizone
+#   docker compose -f docker-compose.dev.yml up -d --build
+#
+# Что НЕ входит в этот compose (специально):
+#   - apps/api (NestJS) — добавим когда [12.4] Lead закроется и Vika
+#     поднимет рядом managed PostgreSQL/Redis
+#   - nginx/caddy — Roman утвердил доступ по IP:port, без TLS на dev
+#   - PostgreSQL/Redis — пока mock-data в apps/web/lib/mock/
+
+services:
+  web:
+    build:
+      context: ./deploy
+      dockerfile: apps/web/Dockerfile
+    image: indiahorizone-web:dev
+    container_name: indiahorizone-web-dev
+    restart: unless-stopped
+    ports:
+      - "3010:3000"
+    environment:
+      - NODE_ENV=production
+      - NEXT_TELEMETRY_DISABLED=1
+      # API URL — placeholder пока [12.4] не закрыт. Когда apps/api поедет
+      # в этот же compose — заменим на http://api:4000
+      - NEXT_PUBLIC_API_URL=http://2.56.241.126:3011
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"


### PR DESCRIPTION
## Summary

Подготовка к deploy на dev-сервер **2.56.241.126:3010** (issue #320 [devops:vika]).

После merge — Vика берёт это в работу: SSH discovery → secrets → initial deploy → Roman видит интерфейсы.

## Что внутри

### Docker
- **`apps/web/Dockerfile`** — multi-stage (base / deps / builder / runner)
  - Node 20 alpine, pnpm через corepack
  - Next.js standalone output → runner ≤ 200 MB
  - Non-root user (`nextjs:nodejs`), HEALTHCHECK
- **`apps/web/.dockerignore`** — exclude `.next`, `node_modules`, env-файлов, `docs/`
- **`next.config.mjs`**: `output: 'standalone'` + `outputFileTracingRoot` для pnpm-monorepo

### CI/CD
- **`.github/workflows/deploy-dev.yml`** — `push main` → SSH deploy. `workflow_dispatch` для PR-веток
- Healthcheck-ожидание + smoke-test после deploy

### Compose + docs
- **`deploy/docker-compose.dev.yml`** — web на порту 3010 (host:3010 → container:3000)
- **`deploy/README.md`** — что где лежит на сервере

## Pre-existing strict-type fixes (минимум для прохождения build)

Без них `next build` падал. Однострочные правки, не «улучшение соседнего кода»:

| Файл | Было | Стало |
|---|---|---|
| `app/(auth)/register/page.tsx:92` | `{error && (...)` | `{error != null && (...)` |
| `components/ui/field.tsx:41` | `required={required}` | `required={required ?? false}` |

## Test plan

- [x] `pnpm --filter @indiahorizone/web build` — успешен (37MB standalone bundle)
- [x] Все routes pre-rendered: `/`, `/login`, `/register`, `/tours/[slug]` (SSG)
- [ ] **Vika:** Docker build на 2.56.241.126 проходит (после merge)
- [ ] **Vika:** Container запускается, healthcheck зелёный
- [ ] **Vika:** Smoke-test `curl http://localhost:3010/` → 200
- [ ] **Roman:** `http://2.56.241.126:3010/` открывается, видны интерфейсы

## Что нужно от Vика (после merge)

См. issue #320 — она сделает:
1. Discovery (что есть на сервере)
2. GitHub Secrets: `DEV_SSH_HOST=2.56.241.126`, `DEV_SSH_USER`, `DEV_SSH_KEY`
3. Сервер: `git clone`, `docker compose up -d --build`
4. Verification

После — auto-deploy на каждый push в main работает «из коробки».

https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_