### PR TITLE
[M5.12.4] feat(leads): Lead model + POST /leads + Telegram (#297)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,12 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
 # === Уведомления ===
+# Bot token для нотификаций о новых Lead'ах (#297) и других уведомлений.
+# Создать бота: @BotFather → /newbot. Токен формата 123456:ABC-DEF...
 TELEGRAM_BOT_TOKEN=
+# Chat ID куда падают новые заявки (личка Roman / групповой чат с Шивам).
+# Узнать chat_id: добавить @userinfobot в чат или личку, он покажет ID.
+TELEGRAM_LEADS_CHAT_ID=
 FCM_SERVER_KEY=
 APNS_KEY_ID=
 APNS_TEAM_ID=

--- a/apps/api/prisma/migrations/20260427120000_M5_leads_lead_model/migration.sql
+++ b/apps/api/prisma/migrations/20260427120000_M5_leads_lead_model/migration.sql
@@ -1,0 +1,37 @@
+-- Migration: M5.12.4 — leads domain (Lead model)
+-- Issue: #297 [12.4]
+-- Эпик: #293
+--
+-- Заявки с tour landing pages (форма «Хочу этот тур»).
+-- ПДн поля (name, contact, comment) — encrypted через CryptoService (#139),
+-- хранятся как base64 TEXT.
+--
+-- ipHash — sha256(ip) для антифрод-аналитики; raw IP не храним (privacy).
+-- Cross-module rule: НЕТ FK на User/Tour — Lead независим.
+
+-- CreateEnum
+CREATE TYPE "lead_status" AS ENUM ('NEW', 'CONTACTED', 'CONVERTED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "leads" (
+    "id" UUID NOT NULL,
+    "source" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "contact_type" TEXT NOT NULL,
+    "contact" TEXT NOT NULL,
+    "comment" TEXT,
+    "consent_text_version" TEXT NOT NULL,
+    "ip_hash" TEXT,
+    "user_agent" TEXT,
+    "status" "lead_status" NOT NULL DEFAULT 'NEW',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "leads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_leads_status_created" ON "leads"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "idx_leads_source" ON "leads"("source");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -330,3 +330,60 @@ model TourMedia {
   @@index([tourId, kind], map: "idx_tour_media_tour_kind")
   @@map("tour_media")
 }
+
+// === leads модуль (#297 [12.4]) ===
+//
+// Источник: issue #297, EPIC #293.
+// leads — заявки с tour landing pages (форма «Хочу этот тур»).
+// ПДн поля (name, contact, comment) шифруются через CryptoService (#139).
+// Cross-module rule: НЕТ FK на User / Tour. Lead — самостоятельная сущность,
+// привязка к туру — через soft-string `source`.
+//
+// В фазе 4 переносится в CRM-модуль (sales-svc) вместе с таблицами
+// клиентов и сделок.
+
+enum LeadStatus {
+  NEW
+  CONTACTED
+  CONVERTED
+  REJECTED
+
+  @@map("lead_status")
+}
+
+/// Заявка на тур / общая. ПДн (name, contact, comment) — зашифрованы через
+/// CryptoService. ipHash — sha256(ip), для антифрод-аналитики (без хранения
+/// сырого IP).
+///
+/// status workflow: NEW → CONTACTED → CONVERTED|REJECTED. Переходы делает
+/// менеджер через будущую CRM (EPIC 14). До этого — все Lead'ы NEW.
+model Lead {
+  id          String     @id @default(uuid()) @db.Uuid
+  /// Источник заявки. Свободный slug:
+  /// - "tour-tury-kerala-oktyabr-2026" — кнопка с tour landing page
+  /// - "general" — общая форма с главной (когда будет)
+  source      String
+  /// Зашифровано (#139). plaintext: имя клиента (2–100 символов).
+  name        String
+  /// Тип контакта: 'phone' | 'telegram' | 'email'. Не шифруется (enum-like).
+  contactType String     @map("contact_type")
+  /// Зашифровано (#139). plaintext: телефон / @username / email.
+  contact     String
+  /// Зашифровано (#139). plaintext: свободный комментарий клиента (опционально).
+  comment     String?
+  /// Версия текста consent на момент согласия. При обновлении Политики
+  /// конфиденциальности версия меняется → новый клиент подписывает новую,
+  /// старый Lead.consentTextVersion сохраняет старую (для аудита 152-ФЗ).
+  /// Формат: 'YYYY-MM-DD-vN'.
+  consentTextVersion String @map("consent_text_version")
+  /// sha256(ip) — для rate-limit и антифрод-аналитики, не raw IP (privacy).
+  ipHash      String?    @map("ip_hash")
+  userAgent   String?    @map("user_agent")
+  status      LeadStatus @default(NEW)
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
+
+  @@index([status, createdAt], map: "idx_leads_status_created")
+  @@index([source], map: "idx_leads_source")
+  @@map("leads")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { CatalogModule } from './modules/catalog/catalog.module';
 import { ClientsModule } from './modules/clients/clients.module';
 import { HealthModule } from './modules/health/health.module';
+import { LeadsModule } from './modules/leads/leads.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { HealthModule } from './modules/health/health.module';
     AuthModule,
     ClientsModule,
     CatalogModule,
+    LeadsModule,
     CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
     HealthModule,
   ],

--- a/apps/api/src/modules/leads/dto/create-lead.dto.ts
+++ b/apps/api/src/modules/leads/dto/create-lead.dto.ts
@@ -1,0 +1,53 @@
+import {
+  IsBoolean,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Length,
+  MaxLength,
+} from 'class-validator';
+
+/**
+ * DTO для POST /leads. Все поля строгие.
+ * `consent === true` обязателен — на сервере проверяем явно (152-ФЗ).
+ *
+ * Шифрование name/contact/comment происходит в LeadsService через
+ * CryptoService (#139).
+ */
+export class CreateLeadDto {
+  /** 'tour-<slug>' | 'general' */
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  source!: string;
+
+  @IsString()
+  @Length(2, 100)
+  name!: string;
+
+  @IsIn(['phone', 'telegram', 'email'])
+  contactType!: 'phone' | 'telegram' | 'email';
+
+  /** Сырой контакт. Валидация формата — в service (по contactType). */
+  @IsString()
+  @Length(3, 200)
+  contact!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  comment?: string;
+
+  /**
+   * Обязательно `true`. На сервере дополнительный check — на случай обхода
+   * фронт-валидации (защита от Роскомнадзора 152-ФЗ).
+   */
+  @IsBoolean()
+  consent!: boolean;
+
+  /** Версия текста consent на момент отправки. Формат: 'YYYY-MM-DD-vN'. */
+  @IsString()
+  @MaxLength(20)
+  consentTextVersion!: string;
+}

--- a/apps/api/src/modules/leads/leads.controller.ts
+++ b/apps/api/src/modules/leads/leads.controller.ts
@@ -1,0 +1,57 @@
+/**
+ * LeadsController — публичный endpoint для приёма заявок с tour landing.
+ *
+ * - POST /leads — `@Public()`, валидация через class-validator,
+ *   server-side check consent, rate-limit по IP.
+ *
+ * Issue: #297 [12.4]
+ */
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Ip,
+  Post,
+  Req,
+} from '@nestjs/common';
+
+
+
+import { CreateLeadDto } from './dto/create-lead.dto';
+import { LeadsService } from './leads.service';
+import { Public } from '../../common/auth/decorators';
+
+import type { Request } from 'express';
+
+@Controller('leads')
+export class LeadsController {
+  constructor(private readonly leads: LeadsService) {}
+
+  @Public()
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() dto: CreateLeadDto,
+    @Req() req: Request,
+    @Ip() ip: string,
+  ): Promise<{ id: string }> {
+    /*
+     * X-Forwarded-For — приоритет, если стоит за reverse-proxy (nginx/Caddy).
+     * Иначе req.ip (Express trust proxy = 1).
+     */
+    const forwarded = req.header('x-forwarded-for');
+    const realIp =
+      forwarded != null && forwarded.length > 0
+        ? forwarded.split(',')[0]?.trim()
+        : ip;
+
+    const userAgent = req.header('user-agent');
+
+    const input: { dto: CreateLeadDto; ip?: string; userAgent?: string } = { dto };
+    if (realIp != null && realIp.length > 0) input.ip = realIp;
+    if (userAgent != null && userAgent.length > 0) input.userAgent = userAgent;
+
+    return this.leads.create(input);
+  }
+}

--- a/apps/api/src/modules/leads/leads.module.ts
+++ b/apps/api/src/modules/leads/leads.module.ts
@@ -1,0 +1,22 @@
+/**
+ * LeadsModule — приём заявок с tour landing pages.
+ *
+ * - POST /leads — публичный endpoint (с consent и rate-limit)
+ *
+ * Зависит от PrismaModule, CryptoModule (#139 для шифрования ПДн), RedisModule
+ * (для rate-limit), ConfigService (для TELEGRAM_BOT_TOKEN).
+ *
+ * Issue: #297 [12.4], EPIC #293
+ */
+import { Module } from '@nestjs/common';
+
+import { LeadsController } from './leads.controller';
+import { LeadsService } from './leads.service';
+import { TelegramClient } from './telegram.client';
+
+@Module({
+  controllers: [LeadsController],
+  providers: [LeadsService, TelegramClient],
+  exports: [LeadsService],
+})
+export class LeadsModule {}

--- a/apps/api/src/modules/leads/leads.service.ts
+++ b/apps/api/src/modules/leads/leads.service.ts
@@ -1,0 +1,165 @@
+/**
+ * LeadsService — обработка заявок с tour landing.
+ *
+ * 1. Валидация consent (boolean true — server-side check, защита от обхода фронта).
+ * 2. Rate-limit по ipHash через Redis (5/мин).
+ * 3. Шифрование ПДн (name, contact, comment) через CryptoService (#139).
+ * 4. Запись в БД + async notify в Telegram (не блокирует ответ).
+ *
+ * Issue: #297 [12.4]
+ */
+import { createHash } from 'node:crypto';
+
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+
+import { TelegramClient } from './telegram.client';
+import { CryptoService } from '../../common/crypto/crypto.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { RedisService } from '../../common/redis/redis.service';
+
+import type { CreateLeadDto } from './dto/create-lead.dto';
+import type { Lead } from '@prisma/client';
+
+
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_SEC = 60;
+
+interface CreateLeadInput {
+  dto: CreateLeadDto;
+  ip?: string;
+  userAgent?: string;
+}
+
+@Injectable()
+export class LeadsService {
+  private readonly logger = new Logger(LeadsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+    private readonly redis: RedisService,
+    private readonly telegram: TelegramClient,
+  ) {}
+
+  async create(input: CreateLeadInput): Promise<{ id: string }> {
+    const { dto, ip, userAgent } = input;
+
+    if (dto.consent !== true) {
+      throw new BadRequestException(
+        'Согласие на обработку персональных данных обязательно (152-ФЗ).',
+      );
+    }
+
+    this.validateContactByType(dto.contactType, dto.contact);
+
+    const ipHash = ip != null && ip.length > 0 ? this.hashIp(ip) : null;
+    if (ipHash != null) {
+      await this.checkRateLimit(ipHash);
+    }
+
+    const created = await this.prisma.lead.create({
+      data: {
+        source: dto.source,
+        name: this.crypto.encrypt(dto.name.trim()),
+        contactType: dto.contactType,
+        contact: this.crypto.encrypt(dto.contact.trim()),
+        comment:
+          dto.comment != null && dto.comment.trim().length > 0
+            ? this.crypto.encrypt(dto.comment.trim())
+            : null,
+        consentTextVersion: dto.consentTextVersion,
+        ipHash,
+        userAgent: userAgent ?? null,
+      },
+      select: { id: true, createdAt: true },
+    });
+
+    this.logger.log(
+      {
+        leadId: created.id,
+        source: dto.source,
+        contactType: dto.contactType,
+        ipHashShort: ipHash?.slice(0, 8),
+      },
+      'leads.create.ok',
+    );
+
+    // Async notify — не блокируем ответ. Если telegram упадёт — lead уже в БД.
+    const notify: Parameters<TelegramClient['notifyNewLead']>[0] = {
+      source: dto.source,
+      name: dto.name.trim(),
+      contactType: dto.contactType,
+      contact: dto.contact.trim(),
+      comment: dto.comment?.trim() ?? null,
+      createdAtIso: created.createdAt.toISOString(),
+    };
+    if (ipHash != null) notify.ipHashShort = ipHash.slice(0, 8);
+    void this.telegram.notifyNewLead(notify);
+
+    return { id: created.id };
+  }
+
+  // ────────────────────────── helpers
+
+  /**
+   * Лёгкая валидация контакта по типу. Полная — клиент-side через zod;
+   * на сервере достаточно sanity-check, чтобы отсечь явный спам.
+   */
+  private validateContactByType(
+    type: 'phone' | 'telegram' | 'email',
+    contact: string,
+  ): void {
+    const trimmed = contact.trim();
+    if (type === 'email') {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+        throw new BadRequestException('Некорректный email.');
+      }
+    } else if (type === 'phone') {
+      // Допускаем + ( ) - пробел и цифры; минимум 7 цифр
+      const digits = trimmed.replace(/\D/g, '');
+      if (digits.length < 7 || digits.length > 20) {
+        throw new BadRequestException('Некорректный телефон.');
+      }
+    } else if (type === 'telegram') {
+      // @username — латиница/цифры/_, 4–32 символа
+      if (!/^@?[A-Za-z0-9_]{4,32}$/.test(trimmed)) {
+        throw new BadRequestException('Некорректный Telegram username.');
+      }
+    }
+  }
+
+  /**
+   * Rate-limit: 5 заявок / минуту с одного IP. Используем Redis INCR + EXPIRE.
+   * Превышение → 429.
+   */
+  private async checkRateLimit(ipHash: string): Promise<void> {
+    const key = `lead:rl:${ipHash}`;
+    const client = this.redis.getClient();
+    const count = await client.incr(key);
+    if (count === 1) {
+      await client.expire(key, RATE_LIMIT_WINDOW_SEC);
+    }
+    if (count > RATE_LIMIT_MAX) {
+      this.logger.warn({ ipHashShort: ipHash.slice(0, 8), count }, 'leads.rate_limit.hit');
+      throw new HttpException(
+        'Слишком много заявок с этого устройства. Попробуйте через минуту.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+  }
+
+  private hashIp(ip: string): string {
+    return createHash('sha256').update(ip).digest('hex');
+  }
+
+  /** Public — для дальнейших admin-list endpoints (EPIC 14). */
+  async getById(id: string): Promise<Lead | null> {
+    return this.prisma.lead.findUnique({ where: { id } });
+  }
+}

--- a/apps/api/src/modules/leads/telegram.client.ts
+++ b/apps/api/src/modules/leads/telegram.client.ts
@@ -1,0 +1,100 @@
+/**
+ * Telegram Bot API client — отправка нотификации о новом lead'е в чат
+ * Roman/Шивам.
+ *
+ * Конфиг: TELEGRAM_BOT_TOKEN + TELEGRAM_LEADS_CHAT_ID в .env.
+ * Если не заданы — сервис логирует warning и не падает (lead всё равно
+ * сохраняется в БД).
+ *
+ * Issue: #297 [12.4]
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+interface NotifyLeadPayload {
+  source: string;
+  name: string;          // plaintext (после расшифровки в LeadsService)
+  contactType: string;
+  contact: string;       // plaintext
+  comment?: string | null;
+  ipHashShort?: string;  // короткий sha256-prefix для тех. идентификации
+  createdAtIso: string;
+}
+
+@Injectable()
+export class TelegramClient {
+  private readonly logger = new Logger(TelegramClient.name);
+  private readonly botToken: string | undefined;
+  private readonly chatId: string | undefined;
+
+  constructor(config: ConfigService) {
+    this.botToken = config.get<string>('TELEGRAM_BOT_TOKEN');
+    this.chatId = config.get<string>('TELEGRAM_LEADS_CHAT_ID');
+
+    if (!this.botToken || !this.chatId) {
+      this.logger.warn(
+        'TELEGRAM_BOT_TOKEN или TELEGRAM_LEADS_CHAT_ID не заданы — нотификации Lead\'ов отключены. ' +
+          'Lead\'ы продолжают сохраняться в БД.',
+      );
+    }
+  }
+
+  /**
+   * Отправляет нотификацию о новом lead'е. НЕ блокирует caller'а на ошибках —
+   * лог + return. Lead уже в БД, нотификация — bonus, не критично.
+   */
+  async notifyNewLead(payload: NotifyLeadPayload): Promise<void> {
+    if (!this.botToken || !this.chatId) return;
+
+    const text = this.formatMessage(payload);
+
+    try {
+      const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: this.chatId,
+          text,
+          parse_mode: 'HTML',
+          disable_web_page_preview: true,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        this.logger.error(
+          { status: res.status, body },
+          'telegram.sendMessage failed',
+        );
+      }
+    } catch (err) {
+      this.logger.error({ err }, 'telegram.sendMessage error');
+    }
+  }
+
+  private formatMessage(p: NotifyLeadPayload): string {
+    const escape = (s: string): string =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    const lines = [
+      `🆕 <b>Новая заявка</b>`,
+      ``,
+      `📌 Источник: <code>${escape(p.source)}</code>`,
+      `👤 Имя: <b>${escape(p.name)}</b>`,
+      `📞 ${escape(p.contactType)}: <code>${escape(p.contact)}</code>`,
+    ];
+
+    if (p.comment != null && p.comment.trim().length > 0) {
+      lines.push(`💬 Комментарий: ${escape(p.comment)}`);
+    }
+
+    lines.push(``);
+    lines.push(`🕐 ${escape(p.createdAtIso)}`);
+    if (p.ipHashShort != null) {
+      lines.push(`🔍 ip-hash: <code>${escape(p.ipHashShort)}</code>`);
+    }
+
+    return lines.join('\n');
+  }
+}


### PR DESCRIPTION
## Summary

Финальная backend-часть EPIC 12. Закрывает функциональный пайплайн страницы тура: форма «Хочу этот тур» → Lead в БД (encrypted ПДн) → Telegram-нотификация Roman/Шивам.

## Что внутри

### Модель + миграция
- `Lead` + `LeadStatus` enum (NEW / CONTACTED / CONVERTED / REJECTED)
- ПДн (`name`, `contact`, `comment`) — encrypted через CryptoService (#139)
- `ipHash = sha256(ip)` — raw IP не храним (privacy)
- `consentTextVersion` — для аудита 152-ФЗ

### `POST /leads` (`@Public()`)
- class-validator DTO (длины, enum, формат)
- **Server-side check** `consent === true` → 400 если иначе (защита от обхода фронта)
- Sanity-валидация контакта по типу (email / phone / telegram regex)
- **Rate-limit** через Redis: 5 запросов / мин с одного `ipHash` → 429
- Шифрование ПДн перед записью в БД
- **Async Telegram-нотификация** — не блокирует ответ. Если TG упал — lead уже в БД, видим в логах

### Telegram
- `TelegramClient` через ConfigService
- `TELEGRAM_BOT_TOKEN` (BotFather) + `TELEGRAM_LEADS_CHAT_ID` (@userinfobot)
- HTML-форматированное сообщение
- Если token/chat_id не заданы — warning + skip (нотификации опциональны для dev)

## Test plan

После merge + apply миграции (Vika) + TELEGRAM env:

- [ ] `POST /leads` валидный payload → 201 + `{id}`
- [ ] `POST /leads` без `consent=true` → 400
- [ ] 6-я заявка с одного IP за минуту → 429
- [ ] Нотификация в TG чат пришла
- [ ] Lead в БД: name/contact/comment в base64 (encrypted)
- [ ] `Lead.consentTextVersion` сохранён

## Что дальше (после merge)

1. **Подключить frontend `<LeadForm/>`** к реальному POST /leads — 15 минут работы:
   ```ts
   // apps/web/app/tours/[slug]/lead-form.tsx (текущий mock submit)
   await fetch(`${API_URL}/leads`, { method: 'POST', body: JSON.stringify({...}) });
   ```
2. **Admin-list `/leads`** endpoint — отдельный issue в EPIC 14 (Sales CRM)

## Что нужно от Vика

1. Применить миграцию `20260427120000_M5_leads_lead_model` на dev DB (когда apps/api поедет на 2.56.241.126)
2. Добавить в env:
   ```
   TELEGRAM_BOT_TOKEN=<from BotFather>
   TELEGRAM_LEADS_CHAT_ID=<from @userinfobot>
   ```

Closes #297

https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_