### PR TITLE
fix(deploy): unblock api+web Docker runtime + seed admin (#326, #328, #330)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+node_modules
+**/node_modules
+**/.next
+**/dist
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store
+*.zip
+docs/UX/prototypes/from-claude-design/project
+deploy

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+# IndiaHorizone — apps/api Dockerfile (multi-stage, pnpm monorepo, NestJS + Prisma)
+#
+# Build context: корень monorepo (см. /opt/indiahorizone/docker-compose.dev.yml).
+# Issue: #329 [devops:vika], #320, EPIC 6.
+#
+# Stages:
+#   1. base    — node:20-alpine + openssl (для Prisma) + corepack (pnpm)
+#   2. deps    — install api-subgraph (web исключаем, он в apps/web/Dockerfile)
+#   3. builder — shared build → prisma generate → nest build
+#   4. runner  — Node 20 alpine + код из builder + healthcheck
+
+# ────────────────────────── 1. base
+FROM node:20-alpine AS base
+RUN apk add --no-cache libc6-compat openssl
+WORKDIR /repo
+RUN corepack enable
+
+# ────────────────────────── 2. deps (api subgraph)
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/package.json
+COPY apps/api/package.json ./apps/api/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+# Prisma schema нужна сейчас — apps/api postinstall запустит `prisma generate`
+# (генератор кладёт client рядом с @prisma/client в node_modules).
+COPY apps/api/prisma ./apps/api/prisma
+# Ставим только подграф api (web исключён — у него свой Dockerfile).
+# `@indiahorizone/api...` = api + транзитивно shared.
+RUN pnpm install --frozen-lockfile --prefer-offline --filter "@indiahorizone/api..."
+
+# ────────────────────────── 3. builder
+FROM base AS builder
+COPY --from=deps /repo /repo
+COPY . .
+ENV NODE_ENV=production
+RUN pnpm --filter @indiahorizone/shared build
+RUN pnpm --filter @indiahorizone/api build
+
+# ────────────────────────── 4. runner
+# рекомендация: для prod-образа — отдельный slim-runner через `pnpm deploy --prod`
+# (только prod node_modules + dist/ + prisma client = ~200 MB). Сейчас dev-pilot,
+# тащим весь monorepo из builder для надёжной работы Prisma + pnpm symlinks
+# (~700 MB). Slim-вариант — отдельный issue фазы 4 после стабилизации dev.
+FROM node:20-alpine AS runner
+RUN apk add --no-cache libc6-compat openssl wget && \
+    addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nestjs
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV API_HOST=0.0.0.0
+ENV API_PORT=4000
+
+COPY --from=builder --chown=nestjs:nodejs /repo /app
+
+USER nestjs
+WORKDIR /app/apps/api
+EXPOSE 4000
+
+# Healthcheck: GET /health (NestJS health.controller — проверяет prisma + redis)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://localhost:4000/health || exit 1
+
+CMD ["node", "dist/main.js"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "db:seed:tours": "ts-node prisma/seed/tours.ts",
+    "db:seed:admin": "ts-node prisma/seed/admin.ts",
     "postinstall": "prisma generate"
   },
   "prisma": {

--- a/apps/api/prisma/seed/admin.ts
+++ b/apps/api/prisma/seed/admin.ts
@@ -1,0 +1,132 @@
+/**
+ * Seed admin — bootstrap первого admin'а из ENV для dev/staging.
+ *
+ * Запуск (см. docs/OPS/BOOTSTRAP.md):
+ *   ADMIN_BOOTSTRAP_EMAIL=... ADMIN_BOOTSTRAP_PASSWORD=... \
+ *     pnpm --filter @indiahorizone/api db:seed:admin
+ *
+ * После первого деплоя БД пуста — войти в /login нечем. Статичный seed-юзер
+ * в коде = пароль в git = security-bug. Решение: env-переменные, которые Вика
+ * экспортирует только на момент запуска, потом unset. См. issue #328.
+ *
+ * Идемпотентность: upsert по email. Если user уже существует — обновляется
+ * ТОЛЬКО passwordHash (ротация пароля повторным запуском). role и status
+ * НЕ перезаписываются — защита от privilege escalation, если ADMIN_BOOTSTRAP_EMAIL
+ * случайно совпадёт с email существующего клиента.
+ *
+ * Без env — exit 0 (no-op). Можно безопасно включить в CI/deploy-pipeline.
+ *
+ * Issue: #328 [M5.B.13]
+ */
+import { PrismaClient } from '@prisma/client';
+import * as argon2 from 'argon2';
+import zxcvbn from 'zxcvbn';
+
+// рекомендация: ARGON2_OPTIONS должны совпадать с password.service.ts:9.
+// Расхождение не сломает login (argon2 хранит параметры в хеше, login сделает
+// silent-rehash при первом успехе) — но при ревизии security-параметров обновлять
+// нужно ОБА места. Долгосрочно — вынести в отдельный constants-модуль.
+const ARGON2_OPTIONS: argon2.Options = {
+  type: argon2.argon2id,
+  memoryCost: 19_456,
+  timeCost: 2,
+  parallelism: 1,
+};
+
+// рекомендация: совпадает с MIN_ZXCVBN_SCORE в password.service.ts:5.
+const MIN_ZXCVBN_SCORE = 2;
+const MIN_PASSWORD_LENGTH = 12;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const prisma = new PrismaClient();
+
+interface BootstrapEnv {
+  email: string;
+  password: string;
+}
+
+function readEnv(): BootstrapEnv | null {
+  const rawEmail = process.env.ADMIN_BOOTSTRAP_EMAIL?.trim();
+  const password = process.env.ADMIN_BOOTSTRAP_PASSWORD;
+
+  if (!rawEmail && !password) {
+    return null;
+  }
+  if (!rawEmail || !password) {
+    throw new Error(
+      'обе переменные ADMIN_BOOTSTRAP_EMAIL и ADMIN_BOOTSTRAP_PASSWORD должны быть заданы (или ни одной)',
+    );
+  }
+
+  const email = rawEmail.toLowerCase();
+  if (!EMAIL_REGEX.test(email)) {
+    throw new Error(`ADMIN_BOOTSTRAP_EMAIL некорректен: "${email}"`);
+  }
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(
+      `пароль слишком короткий (${password.length} < ${MIN_PASSWORD_LENGTH} символов)`,
+    );
+  }
+
+  const strength = zxcvbn(password, [email]);
+  if (strength.score < MIN_ZXCVBN_SCORE) {
+    const hint =
+      strength.feedback.warning ||
+      strength.feedback.suggestions[0] ||
+      'добавь длины и непредсказуемых символов';
+    throw new Error(
+      `пароль слишком слабый (zxcvbn score ${strength.score} < ${MIN_ZXCVBN_SCORE}): ${hint}`,
+    );
+  }
+
+  return { email, password };
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  if (!env) {
+    // eslint-disable-next-line no-console
+    console.log('[seed:admin] ADMIN_BOOTSTRAP_* не заданы — пропускаю (no-op)');
+    return;
+  }
+
+  const passwordHash = await argon2.hash(env.password, ARGON2_OPTIONS);
+
+  const existing = await prisma.user.findUnique({
+    where: { email: env.email },
+    select: { id: true, role: true, status: true },
+  });
+
+  if (existing) {
+    await prisma.user.update({
+      where: { id: existing.id },
+      data: { passwordHash },
+    });
+    // eslint-disable-next-line no-console
+    console.log(
+      `✓ [seed:admin] password updated for ${env.email} ` +
+        `(role=${existing.role}, status=${existing.status} — unchanged)`,
+    );
+    return;
+  }
+
+  await prisma.user.create({
+    data: {
+      email: env.email,
+      passwordHash,
+      role: 'admin',
+      status: 'active',
+    },
+  });
+  // eslint-disable-next-line no-console
+  console.log(`✓ [seed:admin] admin created: ${env.email}`);
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[seed:admin] failed:', err instanceof Error ? err.message : err);
+    void prisma.$disconnect().finally(() => process.exit(1));
+  });

--- a/apps/api/src/common/events-bus/events-bus.service.ts
+++ b/apps/api/src/common/events-bus/events-bus.service.ts
@@ -67,8 +67,8 @@ export class EventsBusService implements OnModuleDestroy {
       occurredAt: event.occurredAt ?? new Date().toISOString(),
       type: event.type,
       schemaVersion: event.schemaVersion,
-      correlationId: event.correlationId,
-      causationId: event.causationId,
+      ...(event.correlationId !== undefined && { correlationId: event.correlationId }),
+      ...(event.causationId !== undefined && { causationId: event.causationId }),
       actor: event.actor,
       payload: event.payload,
     };

--- a/apps/api/src/common/outbox/outbox-relay.worker.ts
+++ b/apps/api/src/common/outbox/outbox-relay.worker.ts
@@ -91,8 +91,8 @@ export class OutboxRelayWorker implements OnModuleInit, OnModuleDestroy {
           occurredAt: envelope.occurredAt ?? entry.createdAt.toISOString(),
           type: entry.eventType,
           schemaVersion: entry.schemaVersion,
-          correlationId: envelope.correlationId,
-          causationId: envelope.causationId,
+          ...(envelope.correlationId !== undefined && { correlationId: envelope.correlationId }),
+          ...(envelope.causationId !== undefined && { causationId: envelope.causationId }),
           actor: envelope.actor,
           payload: envelope.payload,
         });

--- a/apps/api/src/common/outbox/outbox.service.ts
+++ b/apps/api/src/common/outbox/outbox.service.ts
@@ -58,8 +58,8 @@ export class OutboxService {
       occurredAt,
       type: event.type,
       schemaVersion: event.schemaVersion,
-      correlationId: event.correlationId,
-      causationId: event.causationId,
+      ...(event.correlationId !== undefined && { correlationId: event.correlationId }),
+      ...(event.causationId !== undefined && { causationId: event.causationId }),
       actor: event.actor,
       payload: event.payload,
     };

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -39,7 +39,7 @@ export class LoginService {
 
   async login(
     dto: LoginDto,
-    context: { ip?: string; userAgent?: string },
+    context: { ip?: string | undefined; userAgent?: string | undefined },
   ): Promise<LoginResponse> {
     const user = await this.prisma.user.findUnique({
       where: { email: dto.email },
@@ -82,8 +82,8 @@ export class LoginService {
         data: {
           userId: user.id,
           refreshTokenHash: refreshHash,
-          ip: context.ip,
-          userAgent: context.userAgent,
+          ip: context.ip ?? null,
+          userAgent: context.userAgent ?? null,
           expiresAt: refresh.expiresAt,
         },
         select: { id: true },

--- a/apps/api/src/modules/auth/services/logout.service.ts
+++ b/apps/api/src/modules/auth/services/logout.service.ts
@@ -4,8 +4,8 @@ import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
 
 export interface LogoutContext {
-  ip?: string;
-  userAgent?: string;
+  ip?: string | undefined;
+  userAgent?: string | undefined;
 }
 
 /**

--- a/apps/api/src/modules/auth/services/password.service.ts
+++ b/apps/api/src/modules/auth/services/password.service.ts
@@ -39,7 +39,7 @@ export class PasswordService {
     return {
       ok: result.score >= MIN_ZXCVBN_SCORE,
       score: result.score,
-      warning: result.feedback.warning || undefined,
+      ...(result.feedback.warning ? { warning: result.feedback.warning } : {}),
       suggestions: result.feedback.suggestions ?? [],
     };
   }

--- a/apps/api/src/modules/auth/services/refresh.service.ts
+++ b/apps/api/src/modules/auth/services/refresh.service.ts
@@ -51,7 +51,7 @@ export class RefreshService {
 
   async refresh(
     dto: RefreshDto,
-    context: { ip?: string; userAgent?: string },
+    context: { ip?: string | undefined; userAgent?: string | undefined },
   ): Promise<RefreshResponse> {
     const parsed = this.jwt.parseRefresh(dto.refreshToken);
     if (!parsed) {
@@ -112,8 +112,8 @@ export class RefreshService {
         data: {
           userId: session.userId,
           refreshTokenHash: newRefreshHash,
-          ip: context.ip,
-          userAgent: context.userAgent,
+          ip: context.ip ?? null,
+          userAgent: context.userAgent ?? null,
           expiresAt: newRefresh.expiresAt,
         },
         select: { id: true },
@@ -165,7 +165,7 @@ export class RefreshService {
   private async handleReuseAttempt(
     userId: string,
     suspiciousSessionId: string,
-    context: { ip?: string; userAgent?: string },
+    context: { ip?: string | undefined; userAgent?: string | undefined },
   ): Promise<void> {
     this.logger.warn(
       {

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -32,7 +32,7 @@ export class HealthController {
     return {
       status: 'ok',
       uptime: process.uptime(),
-      version: process.env.npm_package_version ?? '0.0.0',
+      version: process.env['npm_package_version'] ?? '0.0.0',
       timestamp: new Date().toISOString(),
     };
   }

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,13 +18,18 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /repo
 RUN corepack enable
 
-# ────────────────────────── 2. deps (frozen install с workspace)
+# ────────────────────────── 2. deps (frozen install — scoped to web subgraph)
 FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json ./apps/web/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY packages/shared/package.json ./packages/shared/package.json
-RUN pnpm install --frozen-lockfile --prefer-offline
+# рекомендация: ставим только подграф web (web → shared). apps/api не ставим:
+# 1) web не зависит от api;
+# 2) apps/api postinstall = `prisma generate` требует apps/api/prisma/schema.prisma,
+#    которая для web-билда не нужна (issue #326);
+# 3) меньше слой → быстрее build, не тянем libssl/openssl ради ненужного prisma.
+RUN pnpm install --frozen-lockfile --prefer-offline --filter "@indiahorizone/web..."
 
 # ────────────────────────── 3. builder
 FROM base AS builder

--- a/docs/OPS/BOOTSTRAP.md
+++ b/docs/OPS/BOOTSTRAP.md
@@ -1,0 +1,108 @@
+# Bootstrap admin пользователя в dev/staging
+
+Runbook для Вики (devops AI). Контекст: после первого деплоя `apps/api` БД пуста, в `/login` войти нечем. Этот скрипт создаёт первого admin'а из ENV-переменных, переданных только на момент запуска.
+
+> **Issue:** #328 (Claude — код), #329 (Vika — compose).
+> **Принцип:** пароль НИКОГДА не оказывается на диске сервера и в git. Только в shell-сессии Вики на момент запуска.
+
+## Когда запускать
+
+- Один раз после первого `prisma migrate deploy` на новом окружении (dev/staging).
+- Повторно — для **ротации пароля** того же admin'а (role не меняется).
+- В CI — безопасно, без env скрипт делает `exit 0` (no-op).
+
+## Предусловия
+
+- `apps/api` контейнер собран (через `docker compose build api`)
+- `prisma migrate deploy` выполнен (таблица `users` существует)
+- Вика получила от Roman'а:
+  - **email** через любой канал (не секрет)
+  - **password ≥ 12 символов** через secure канал (Telegram «Секретный чат», Bitwarden Send, или out-of-band)
+
+## Запуск
+
+```bash
+cd /opt/indiahorizone
+
+# Roman диктует пароль — Вика читает с -s (no echo, история не сохраняется)
+read -s ADMIN_BOOTSTRAP_PASSWORD
+export ADMIN_BOOTSTRAP_PASSWORD
+export ADMIN_BOOTSTRAP_EMAIL=roman@indiahorizone.ru   # пример
+
+docker compose --env-file .env -f docker-compose.dev.yml run --rm \
+  -e ADMIN_BOOTSTRAP_EMAIL \
+  -e ADMIN_BOOTSTRAP_PASSWORD \
+  api pnpm --filter @indiahorizone/api db:seed:admin
+
+# КРИТИЧНО: сразу очищаем env и историю
+unset ADMIN_BOOTSTRAP_EMAIL ADMIN_BOOTSTRAP_PASSWORD
+history -c
+```
+
+## Ожидаемый вывод
+
+При первом запуске:
+```
+✓ [seed:admin] admin created: roman@indiahorizone.ru
+```
+
+При повторном запуске (ротация пароля):
+```
+✓ [seed:admin] password updated for roman@indiahorizone.ru (role=admin, status=active — unchanged)
+```
+
+Без env (smoke test):
+```
+[seed:admin] ADMIN_BOOTSTRAP_* не заданы — пропускаю (no-op)
+```
+
+## Проверки
+
+После успешного запуска:
+
+```bash
+# 1. User в БД появился
+docker compose --env-file .env -f docker-compose.dev.yml exec postgres \
+  psql -U indiahorizone -d indiahorizone \
+  -c "select email, role, status, created_at from users;"
+
+# 2. Roman логинится через API
+curl -X POST http://localhost:3011/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"roman@indiahorizone.ru","password":"ТОТ-САМЫЙ-ПАРОЛЬ"}'
+# Ожидаем 200 + { accessToken, refreshToken }
+
+# 3. Roman в браузере
+# http://2.56.241.126:3010/login → email + password → /trips
+```
+
+## Если упало
+
+| Ошибка | Причина | Действие |
+|---|---|---|
+| `пароль слишком короткий` | < 12 символов | попроси Roman'а длиннее |
+| `пароль слишком слабый (zxcvbn score N < 2)` | очевидный паттерн (`IndiaHorizone2026`, `password123`) | попроси непредсказуемее, лучше из менеджера паролей |
+| `ADMIN_BOOTSTRAP_EMAIL некорректен` | опечатка | проверь, что нет лишних пробелов и знаков |
+| `Can't reach database server` | postgres не поднят / DATABASE_URL кривой | `docker compose ps`, проверь `.env` |
+| `Could not load schema from prisma/schema.prisma` | image не собрался с prisma директорией | re-build: `docker compose build api --no-cache` |
+
+## Что НЕ делать
+
+> **Не клади ADMIN_BOOTSTRAP_PASSWORD в `.env` или `docker-compose.yml`.** Файл попадёт в `docker logs`, в backup, в snapshot диска. Ключ admin'а — root-доступ ко всему стэку. **Эфемерное окружение shell-а — единственное место, где этот пароль допустимо иметь.**
+
+> **Не пиши пароль в комментариях issue / PR / Telegram-каналах.** Если Roman прислал пароль не в защищённом канале — попроси сменить и пришли заново через secure канал.
+
+> **Не запускай скрипт с дефолтным паролем «для теста»** (вроде `Admin12345!`). Dev-сервер `2.56.241.126:3010` доступен из интернета — Shodan-боты ловят дефолты за минуты. Лучше пропустить bootstrap, чем оставить дефолт.
+
+## Будущее
+
+- **Production** — отдельный runbook когда дойдём до prod-инфры (Vault / KMS вместо ENV).
+- **Invitation flow** для остальных ролей (manager, finance, concierge, guide) — issue #134 (password reset через email = тот же механизм для invite). После него seed нужен только для первого admin'а; всех остальных Roman приглашает из ЛК.
+- **Slim-runner** Dockerfile вместо текущего «весь монорепо в runner» — отдельный issue фазы 4.
+
+## Ссылки
+
+- Скрипт: `apps/api/prisma/seed/admin.ts`
+- Issue: [#328 M5.B.13 seed admin](https://github.com/Rivega42/indiahorizone/issues/328)
+- Compose-issue: [#329 [devops:vika] api+postgres+redis](https://github.com/Rivega42/indiahorizone/issues/329)
+- Argon2 параметры: `apps/api/src/modules/auth/services/password.service.ts:9`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "description": "Общие утилиты, типы, доменные модели для api/web/mobile",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint .",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,8 +4,14 @@
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    // CommonJS output — apps/api (NestJS, CJS) и apps/web (Next.js, bundler)
+    // оба корректно резолвят CJS-модули из @indiahorizone/shared в runtime'е
+    // (#330: Node ESM не поддерживает directory imports вида `./crypto`,
+    // CJS их прекрасно резолвит).
+    // Node moduleResolution — чтобы tsc понимал bare imports без bundler-magic.
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "verbatimModuleSyntax": false,
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

Atomic PR разблокирующий Викин deploy (#329) на dev-сервер. Никаких бизнес-фич — только инфра-фиксы.

| Commit | Closes |
|--------|--------|
| `84d3710` fix(web): scope Dockerfile pnpm install to web subgraph | #326 |
| `6c4ac67` feat(api): Dockerfile + seed admin bootstrap | #328 |
| `4c001f4` fix(api): align with exactOptionalPropertyTypes | unblock |
| `85033ee` fix(shared): CJS output + main→dist | #330 |

## Что внутри

### `apps/web/Dockerfile` (#326)
Изначально `pnpm install` пытался поставить весь monorepo, включая `apps/api`, чей postinstall (`prisma generate`) падал на отсутствующей schema.prisma. Заменил на:
```diff
-RUN pnpm install --frozen-lockfile --prefer-offline
+RUN pnpm install --frozen-lockfile --prefer-offline --filter "@indiahorizone/web..."
```
Web Dockerfile концептуально не должен зависеть от api.

### `apps/api/Dockerfile` + `.dockerignore` (#329 dependency)
Multi-stage build для NestJS: base→deps→builder→runner. В builder делается shared build → prisma generate (postinstall) → nest build. Runner копирует repo из builder (~700MB; slim-runner с `pnpm deploy --prod` — отдельный issue фазы 4 после стабилизации dev).

### `apps/api/prisma/seed/admin.ts` (#328)
Идемпотентный seed первого admin'а из `ADMIN_BOOTSTRAP_EMAIL` + `ADMIN_BOOTSTRAP_PASSWORD` env. Без env → exit 0 (CI-safe). При update НЕ перезаписывает role/status (защита от privilege-escalation если email совпадёт с существующим юзером). Argon2id с теми же параметрами что `password.service.ts`. Runbook для Вики — `docs/OPS/BOOTSTRAP.md`.

### `apps/api/src/*` TS-фиксы (unblock build)
11 pre-existing TS-ошибок, появившихся после введения `exactOptionalPropertyTypes: true` в #234. Без них `nest build` падал → апи-контейнер не собирался. Фиксы хирургические — без semantic-смен:
- `auth/services/{login,refresh,logout}` — `ip?: string` → `ip?: string | undefined`, `?? null` для Prisma
- `events-bus`, `outbox`, `outbox-relay` — conditional spread для опциональных correlationId/causationId
- `password.service` — conditional spread для warning
- `health.controller` — bracket-access `process.env['npm_package_version']`

### `packages/shared` CJS (#330)
Вика обнаружила в Docker:
```
ERR_UNSUPPORTED_DIR_IMPORT: '/app/packages/shared/src/crypto'
```
Две корневые проблемы:
1. `package.json.main` указывал на `src/index.ts` (TypeScript) → Node не мог загрузить
2. `tsconfig.json` компилил в ESNext → directory imports `./crypto` не валидны в Node ESM

Фикс: `main → dist/index.js`, `module: "CommonJS"`. В CJS Node штатно резолвит directory → `directory/index.js`.

## Test plan

- [x] `pnpm --filter @indiahorizone/shared build` — зелёный, dist/ содержит CJS
- [x] `pnpm --filter @indiahorizone/api build` — зелёный (nest build)
- [x] `pnpm --filter @indiahorizone/api type-check` — зелёный
- [x] Runtime: `node -e "require('@indiahorizone/shared').crypto.encrypt(...)"` — работает
- [ ] **На сервере (Вика):** `docker compose build --no-cache api web` — проверить что оба образа собираются
- [ ] **На сервере (Вика):** `docker compose up -d` — оба контейнера healthy
- [ ] **На сервере (Вика):** после `db:migrate:deploy` — `docker logs indiahorizone-api-dev` показывает `🚀 API listening on http://0.0.0.0:4000`

## Closes

- Closes #326
- Closes #328 (код реализован; запуск seed на сервере — за Викой через #329)
- Closes #330

## Связано

- Разблокирует #329 (Викин deploy api+postgres+redis в compose)
- Не блокирует: следующие PR из ветки (2FA, clients, trips) — каждый отдельным атомарным PR'ом

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_