### PR TITLE
feat(web): подключить страницу тура и LeadForm к backend API

### DIFF
--- a/apps/web/app/tours/[slug]/lead-form.tsx
+++ b/apps/web/app/tours/[slug]/lead-form.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { LeadApiError, submitLead } from '@/lib/api/leads';
+
 type ContactType = 'phone' | 'telegram' | 'email';
 
 type FormState =
@@ -31,23 +33,26 @@ export function LeadForm({ tourSlug }: { tourSlug: string }): React.ReactElement
     if (!canSubmit) return;
     setState({ kind: 'submitting' });
 
-    /*
-     * TODO #297: подключить POST /leads когда backend Lead endpoint готов.
-     * Пока — симулируем 800ms задержку и показываем success.
-     */
-    await new Promise((r) => setTimeout(r, 800));
-    setState({ kind: 'success' });
-
-    // eslint-disable-next-line no-console
-    console.log('[lead-form mock]', {
+    const payload = {
       source: `tour-${tourSlug}`,
-      name,
+      name: name.trim(),
       contactType,
-      contact,
-      comment,
+      contact: contact.trim(),
+      ...(comment.trim().length > 0 ? { comment: comment.trim() } : {}),
       consent,
       consentTextVersion: CONSENT_TEXT_VERSION,
-    });
+    };
+
+    try {
+      await submitLead(payload);
+      setState({ kind: 'success' });
+    } catch (err) {
+      const message =
+        err instanceof LeadApiError
+          ? err.message
+          : 'Не удалось отправить заявку. Напишите нам в Telegram.';
+      setState({ kind: 'error', message });
+    }
   }
 
   if (state.kind === 'success') {
@@ -63,7 +68,7 @@ export function LeadForm({ tourSlug }: { tourSlug: string }): React.ReactElement
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
+    <form onSubmit={(e) => { void onSubmit(e); }} className="space-y-4">
       <div className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
         Заявка на тур
       </div>

--- a/apps/web/app/tours/[slug]/page.tsx
+++ b/apps/web/app/tours/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation';
 import {
   Bed,
   Calendar,
@@ -16,18 +15,27 @@ import {
   Waves,
   X,
 } from 'lucide-react';
+import { notFound } from 'next/navigation';
 
-import { getTourBySlug, listToursSlugs, type ActivityKind, type Tour } from '@/lib/mock/tours';
 import { LeadForm } from './lead-form';
+
+import type { ActivityKind, Tour } from '@/lib/mock/tours';
+
+import { getTourBySlug, listTourSlugs } from '@/lib/api/tours';
 
 export const revalidate = 3600;
 
-export function generateStaticParams(): { slug: string }[] {
-  return listToursSlugs().map((slug) => ({ slug }));
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  const slugs = await listTourSlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
-export default function TourPage({ params }: { params: { slug: string } }): React.ReactElement {
-  const tour = getTourBySlug(params.slug);
+export default async function TourPage({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<React.ReactElement> {
+  const tour = await getTourBySlug(params.slug);
   if (!tour) notFound();
 
   return (

--- a/apps/web/lib/api/leads.ts
+++ b/apps/web/lib/api/leads.ts
@@ -1,0 +1,87 @@
+/**
+ * Leads API client — отправка заявок на backend (#297).
+ *
+ * Используется в `<LeadForm/>` на странице тура. Browser-side fetch.
+ *
+ * Server-side validation — на API:
+ * - consent === true (иначе 400)
+ * - rate-limit 5/мин на IP (иначе 429)
+ *
+ * Issue: backend integration phase EPIC 12.
+ */
+
+const API_URL = process.env['NEXT_PUBLIC_API_URL'] ?? '';
+
+export interface CreateLeadPayload {
+  source: string;
+  name: string;
+  contactType: 'phone' | 'telegram' | 'email';
+  contact: string;
+  comment?: string;
+  consent: boolean;
+  consentTextVersion: string;
+}
+
+export interface CreateLeadResult {
+  id: string;
+}
+
+export class LeadApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: 'rate_limit' | 'validation' | 'server' | 'network',
+  ) {
+    super(message);
+    this.name = 'LeadApiError';
+  }
+}
+
+export async function submitLead(payload: CreateLeadPayload): Promise<CreateLeadResult> {
+  if (API_URL.length === 0) {
+    throw new LeadApiError('API недоступен', 0, 'network');
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/leads`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    throw new LeadApiError(
+      'Не удалось связаться с сервером. Попробуйте Telegram.',
+      0,
+      'network',
+    );
+  }
+
+  if (res.status === 429) {
+    throw new LeadApiError(
+      'Слишком много заявок с этого устройства. Попробуйте через минуту.',
+      429,
+      'rate_limit',
+    );
+  }
+  if (res.status === 400) {
+    let msg = 'Проверьте корректность данных.';
+    try {
+      const body = (await res.json()) as { message?: string };
+      if (typeof body.message === 'string' && body.message.length > 0) msg = body.message;
+    } catch {
+      /* ignore parse */
+    }
+    throw new LeadApiError(msg, 400, 'validation');
+  }
+  if (!res.ok) {
+    throw new LeadApiError(
+      'Что-то пошло не так. Напишите нам в Telegram.',
+      res.status,
+      'server',
+    );
+  }
+
+  const result = (await res.json()) as CreateLeadResult;
+  return result;
+}

--- a/apps/web/lib/api/tours.ts
+++ b/apps/web/lib/api/tours.ts
@@ -1,0 +1,78 @@
+/**
+ * Tour catalog API client. Читает данные с backend (NestJS catalog-module #296).
+ *
+ * Стратегия: пытается fetch на NEXT_PUBLIC_API_URL/tours, при любой ошибке
+ * (network / 4xx / 5xx) возвращает fallback из mock'а. Это позволяет:
+ * 1. Билдить frontend без backend на build-time (Vercel-like envs)
+ * 2. Сохранять страницу работоспособной если backend недоступен
+ * 3. Постепенно мигрировать с mock на real-api по мере готовности backend
+ *
+ * Как только бэкенд стабильно живёт — fallback убираем и оставляем только fetch.
+ *
+ * Issue: backend integration phase EPIC 12.
+ */
+
+import {
+  KERALA_TOUR,
+  listToursSlugs as listMockSlugs,
+  TOURS_BY_SLUG as MOCK_TOURS_BY_SLUG,
+  type Tour,
+} from '../mock/tours';
+
+const API_URL = process.env['NEXT_PUBLIC_API_URL'];
+
+/**
+ * Хелпер с timeout — fetch без timeout вешается на 30+ секунд при сетевых
+ * проблемах, что разрушит build (generateStaticParams).
+ */
+async function fetchWithTimeout(url: string, ms = 3000): Promise<Response | null> {
+  if (API_URL == null || API_URL.length === 0) return null;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      next: { revalidate: 3600 },
+    });
+    clearTimeout(timer);
+    return res;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Найти тур по slug. Сначала API, затем fallback на mock.
+ */
+export async function getTourBySlug(slug: string): Promise<Tour | null> {
+  const res = await fetchWithTimeout(`${API_URL}/tours/${encodeURIComponent(slug)}`);
+  if (res?.ok) {
+    try {
+      const data = (await res.json()) as Tour;
+      return data;
+    } catch {
+      /* falls through to mock */
+    }
+  }
+  return MOCK_TOURS_BY_SLUG[slug] ?? null;
+}
+
+/**
+ * Список slug'ов для generateStaticParams. Используется в build-time —
+ * timeout важен, иначе build виснет.
+ */
+export async function listTourSlugs(): Promise<string[]> {
+  const res = await fetchWithTimeout(`${API_URL}/tours`, 3000);
+  if (res?.ok) {
+    try {
+      const data = (await res.json()) as { slug: string }[];
+      if (data.length > 0) return data.map((t) => t.slug);
+    } catch {
+      /* falls through to mock */
+    }
+  }
+  return listMockSlugs();
+}
+
+export type { Tour };
+export { KERALA_TOUR };


### PR DESCRIPTION
## Summary

Замена mock-данных на реальный fetch с backend (после merge'а #321/#322/#325). Mock остаётся как **build-time fallback** — если бэкенд недоступен, страница продолжает работать.

## Что внутри

### `lib/api/tours.ts` (новый)
- `getTourBySlug(slug)` — fetch на `${NEXT_PUBLIC_API_URL}/tours/:slug`, 3 сек timeout, fallback на mock
- `listTourSlugs()` — для `generateStaticParams`, та же стратегия
- ISR-кеш `next: { revalidate: 3600 }`

### `lib/api/leads.ts` (новый)
- `submitLead(payload)` — POST `/leads`
- `LeadApiError` с кодами `rate_limit` / `validation` / `server` / `network`
- Понятные сообщения: 429 → «Слишком много заявок», 400 → серверное msg, иначе → «Напишите в Telegram»

### `app/tours/[slug]/page.tsx`
- Синхронный → `async` с реальным API + ISR

### `app/tours/[slug]/lead-form.tsx`
- Mock submit → `submitLead()`, error-state с понятным сообщением

## Test plan

После Vика deploy на 2.56.241.126:3010:
- [x] Build чистый (37MB standalone bundle)
- [ ] Открыть `/tours/tury-kerala-oktyabr-2026` — страница рендерится
- [ ] Submit без consent → 400 + красный alert
- [ ] Submit с consent → success-state
- [ ] Roman получает Telegram-нотификацию (когда api задеплоен)
- [ ] 6-я подряд заявка с одного IP → 429

## Известные ограничения

apps/api пока **не задеплоен** на 2.56.241.126 (Vика деплоит сейчас только web). Поэтому до отдельного API-deploy:
- Страница тура рендерится из **mock-fallback** (выглядит ОК)
- Форма заявки показывает «Напишите в Telegram» на submit (network error → graceful fallback)

После api-deploy — full end-to-end: тур из БД → форма → Telegram-уведомление.

https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2L3VjeU79v2nAxRU9rmVi)_