### PR TITLE
feat(auth): 2FA TOTP enrollment + verify при login + recovery codes (#132, #133)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,18 +23,19 @@
     "schema": "prisma/schema.prisma"
   },
   "dependencies": {
+    "@indiahorizone/shared": "workspace:*",
     "@nestjs/common": "^10.4.6",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.6",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.4.6",
     "@nestjs/terminus": "^10.2.3",
-    "@indiahorizone/shared": "workspace:*",
     "@prisma/client": "^5.21.1",
     "argon2": "^0.41.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "ioredis": "^5.4.1",
+    "otplib": "^13.4.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zxcvbn": "^4.4.2"

--- a/apps/api/prisma/migrations/20260428100000_M5_B_007_two_fa/migration.sql
+++ b/apps/api/prisma/migrations/20260428100000_M5_B_007_two_fa/migration.sql
@@ -1,0 +1,24 @@
+-- M5.B.007 — 2FA TOTP enrollment (issue #132)
+--
+-- Изменения:
+-- 1. users — два новых поля: two_fa_enabled (default false), two_fa_secret (nullable)
+-- 2. recovery_codes — новая таблица для 2FA fallback кодов
+
+ALTER TABLE "users"
+  ADD COLUMN "two_fa_enabled" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "two_fa_secret" TEXT;
+
+CREATE TABLE "recovery_codes" (
+  "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"    UUID NOT NULL,
+  "code_hash"  TEXT NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "used_at"    TIMESTAMP(3),
+
+  CONSTRAINT "recovery_codes_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "recovery_codes_user_id_fkey" FOREIGN KEY ("user_id")
+    REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Active codes per user (used_at IS NULL) — для быстрого поиска при verify
+CREATE INDEX "idx_recovery_codes_user_active" ON "recovery_codes" ("user_id", "used_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -122,14 +122,43 @@ model User {
   passwordHash String     @map("password_hash")
   role         UserRole   @default(client)
   status       UserStatus @default(active)
+  /// 2FA TOTP активирован после успешного verify-enroll (#132).
+  /// false → /login возвращает токены сразу.
+  /// true  → /login возвращает { challengeId } и требует /auth/2fa/verify (#133).
+  twoFaEnabled Boolean    @default(false) @map("two_fa_enabled")
+  /// TOTP secret (base32-string), зашифрован через CryptoService (AES-256-GCM).
+  /// Заполняется в /auth/2fa/enroll, сохраняется при verify-enroll, очищается при disable.
+  twoFaSecret  String?    @map("two_fa_secret")
   createdAt    DateTime   @default(now()) @map("created_at")
   updatedAt    DateTime   @updatedAt @map("updated_at")
 
   /// Backref для CASCADE на logout-all и trip-history.
-  sessions Session[]
+  sessions      Session[]
+  recoveryCodes RecoveryCode[]
 
   @@index([email], map: "idx_users_email")
   @@map("users")
+}
+
+/// Recovery codes для 2FA — одноразовые fallback при потере устройства (#132).
+/// Хранятся как argon2id-хеши. Plaintext выдаётся пользователю ОДИН раз при
+/// /auth/2fa/verify-enroll (или при regenerate). После use — usedAt заполняется,
+/// код больше не принимается.
+///
+/// Cross-module FK на User ОК (тот же модуль auth, единая extraction unit).
+model RecoveryCode {
+  id        String    @id @default(uuid()) @db.Uuid
+  userId    String    @map("user_id") @db.Uuid
+  /// argon2id(plaintext_code). Plaintext НИКОГДА не хранится.
+  codeHash  String    @map("code_hash")
+  createdAt DateTime  @default(now()) @map("created_at")
+  /// NULL — код активен. Заполняется при первом успешном использовании.
+  usedAt    DateTime? @map("used_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, usedAt], map: "idx_recovery_codes_user_active")
+  @@map("recovery_codes")
 }
 
 // === clients модуль (#138–#148) ===

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { LoginService } from './services/login.service';
 import { LogoutService } from './services/logout.service';
 import { PasswordService } from './services/password.service';
 import { RefreshService } from './services/refresh.service';
+import { TwoFaChallengeService } from './two-fa/two-fa-challenge.service';
 import { TwoFaController } from './two-fa/two-fa.controller';
 import { TwoFaService } from './two-fa/two-fa.service';
 
@@ -38,6 +39,7 @@ import { TwoFaService } from './two-fa/two-fa.service';
     PasswordService,
     JwtTokenService,
     TwoFaService,
+    TwoFaChallengeService,
   ],
   exports: [
     AuthService,
@@ -47,6 +49,7 @@ import { TwoFaService } from './two-fa/two-fa.service';
     PasswordService,
     JwtTokenService,
     TwoFaService,
+    TwoFaChallengeService,
   ],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { LoginService } from './services/login.service';
 import { LogoutService } from './services/logout.service';
 import { PasswordService } from './services/password.service';
 import { RefreshService } from './services/refresh.service';
+import { TwoFaController } from './two-fa/two-fa.controller';
+import { TwoFaService } from './two-fa/two-fa.service';
 
 /**
  * Auth module — register / login / logout / refresh / 2FA / password-reset.
@@ -27,7 +29,7 @@ import { RefreshService } from './services/refresh.service';
     // Глобальный module не требуется — JwtTokenService сам читает env через ConfigService.
     JwtModule.register({}),
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, TwoFaController],
   providers: [
     AuthService,
     LoginService,
@@ -35,6 +37,7 @@ import { RefreshService } from './services/refresh.service';
     LogoutService,
     PasswordService,
     JwtTokenService,
+    TwoFaService,
   ],
   exports: [
     AuthService,
@@ -43,6 +46,7 @@ import { RefreshService } from './services/refresh.service';
     LogoutService,
     PasswordService,
     JwtTokenService,
+    TwoFaService,
   ],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/dto/login.dto.ts
+++ b/apps/api/src/modules/auth/dto/login.dto.ts
@@ -13,7 +13,7 @@ export class LoginDto {
   password!: string;
 }
 
-export interface LoginResponse {
+export interface LoginTokenResponse {
   accessToken: string;
   refreshToken: string;
   user: {
@@ -22,3 +22,17 @@ export interface LoginResponse {
     role: string;
   };
 }
+
+/**
+ * Если у user активирован 2FA — login возвращает challengeId вместо токенов.
+ * Клиент должен вызвать POST /auth/2fa/verify { challengeId, code } для
+ * получения токенов. Challenge живёт 5 минут, ≤5 попыток.
+ */
+export interface LoginChallengeResponse {
+  challengeId: string;
+}
+
+/**
+ * Discriminated union: проверять наличие `challengeId` для определения формы.
+ */
+export type LoginResponse = LoginTokenResponse | LoginChallengeResponse;

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -101,11 +101,28 @@ export class LoginService {
    * Выпуск JWT-токенов + создание Session + outbox.
    * Используется в успешном /login (без 2FA) и в /auth/2fa/verify после
    * подтверждения второго фактора (#133).
+   *
+   * Defense-in-depth: caller обязан передать user после проверки status === active.
+   * На случай если будущий caller забудет — повторно валидируем status здесь.
+   * JwtAuthGuard на каждом запросе НЕ ходит в БД — поэтому suspend существующей
+   * сессии работает только через revoke в Session table, не через user.status.
+   * Здесь — единственное место, где status гарантированно проверяется перед
+   * созданием новой Session.
    */
   async issueTokensForUser(
-    user: { id: string; email: string; role: UserRole },
+    user: { id: string; email: string; role: UserRole; status: UserStatus },
     context: { ip?: string | undefined; userAgent?: string | undefined },
   ): Promise<LoginTokenResponse> {
+    if (user.status !== UserStatus.active) {
+      // Generic message — caller должен был проверить раньше; если нет, это bug
+      // или race-condition (suspend между чтением и issue).
+      this.logger.warn(
+        { userId: user.id, status: user.status },
+        'issueTokens.blocked-status',
+      );
+      throw new UnauthorizedException(GENERIC_INVALID_CREDS);
+    }
+
     const refresh = this.jwt.generateRefresh();
     const refreshHash = await this.password.hash(refresh.random);
 

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -1,13 +1,14 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
-import { UserStatus } from '@prisma/client';
+import { UserStatus, type UserRole } from '@prisma/client';
 
 import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
+import { TwoFaChallengeService } from '../two-fa/two-fa-challenge.service';
 
 import { JwtTokenService } from './jwt.service';
 import { PasswordService } from './password.service';
 
-import type { LoginDto, LoginResponse } from '../dto/login.dto';
+import type { LoginDto, LoginResponse, LoginTokenResponse } from '../dto/login.dto';
 
 const GENERIC_INVALID_CREDS = 'Неверный email или пароль';
 
@@ -35,6 +36,7 @@ export class LoginService {
     private readonly outbox: OutboxService,
     private readonly password: PasswordService,
     private readonly jwt: JwtTokenService,
+    private readonly twoFaChallenge: TwoFaChallengeService,
   ) {}
 
   async login(
@@ -43,7 +45,14 @@ export class LoginService {
   ): Promise<LoginResponse> {
     const user = await this.prisma.user.findUnique({
       where: { email: dto.email },
-      select: { id: true, email: true, role: true, status: true, passwordHash: true },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        status: true,
+        passwordHash: true,
+        twoFaEnabled: true,
+      },
     });
 
     // Anti-enumeration: даже если user не найден, выполняем dummy-verify, чтобы
@@ -73,6 +82,30 @@ export class LoginService {
         .catch((err: unknown) => this.logger.warn({ err, userId: user.id }, 'rehash.failed'));
     }
 
+    // 2FA fork: пароль верный, но второй фактор требуется. Создаём challenge,
+    // токены НЕ выпускаем. Юзер пройдёт POST /auth/2fa/verify (#133).
+    if (user.twoFaEnabled) {
+      const challengeId = await this.twoFaChallenge.create({
+        userId: user.id,
+        ...(context.ip !== undefined ? { ip: context.ip } : {}),
+        ...(context.userAgent !== undefined ? { userAgent: context.userAgent } : {}),
+      });
+      this.logger.log({ userId: user.id, challengeId }, 'auth.login.2fa-challenge');
+      return { challengeId };
+    }
+
+    return this.issueTokensForUser(user, context);
+  }
+
+  /**
+   * Выпуск JWT-токенов + создание Session + outbox.
+   * Используется в успешном /login (без 2FA) и в /auth/2fa/verify после
+   * подтверждения второго фактора (#133).
+   */
+  async issueTokensForUser(
+    user: { id: string; email: string; role: UserRole },
+    context: { ip?: string | undefined; userAgent?: string | undefined },
+  ): Promise<LoginTokenResponse> {
     const refresh = this.jwt.generateRefresh();
     const refreshHash = await this.password.hash(refresh.random);
 
@@ -104,7 +137,6 @@ export class LoginService {
       return session.id;
     });
 
-    // sessionId известен после INSERT'а — теперь подписываем JWT с ним
     const access = this.jwt.signAccess({ userId: user.id, sessionId, role: user.role });
 
     this.logger.log({ userId: user.id, sessionId }, 'auth.user.logged_in');

--- a/apps/api/src/modules/auth/two-fa/dto/verify-enroll.dto.ts
+++ b/apps/api/src/modules/auth/two-fa/dto/verify-enroll.dto.ts
@@ -1,0 +1,39 @@
+import { IsString, Length, Matches } from 'class-validator';
+
+/**
+ * DTO для POST /auth/2fa/verify-enroll.
+ *
+ * Юзер вводит 6-значный TOTP код из authenticator-приложения.
+ * При успехе — 2FA активирован, возвращаются 10 recovery codes (один раз).
+ *
+ * Issue: #132 [M5.B.7]
+ */
+export class VerifyEnrollDto {
+  @IsString()
+  @Length(6, 6, { message: 'TOTP код должен быть 6 цифр' })
+  @Matches(/^\d{6}$/, { message: 'TOTP код — только цифры' })
+  code!: string;
+}
+
+export interface EnrollResponse {
+  /**
+   * Plaintext base32-секрет. Используется UI для ручного ввода в authenticator,
+   * если QR-сканирование недоступно. После refresh страницы — недоступен,
+   * пользователь должен запустить enroll заново.
+   */
+  secret: string;
+  /**
+   * otpauth://totp/IndiaHorizone:{email}?secret={secret}&issuer=IndiaHorizone
+   * Клиент рендерит QR-код из этой URL.
+   */
+  otpAuthUrl: string;
+}
+
+export interface VerifyEnrollResponse {
+  /**
+   * 10 recovery-кодов в plaintext. Возвращаются ОДИН раз — после ответа
+   * сервер хранит только argon2id-хеши, восстановить нельзя.
+   * Формат: XXXX-XXXX-XXXX-XXXX (16 hex-символов с разделителями).
+   */
+  recoveryCodes: string[];
+}

--- a/apps/api/src/modules/auth/two-fa/dto/verify-login.dto.ts
+++ b/apps/api/src/modules/auth/two-fa/dto/verify-login.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsUUID, MaxLength } from 'class-validator';
+
+/**
+ * DTO для POST /auth/2fa/verify — finalize login после challenge'а (#133).
+ *
+ * code может быть:
+ * - 6 цифр — TOTP из authenticator-приложения
+ * - XXXX-XXXX-XXXX-XXXX — recovery code (одноразовый)
+ *
+ * Server-side определяет формат по regex и проверяет соответственно.
+ */
+export class VerifyTwoFaLoginDto {
+  @IsUUID(4, { message: 'challengeId должен быть UUIDv4' })
+  challengeId!: string;
+
+  @IsString()
+  @MaxLength(32, { message: 'code слишком длинный' })
+  code!: string;
+}

--- a/apps/api/src/modules/auth/two-fa/two-fa-challenge.service.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa-challenge.service.ts
@@ -1,0 +1,99 @@
+/**
+ * TwoFaChallengeService — короткоживущие 2FA challenges в Redis (issue #133).
+ *
+ * Когда пользователь с активированным 2FA шлёт POST /auth/login и пароль
+ * верный — мы НЕ выпускаем токены, а создаём challenge:
+ *   challengeId (random UUIDv4) → userId, TTL 5 мин
+ * И возвращаем юзеру `{ challengeId }`. Юзер вводит TOTP/recovery код
+ * на втором экране, шлёт POST /auth/2fa/verify { challengeId, code },
+ * и только тогда получает токены.
+ *
+ * Rate-limit: 5 попыток на challengeId (атакующий не может бомбардировать
+ * один challenge). После исчерпания попыток challenge удаляется → юзер
+ * должен пройти password-step заново.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import { RedisService } from '../../../common/redis/redis.service';
+
+const CHALLENGE_TTL_SEC = 5 * 60; // 5 минут
+const MAX_ATTEMPTS = 5;
+const KEY_PREFIX = '2fa-challenge';
+
+interface ChallengePayload {
+  userId: string;
+  ip?: string;
+  userAgent?: string;
+}
+
+@Injectable()
+export class TwoFaChallengeService {
+  private readonly logger = new Logger(TwoFaChallengeService.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  /**
+   * Создать challenge для user'а после successful password verify.
+   * Возвращает challengeId для отдачи клиенту.
+   */
+  async create(payload: ChallengePayload): Promise<string> {
+    const challengeId = randomUUID();
+    await this.redis
+      .getClient()
+      .set(this.dataKey(challengeId), JSON.stringify(payload), 'EX', CHALLENGE_TTL_SEC);
+    return challengeId;
+  }
+
+  /**
+   * Atomically: increment attempts + read payload.
+   *
+   * @returns null если challenge не найден (TTL истёк / уже использован)
+   *          или превышен лимит попыток (auto-cleanup).
+   */
+  async consumeAttempt(
+    challengeId: string,
+  ): Promise<{ attempt: number; payload: ChallengePayload } | null> {
+    const dataKey = this.dataKey(challengeId);
+    const attemptsKey = this.attemptsKey(challengeId);
+
+    const raw = await this.redis.getClient().get(dataKey);
+    if (!raw) {
+      return null;
+    }
+
+    const attempt = await this.redis.getClient().incr(attemptsKey);
+    // Counter живёт столько же, сколько challenge — устанавливаем TTL только
+    // на первой инкрементации (когда attempt=1).
+    if (attempt === 1) {
+      await this.redis.getClient().expire(attemptsKey, CHALLENGE_TTL_SEC);
+    }
+
+    if (attempt > MAX_ATTEMPTS) {
+      this.logger.warn({ challengeId, attempt }, '2fa.challenge.attempts-exceeded');
+      await this.cleanup(challengeId);
+      return null;
+    }
+
+    const payload = JSON.parse(raw) as ChallengePayload;
+    return { attempt, payload };
+  }
+
+  /**
+   * Удалить challenge после успешной верификации (или превышения лимита).
+   */
+  async cleanup(challengeId: string): Promise<void> {
+    await this.redis
+      .getClient()
+      .del(this.dataKey(challengeId), this.attemptsKey(challengeId));
+  }
+
+  private dataKey(challengeId: string): string {
+    return `${KEY_PREFIX}:${challengeId}`;
+  }
+
+  private attemptsKey(challengeId: string): string {
+    return `${KEY_PREFIX}:${challengeId}:attempts`;
+  }
+}

--- a/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
@@ -1,0 +1,43 @@
+/**
+ * TwoFaController — endpoints для enrollment 2FA TOTP (issue #132).
+ *
+ * - POST /auth/2fa/enroll        — generate secret + QR URL (требует auth)
+ * - POST /auth/2fa/verify-enroll — verify code, activate, return recovery codes
+ *
+ * Verify при login (POST /auth/2fa/verify) — отдельный endpoint в #133.
+ *
+ * Все endpoints требуют залогиненного user'а (без @Public). Любая роль —
+ * 2FA доступен всем (для admin/finance — рекомендуется, для client/guide —
+ * по желанию).
+ */
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+
+import { TwoFaService } from './two-fa.service';
+import {
+  type EnrollResponse,
+  VerifyEnrollDto,
+  type VerifyEnrollResponse,
+} from './dto/verify-enroll.dto';
+import { CurrentUser } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+
+@Controller('auth/2fa')
+export class TwoFaController {
+  constructor(private readonly twoFa: TwoFaService) {}
+
+  @Post('enroll')
+  @HttpCode(HttpStatus.OK)
+  async enroll(@CurrentUser() user: AuthenticatedUser): Promise<EnrollResponse> {
+    return this.twoFa.startEnrollment(user.id);
+  }
+
+  @Post('verify-enroll')
+  @HttpCode(HttpStatus.OK)
+  async verifyEnroll(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: VerifyEnrollDto,
+  ): Promise<VerifyEnrollResponse> {
+    return this.twoFa.completeEnrollment(user.id, dto.code);
+  }
+}

--- a/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
@@ -18,9 +18,11 @@ import {
   VerifyEnrollDto,
   type VerifyEnrollResponse,
 } from './dto/verify-enroll.dto';
-import { CurrentUser } from '../../../common/auth/decorators';
+import { VerifyTwoFaLoginDto } from './dto/verify-login.dto';
+import { CurrentUser, Public } from '../../../common/auth/decorators';
 
 import type { AuthenticatedUser } from '../../../common/auth/types';
+import type { LoginTokenResponse } from '../dto/login.dto';
 
 @Controller('auth/2fa')
 export class TwoFaController {
@@ -39,5 +41,16 @@ export class TwoFaController {
     @Body() dto: VerifyEnrollDto,
   ): Promise<VerifyEnrollResponse> {
     return this.twoFa.completeEnrollment(user.id, dto.code);
+  }
+
+  /**
+   * Public endpoint — identity proven by challengeId (выдан после успешного password-step).
+   * Auth-токены выпускаются ТОЛЬКО при успешном verify (TOTP или recovery code).
+   */
+  @Public()
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  async verifyLogin(@Body() dto: VerifyTwoFaLoginDto): Promise<LoginTokenResponse> {
+    return this.twoFa.verifyAtLogin(dto.challengeId, dto.code);
   }
 }

--- a/apps/api/src/modules/auth/two-fa/two-fa.service.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.service.ts
@@ -1,0 +1,180 @@
+/**
+ * TwoFaService — TOTP-based 2FA enrollment.
+ *
+ * Поток (issue #132):
+ * 1. POST /auth/2fa/enroll: генерируем secret + URL, шифруем и сохраняем
+ *    в User.twoFaSecret, НО twoFaEnabled остаётся false. Юзер сканирует QR
+ *    в authenticator (Google Authenticator, Authy, 1Password).
+ * 2. POST /auth/2fa/verify-enroll: юзер вводит 6-значный код, мы проверяем
+ *    по сохранённому секрету. При успехе:
+ *    - twoFaEnabled = true
+ *    - генерируем 10 recovery codes, хешируем через argon2id, сохраняем
+ *    - возвращаем plaintext recovery codes ОДИН раз
+ *    - публикуем `auth.2fa.enabled` через outbox
+ *
+ * Disable 2FA — отдельный endpoint (вне scope #132).
+ * 2FA verify при login — отдельный поток (#133).
+ */
+import { randomBytes } from 'node:crypto';
+
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { generateSecret, generateURI, verifySync } from 'otplib';
+
+import { PasswordService } from '../services/password.service';
+import { CryptoService } from '../../../common/crypto/crypto.service';
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import type { EnrollResponse, VerifyEnrollResponse } from './dto/verify-enroll.dto';
+
+const TOTP_ISSUER = 'IndiaHorizone';
+/** TOTP step (RFC 6238 default 30 sec) — оставляем дефолт. */
+const RECOVERY_CODES_COUNT = 10;
+/** 8 байт = 16 hex-символов — 64 бита энтропии на код. */
+const RECOVERY_CODE_BYTES = 8;
+
+@Injectable()
+export class TwoFaService {
+  private readonly logger = new Logger(TwoFaService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+    private readonly password: PasswordService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  /**
+   * Шаг 1: сгенерировать TOTP secret + сохранить (encrypted) на User.
+   *
+   * Идемпотентен НЕ полностью: при повторном вызове генерируется НОВЫЙ secret
+   * (старый перезаписывается). Это безопасно — юзер не подтвердил старый, значит
+   * никто не настроил authenticator со старым секретом.
+   *
+   * @throws ConflictException если 2FA уже активирован
+   * @throws NotFoundException если user не найден
+   */
+  async startEnrollment(userId: string): Promise<EnrollResponse> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true, twoFaEnabled: true },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (user.twoFaEnabled) {
+      throw new ConflictException('2FA уже активирован. Сначала отключите текущий setup.');
+    }
+
+    const secret = generateSecret(); // base32, RFC 6238 default
+    const otpAuthUrl = generateURI({
+      label: user.email,
+      issuer: TOTP_ISSUER,
+      secret,
+      // strategy default = 'totp'
+    });
+
+    const encryptedSecret = this.crypto.encrypt(secret);
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { twoFaSecret: encryptedSecret },
+    });
+
+    this.logger.log({ userId }, 'auth.2fa.enroll.started');
+
+    return { secret, otpAuthUrl };
+  }
+
+  /**
+   * Шаг 2: проверить TOTP код и активировать 2FA.
+   *
+   * При успехе:
+   * - twoFaEnabled = true
+   * - 10 recovery codes генерируются + хешируются (argon2id) + сохраняются
+   * - публикуется auth.2fa.enabled
+   * - возвращаются plaintext коды (ОДИН раз)
+   *
+   * @throws NotFoundException если у user нет начатого enroll'а
+   * @throws ConflictException если 2FA уже активирован
+   * @throws UnauthorizedException если TOTP код неверен
+   */
+  async completeEnrollment(userId: string, code: string): Promise<VerifyEnrollResponse> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, twoFaEnabled: true, twoFaSecret: true },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (user.twoFaEnabled) {
+      throw new ConflictException('2FA уже активирован');
+    }
+    if (!user.twoFaSecret) {
+      throw new BadRequestException(
+        'Enroll не начат — сначала вызовите POST /auth/2fa/enroll',
+      );
+    }
+
+    const secret = this.crypto.decrypt(user.twoFaSecret);
+    const result = verifySync({ secret, token: code });
+    if (!result.valid) {
+      this.logger.warn({ userId }, 'auth.2fa.verify-enroll.invalid-code');
+      throw new UnauthorizedException('Неверный TOTP код');
+    }
+
+    // Генерируем recovery codes ДО транзакции (хеширование медленное — argon2id).
+    const plaintextCodes: string[] = [];
+    const codeHashes: string[] = [];
+    for (let i = 0; i < RECOVERY_CODES_COUNT; i++) {
+      const plaintext = this.generateRecoveryCode();
+      plaintextCodes.push(plaintext);
+      codeHashes.push(await this.password.hash(plaintext));
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: userId },
+        data: { twoFaEnabled: true },
+      });
+
+      // Защитная очистка старых неиспользованных recovery codes (regenerate-сценарий).
+      // Сейчас не нужно — мы пришли через enroll-flow, ранее не было активации.
+      // Но если в будущем добавим regenerate — этот шаг становится критичным.
+      await tx.recoveryCode.deleteMany({ where: { userId } });
+
+      await tx.recoveryCode.createMany({
+        data: codeHashes.map((codeHash) => ({ userId, codeHash })),
+      });
+
+      await this.outbox.add(tx, {
+        type: 'auth.2fa.enabled',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          recoveryCodesGenerated: RECOVERY_CODES_COUNT,
+        },
+      });
+    });
+
+    this.logger.log({ userId }, 'auth.2fa.enabled');
+    return { recoveryCodes: plaintextCodes };
+  }
+
+  /**
+   * Recovery code: 16 hex-символов (64 бита) с дефис-разделителями.
+   * Формат: XXXX-XXXX-XXXX-XXXX. Удобно читать вслух / диктовать.
+   */
+  private generateRecoveryCode(): string {
+    const hex = randomBytes(RECOVERY_CODE_BYTES).toString('hex'); // 16 chars
+    return `${hex.slice(0, 4)}-${hex.slice(4, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}`;
+  }
+}

--- a/apps/api/src/modules/auth/two-fa/two-fa.service.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.service.ts
@@ -19,19 +19,24 @@ import { randomBytes } from 'node:crypto';
 
 import {
   BadRequestException,
-  ConflictException,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
   UnauthorizedException,
+  forwardRef,
 } from '@nestjs/common';
+import { ConflictException } from '@nestjs/common';
 import { generateSecret, generateURI, verifySync } from 'otplib';
 
+import { LoginService } from '../services/login.service';
 import { PasswordService } from '../services/password.service';
 import { CryptoService } from '../../../common/crypto/crypto.service';
 import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
+import { TwoFaChallengeService } from './two-fa-challenge.service';
 
+import type { LoginTokenResponse } from '../dto/login.dto';
 import type { EnrollResponse, VerifyEnrollResponse } from './dto/verify-enroll.dto';
 
 const TOTP_ISSUER = 'IndiaHorizone';
@@ -49,6 +54,12 @@ export class TwoFaService {
     private readonly crypto: CryptoService,
     private readonly password: PasswordService,
     private readonly outbox: OutboxService,
+    private readonly challenge: TwoFaChallengeService,
+    // forwardRef — LoginService инжектит TwoFaChallengeService, а TwoFaService
+    // (этот класс) инжектит LoginService.issueTokensForUser. NestJS DI требует
+    // явного forwardRef для разрыва circular dependency.
+    @Inject(forwardRef(() => LoginService))
+    private readonly login: LoginService,
   ) {}
 
   /**
@@ -167,6 +178,107 @@ export class TwoFaService {
 
     this.logger.log({ userId }, 'auth.2fa.enabled');
     return { recoveryCodes: plaintextCodes };
+  }
+
+  /**
+   * 2FA verify при login (#133).
+   *
+   * Flow:
+   * 1. Получаем challenge из Redis по challengeId — incr attempts.
+   * 2. Если challenge не найден ИЛИ attempts > MAX → 401.
+   * 3. Определяем формат code: 6 цифр → TOTP, иначе → recovery.
+   * 4. TOTP: decrypt secret, verify через otplib.
+   * 5. Recovery: для каждой неиспользованной recovery-записи user'а — argon2.verify.
+   *    При успехе помечаем usedAt = now (race-safe через UPDATE WHERE used_at IS NULL).
+   * 6. Если verify пройдёт — cleanup challenge, выпускаем токены через
+   *    LoginService.issueTokensForUser (тот же путь что без 2FA).
+   *
+   * Generic error message — не раскрываем «неверный код» vs «исчерпан лимит» vs
+   * «challenge не найден» (anti-enumeration пробного UX).
+   */
+  async verifyAtLogin(challengeId: string, code: string): Promise<LoginTokenResponse> {
+    const consumed = await this.challenge.consumeAttempt(challengeId);
+    if (!consumed) {
+      throw new UnauthorizedException('Невалидный или истёкший код');
+    }
+
+    const { payload, attempt } = consumed;
+    this.logger.debug({ challengeId, attempt, userId: payload.userId }, '2fa.verify.attempt');
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: payload.userId },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        twoFaEnabled: true,
+        twoFaSecret: true,
+      },
+    });
+    if (!user || !user.twoFaEnabled || !user.twoFaSecret) {
+      // Edge case: между созданием challenge и verify — admin отключил 2FA.
+      // Безопасно возвращаем generic error.
+      this.logger.warn({ userId: payload.userId }, '2fa.verify.user-not-eligible');
+      throw new UnauthorizedException('Невалидный или истёкший код');
+    }
+
+    const isTotpFormat = /^\d{6}$/.test(code);
+    const verified = isTotpFormat
+      ? this.verifyTotp(code, user.twoFaSecret)
+      : await this.verifyRecoveryCode(code, user.id);
+
+    if (!verified) {
+      throw new UnauthorizedException('Невалидный или истёкший код');
+    }
+
+    await this.challenge.cleanup(challengeId);
+
+    this.logger.log(
+      { userId: user.id, method: isTotpFormat ? 'totp' : 'recovery' },
+      'auth.2fa.verified',
+    );
+
+    const ctx = {
+      ...(payload.ip !== undefined ? { ip: payload.ip } : {}),
+      ...(payload.userAgent !== undefined ? { userAgent: payload.userAgent } : {}),
+    };
+    return this.login.issueTokensForUser(
+      { id: user.id, email: user.email, role: user.role },
+      ctx,
+    );
+  }
+
+  private verifyTotp(code: string, encryptedSecret: string): boolean {
+    const secret = this.crypto.decrypt(encryptedSecret);
+    const result = verifySync({ secret, token: code });
+    return result.valid;
+  }
+
+  /**
+   * Линейный поиск по неиспользованным recovery codes (≤10 на user'а).
+   * Argon2.verify — медленный, но это OK при ≤10 элементах.
+   *
+   * Race-safety: помечаем used_at в UPDATE WHERE used_at IS NULL — если
+   * параллельный verify уже использовал тот же код, наш UPDATE вернёт count=0
+   * и мы откатываемся (return false).
+   */
+  private async verifyRecoveryCode(code: string, userId: string): Promise<boolean> {
+    const codes = await this.prisma.recoveryCode.findMany({
+      where: { userId, usedAt: null },
+      select: { id: true, codeHash: true },
+    });
+
+    for (const candidate of codes) {
+      const { valid } = await this.password.verify(candidate.codeHash, code);
+      if (!valid) continue;
+
+      const claimed = await this.prisma.recoveryCode.updateMany({
+        where: { id: candidate.id, usedAt: null },
+        data: { usedAt: new Date() },
+      });
+      return claimed.count > 0;
+    }
+    return false;
   }
 
   /**

--- a/apps/api/src/modules/auth/two-fa/two-fa.service.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.service.ts
@@ -27,6 +27,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { ConflictException } from '@nestjs/common';
+import { UserStatus } from '@prisma/client';
 import { generateSecret, generateURI, verifySync } from 'otplib';
 
 import { LoginService } from '../services/login.service';
@@ -211,6 +212,7 @@ export class TwoFaService {
         id: true,
         email: true,
         role: true,
+        status: true,
         twoFaEnabled: true,
         twoFaSecret: true,
       },
@@ -219,6 +221,16 @@ export class TwoFaService {
       // Edge case: между созданием challenge и verify — admin отключил 2FA.
       // Безопасно возвращаем generic error.
       this.logger.warn({ userId: payload.userId }, '2fa.verify.user-not-eligible');
+      throw new UnauthorizedException('Невалидный или истёкший код');
+    }
+    if (user.status !== UserStatus.active) {
+      // Между password-step и 2FA verify admin/concierge мог suspend'нуть аккаунт
+      // (incident response). Не выпускаем токены — even если код валидный.
+      // Generic error — anti-enumeration.
+      this.logger.warn(
+        { userId: user.id, status: user.status },
+        '2fa.verify.blocked-status',
+      );
       throw new UnauthorizedException('Невалидный или истёкший код');
     }
 
@@ -243,7 +255,7 @@ export class TwoFaService {
       ...(payload.userAgent !== undefined ? { userAgent: payload.userAgent } : {}),
     };
     return this.login.issueTokensForUser(
-      { id: user.id, email: user.email, role: user.role },
+      { id: user.id, email: user.email, role: user.role, status: user.status },
       ctx,
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       ioredis:
         specifier: ^5.4.1
         version: 5.10.1
+      otplib:
+        specifier: ^13.4.0
+        version: 13.4.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -470,6 +473,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -486,6 +493,24 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@otplib/core@13.4.0':
+    resolution: {integrity: sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==}
+
+  '@otplib/hotp@13.4.0':
+    resolution: {integrity: sha512-MJjE0x06mn2ptymz5qZmQveb+vWFuaIftqE0b5/TZZqUOK7l97cV8lRTmid5BpAQMwJDNLW6RnYxGeCRiNdekw==}
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    resolution: {integrity: sha512-/t9YWJmMbB8bF5z8mXrBZc2FXBe8B/3hG5FhWr9K8cFwFhyxScbPysmZe8s1UTzSA6N+s8Uv8aIfCtVXPNjJWw==}
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    resolution: {integrity: sha512-KrvE4m7Zv+TT1944HzgqFJWJpKb6AyoxDbvhPStmBqdMlv5Gekb80d66cuFRL08kkPgJ5gXUSb5SFpYeB+bACg==}
+
+  '@otplib/totp@13.4.0':
+    resolution: {integrity: sha512-dK+vl0f0ekzf6mCENRI9AKS2NJUC7OjI3+X8e7QSnhQ2WM7I+i4PGpb3QxKi5hxjTtwVuoZwXR2CFtXdcRtNdQ==}
+
+  '@otplib/uri@13.4.0':
+    resolution: {integrity: sha512-x1ozBa5bPbdZCrrTL/HK21qchiK7jYElTu+0ft22abeEhiLYgH1+SIULvOcVk3CK8YwF4kdcidvkq4ciejucJA==}
 
   '@phc/format@1.0.0':
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
@@ -521,6 +546,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2165,6 +2193,9 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  otplib@13.4.0:
+    resolution: {integrity: sha512-RUcYcRMCgRWhUE/XabRppXpUwCwaWBNHe5iPXhdvP8wwDGpGpsIf/kxX/ec3zFsOaM1Oq8lEhUqDwk6W7DHkwg==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -3214,6 +3245,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.16':
     optional: true
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3233,6 +3266,33 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@otplib/core@13.4.0': {}
+
+  '@otplib/hotp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@scure/base': 2.2.0
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@otplib/core': 13.4.0
+
+  '@otplib/totp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/uri@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
 
   '@phc/format@1.0.0': {}
 
@@ -3265,6 +3325,8 @@ snapshots:
       '@prisma/debug': 5.22.0
 
   '@rtsao/scc@1.1.0': {}
+
+  '@scure/base@2.2.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -5124,6 +5186,15 @@ snapshots:
       wcwidth: 1.0.1
 
   os-tmpdir@1.0.2: {}
+
+  otplib@13.4.0:
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/plugin-base32-scure': 13.4.0
+      '@otplib/plugin-crypto-noble': 13.4.0
+      '@otplib/totp': 13.4.0
+      '@otplib/uri': 13.4.0
 
   own-keys@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Полный 2FA flow: enrollment + verify при login. Включает security-fix из ревью.

| Commit | Closes |
|--------|--------|
| 2FA enrollment + recovery codes | #132 |
| 2FA verify при login + recovery codes | #133 |
| security review fix: status-check в verifyAtLogin | review-finding |

## Что внутри

### Enrollment flow (#132)

```
POST /auth/2fa/enroll        → { secret, otpAuthUrl }
POST /auth/2fa/verify-enroll → { recoveryCodes[] }   (ОДИН раз)
```

- TOTP secret генерируется через `otplib`, шифруется через `CryptoService` (AES-256-GCM), сохраняется в `users.two_fa_secret`. `twoFaEnabled` остаётся `false` до подтверждения кода.
- 10 recovery codes — формат `XXXX-XXXX-XXXX-XXXX` (16 hex, 64 бита энтропии). Хешируются argon2id, plaintext возвращается ОДИН раз. После — только хеши в `recovery_codes`.
- Регенерация (повторный enroll до verify): старый secret перезаписывается, recovery codes очищаются `deleteMany` по userId.
- Outbox event: `auth.2fa.enabled`.

### Verify при login (#133)

```
POST /auth/login                       → если twoFaEnabled → { challengeId }   (5 min TTL в Redis)
POST /auth/2fa/verify { challengeId, code } → { accessToken, refreshToken, user }
```

- `code = 6 цифр` → TOTP verify через otplib (decrypt secret).
- `code = иной формат` → recovery code path: argon2.verify по неиспользованным записям, `UPDATE WHERE used_at IS NULL` для race-safety.
- Rate-limit 5 попыток на challengeId через Redis `INCR` + TTL. Превышение → challenge удаляется → юзер делает password-step заново.
- Generic error «Невалидный или истёкший код» — anti-enumeration.

### Security review fix

Найдено в ревью: `verifyAtLogin` пропускал проверку `user.status`. Сценарий:
1. Юзер с 2FA проходит password-step → status был active → создан challenge
2. Admin/concierge suspend'ит аккаунт (incident response)
3. Юзер в течение 5 минут проходит TOTP → получает токены, несмотря на suspended

Фикс:
- `verifyAtLogin` добавлен `select: status` + проверка `status === active`
- `LoginService.issueTokensForUser` defense-in-depth: повторно валидирует status в типе параметра + runtime check

## Архитектура

- `TwoFaChallengeService` — отдельный класс, Redis storage с TTL и attempts (single responsibility)
- `LoginService.issueTokensForUser` — публичный метод (вынесен из `login()`), используется и в /login без 2FA, и в /auth/2fa/verify
- `forwardRef` для circular DI: `LoginService` использует `TwoFaChallengeService`, `TwoFaService` использует `LoginService.issueTokensForUser`

## Schema changes

- `users` + `two_fa_enabled BOOL DEFAULT false`, `two_fa_secret TEXT NULL`
- Новая таблица `recovery_codes` (id, user_id FK, code_hash, used_at, created_at)
- Migration: `20260428100000_M5_B_007_two_fa`

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [x] `pnpm --filter @indiahorizone/api type-check` — зелёный
- [ ] **На сервере (Вика после миграции):**
  - Roman enroll'ит 2FA через UI (когда #135 frontend будет готов; пока через curl)
  - Login с 2FA возвращает challengeId
  - TOTP code из authenticator-app проходит verify
  - Recovery code одноразовый
  - 5 попыток превышены → challenge удалён

## Closes

- Closes #132
- Closes #133

## Зависимости

- Базируется на main (PR #331 уже merged — TS-фиксы для unblock build)
- Не блокирует следующие PR (clients, trips)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_