### PR TITLE
feat(clients): /me + Consent + EmergencyContact + granular consent endpoints (#140, #142, #143, #144)

### DIFF
--- a/apps/api/prisma/migrations/20260428120000_M5_C_005_consent_model/migration.sql
+++ b/apps/api/prisma/migrations/20260428120000_M5_C_005_consent_model/migration.sql
@@ -1,0 +1,31 @@
+-- M5.C.005 — Consent модель (issue #142)
+--
+-- 4 типа согласий: pdn / photo_video / geo / emergency_contacts.
+-- Один активный consent на (client, type) обеспечивается partial unique index'ом —
+-- Prisma ещё не поддерживает partial unique нативно, делаем raw SQL.
+
+CREATE TYPE "consent_type" AS ENUM ('pdn', 'photo_video', 'geo', 'emergency_contacts');
+
+CREATE TABLE "consents" (
+  "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+  "client_id"  UUID NOT NULL,
+  "type"       "consent_type" NOT NULL,
+  "scope"      JSONB NOT NULL,
+  "version"    TEXT NOT NULL,
+  "granted_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "revoked_at" TIMESTAMP(3),
+
+  CONSTRAINT "consents_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "consents_client_id_fkey" FOREIGN KEY ("client_id")
+    REFERENCES "clients" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "idx_consents_client_type" ON "consents" ("client_id", "type");
+CREATE INDEX "idx_consents_client_active" ON "consents" ("client_id", "revoked_at");
+
+-- Partial unique index: один активный consent на (client, type).
+-- Если revokedAt IS NULL → запись активна → дубль на тот же (client, type) запрещён.
+-- Revoked consents (revokedAt NOT NULL) — audit-trail, могут повторяться.
+CREATE UNIQUE INDEX "uq_consents_client_type_active"
+  ON "consents" ("client_id", "type")
+  WHERE "revoked_at" IS NULL;

--- a/apps/api/prisma/migrations/20260428130000_M5_C_007_emergency_contacts/migration.sql
+++ b/apps/api/prisma/migrations/20260428130000_M5_C_007_emergency_contacts/migration.sql
@@ -1,0 +1,25 @@
+-- M5.C.007 — EmergencyContact модель (issue #144)
+--
+-- Контакты экстренной связи: максимум 2 на клиента (primary + secondary)
+-- через unique constraint на (client_id, priority).
+
+CREATE TYPE "emergency_contact_priority" AS ENUM ('primary', 'secondary');
+
+CREATE TABLE "emergency_contacts" (
+  "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+  "client_id"  UUID NOT NULL,
+  "name"       TEXT NOT NULL,
+  "phone"      TEXT NOT NULL,
+  "relation"   TEXT NOT NULL,
+  "language"   CHAR(2) NOT NULL,
+  "priority"   "emergency_contact_priority" NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "emergency_contacts_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "emergency_contacts_client_id_fkey" FOREIGN KEY ("client_id")
+    REFERENCES "clients" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "uq_emergency_contacts_client_priority"
+  ON "emergency_contacts" ("client_id", "priority");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -177,8 +177,9 @@ model Client {
   userId    String   @unique @map("user_id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
-  profile  ClientProfile?
-  consents Consent[]
+  profile           ClientProfile?
+  consents          Consent[]
+  emergencyContacts EmergencyContact[]
 
   @@index([userId], map: "idx_clients_user_id")
   @@map("clients")
@@ -233,6 +234,49 @@ model Consent {
   @@index([clientId, type], map: "idx_consents_client_type")
   @@index([clientId, revokedAt], map: "idx_consents_client_active")
   @@map("consents")
+}
+
+/// Приоритет контакта экстренной связи. Максимум 2 на клиента — primary
+/// (главный, звонит первым) + secondary (резервный). См. #144.
+enum EmergencyContactPriority {
+  primary
+  secondary
+
+  @@map("emergency_contact_priority")
+}
+
+/// Контакт экстренной связи (#144). Используется при SOS — concierge звонит
+/// сначала primary, при недозвоне — secondary.
+///
+/// Сохранение/обновление требует активного Consent типа emergency_contacts
+/// со scope.allowed=true (#142). Без него endpoint возвращает 403.
+///
+/// Поля name/phone — ПДн (имя третьего лица + его телефон). Шифруются через
+/// CryptoService (как в ClientProfile, #139). relation/language — нет.
+///
+/// Cross-module FK на Client OK (один модуль clients).
+model EmergencyContact {
+  id        String                   @id @default(uuid()) @db.Uuid
+  clientId  String                   @map("client_id") @db.Uuid
+  /// Зашифровано (#139). plaintext: ФИО контакта.
+  name      String
+  /// Зашифровано (#139). plaintext: E.164 телефон.
+  phone     String
+  /// Свободный текст: "Отец", "Жена", "Друг". Не шифруется (не идентифицирует
+  /// само по себе).
+  relation  String
+  /// ISO 639-1 (например 'ru', 'en'). Подсказка оператору на каком языке
+  /// можно говорить с контактом.
+  language  String                   @db.Char(2)
+  priority  EmergencyContactPriority
+  createdAt DateTime                 @default(now()) @map("created_at")
+  updatedAt DateTime                 @updatedAt @map("updated_at")
+
+  client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
+
+  /// Один контакт на (client, priority) → максимум 2 контакта на клиента.
+  @@unique([clientId, priority], map: "uq_emergency_contacts_client_priority")
+  @@map("emergency_contacts")
 }
 
 /// Персональные данные туриста. ПДн в смысле 152-ФЗ.

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -177,10 +177,62 @@ model Client {
   userId    String   @unique @map("user_id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
-  profile ClientProfile?
+  profile  ClientProfile?
+  consents Consent[]
 
   @@index([userId], map: "idx_clients_user_id")
   @@map("clients")
+}
+
+/// Тип согласия (#142). 4 категории, каждая с своим scope:
+/// - pdn — общая обработка ПДн (ФИО, паспорт, контакты, реквизиты). scope: {}
+/// - photo_video — фото/видео клиента в материалах. scope: {level: 1..4, useName?: boolean}
+/// - geo — геолокация. scope: {modes: ('A'|'B'|'C'|'D')[]}
+/// - emergency_contacts — обработка контактов экстренных лиц. scope: {allowed: boolean}
+///
+/// Подробности в docs/LEGAL/CONSENTS/.
+enum ConsentType {
+  pdn
+  photo_video
+  geo
+  emergency_contacts
+
+  @@map("consent_type")
+}
+
+/// Granular consent клиента на обработку определённого scope (#142).
+/// 152-ФЗ ст. 9: для каждой категории ПДн — отдельное явное согласие.
+///
+/// Один активный (revokedAt IS NULL) consent на пару (clientId, type) — обеспечивается
+/// partial unique index в миграции (Prisma ещё не поддерживает partial unique нативно).
+/// При отзыве revokedAt заполняется; новое согласие — отдельная запись (история сохраняется
+/// как audit-trail для проверок Роскомнадзора 152-ФЗ ст. 14).
+///
+/// scope JSONB шейп:
+/// - pdn: `{}` (просто маркер что консент дан)
+/// - photo_video: `{level: 1|2|3|4, useName?: boolean}` см. PHOTO_VIDEO.md
+/// - geo: `{modes: ('A'|'B'|'C'|'D')[]}` см. GEO.md
+/// - emergency_contacts: `{allowed: boolean}` см. EMERGENCY_CONTACTS.md
+///
+/// version — формат '<DATE>-v<N>', например '2026-04-25-v1'. Меняется при правке
+/// шаблона текста в docs/LEGAL/CONSENTS/. Сохраняем версию для каждого consent'а
+/// чтобы в случае спора показать какой именно текст подписал клиент.
+model Consent {
+  id        String      @id @default(uuid()) @db.Uuid
+  clientId  String      @map("client_id") @db.Uuid
+  type      ConsentType
+  scope     Json
+  /// Версия текста согласия на момент grant'а (snapshot для аудита 152-ФЗ).
+  version   String
+  grantedAt DateTime    @default(now()) @map("granted_at")
+  /// NULL = активен. После отзыва — заполняется (audit-trail сохраняется).
+  revokedAt DateTime?   @map("revoked_at")
+
+  client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
+
+  @@index([clientId, type], map: "idx_consents_client_type")
+  @@index([clientId, revokedAt], map: "idx_consents_client_active")
+  @@map("consents")
 }
 
 /// Персональные данные туриста. ПДн в смысле 152-ФЗ.

--- a/apps/api/src/common/auth/auth.module.ts
+++ b/apps/api/src/common/auth/auth.module.ts
@@ -1,9 +1,9 @@
 import { Global, Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 
+import { JwtAuthGuard } from './jwt-auth.guard';
 import { AuthModule as AuthFeatureModule } from '../../modules/auth/auth.module';
 
-import { JwtAuthGuard } from './jwt-auth.guard';
 
 /**
  * Common Auth Module — регистрирует глобальный JwtAuthGuard.

--- a/apps/api/src/common/auth/decorators.ts
+++ b/apps/api/src/common/auth/decorators.ts
@@ -1,9 +1,9 @@
 import { type ExecutionContext, SetMetadata, createParamDecorator } from '@nestjs/common';
 
-import type { Request } from 'express';
-import type { UserRole } from '@prisma/client';
-
 import type { AuthenticatedUser } from './types';
+import type { UserRole } from '@prisma/client';
+import type { Request } from 'express';
+
 
 /**
  * Метаданные для guards.
@@ -13,11 +13,11 @@ export const PUBLIC_KEY = 'isPublic';
 
 /**
  * @Roles('admin', 'concierge') — требует одну из перечисленных ролей.
+ * Применяется и к методу, и к классу (через SetMetadata от NestJS).
  * Если декоратор не применён И @Public() тоже не применён — by default
  * требуется аутентификация без role-restriction (любой залогиненный).
  */
-export const Roles = (...roles: UserRole[]): MethodDecorator =>
-  SetMetadata(ROLES_KEY, roles);
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
 
 /**
  * @Public() — endpoint доступен без аутентификации.

--- a/apps/api/src/common/auth/jwt-auth.guard.ts
+++ b/apps/api/src/common/auth/jwt-auth.guard.ts
@@ -8,13 +8,13 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 
-import type { Request } from 'express';
-import type { UserRole } from '@prisma/client';
-
-import { JwtTokenService } from '../../modules/auth/services/jwt.service';
 
 import { PUBLIC_KEY, ROLES_KEY } from './decorators';
+import { JwtTokenService } from '../../modules/auth/services/jwt.service';
+
 import type { AuthenticatedUser } from './types';
+import type { UserRole } from '@prisma/client';
+import type { Request } from 'express';
 
 /**
  * Глобальный JwtAuthGuard — требует валидный access-token в Authorization

--- a/apps/api/src/common/events-bus/events-bus.service.ts
+++ b/apps/api/src/common/events-bus/events-bus.service.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto';
 
 import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
 
-import { RedisService } from '../redis/redis.service';
 
 import { IdempotencyService } from './idempotency.service';
 import {
@@ -13,6 +12,7 @@ import {
   type SubscribeOptions,
   streamForEventType,
 } from './types';
+import { RedisService } from '../redis/redis.service';
 
 /**
  * EventsBusService — обёртка над Redis Streams для domain events.
@@ -118,7 +118,7 @@ export class EventsBusService implements OnModuleDestroy {
         try {
           const result = (await this.redis
             .getSubscriber()
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+             
             .xreadgroup(
               'GROUP',
               options.consumerGroup,
@@ -200,7 +200,7 @@ export class EventsBusService implements OnModuleDestroy {
       return;
     }
 
-    const raw = fields[dataIndex + 1] as string;
+    const raw = fields[dataIndex + 1]!;
     let event: DomainEvent<T>;
     try {
       event = JSON.parse(raw) as DomainEvent<T>;

--- a/apps/api/src/common/outbox/outbox-relay.worker.ts
+++ b/apps/api/src/common/outbox/outbox-relay.worker.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
 
 import { EventsBusService } from '../events-bus/events-bus.service';
-import type { DomainEvent } from '../events-bus/types';
 import { PrismaService } from '../prisma/prisma.service';
+
+import type { DomainEvent } from '../events-bus/types';
 
 const POLL_INTERVAL_MS = 1_000;
 const BATCH_SIZE = 50;

--- a/apps/api/src/common/outbox/outbox.service.ts
+++ b/apps/api/src/common/outbox/outbox.service.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'node:crypto';
 
 import { Injectable, Logger } from '@nestjs/common';
-import type { Prisma, PrismaClient } from '@prisma/client';
-
-import type { DomainEvent } from '../events-bus/types';
 
 import { PrismaService } from '../prisma/prisma.service';
+
+import type { DomainEvent } from '../events-bus/types';
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+
 
 /**
  * OutboxService — запись событий в outbox в той же транзакции, что и

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -8,7 +8,6 @@ import {
   Post,
 } from '@nestjs/common';
 
-import { CurrentUser, Public } from '../../common/auth/decorators';
 
 import { LoginDto } from './dto/login.dto';
 import { RefreshDto } from './dto/refresh.dto';
@@ -17,11 +16,12 @@ import { AuthService } from './services/auth.service';
 import { LoginService } from './services/login.service';
 import { LogoutService } from './services/logout.service';
 import { RefreshService } from './services/refresh.service';
+import { CurrentUser, Public } from '../../common/auth/decorators';
 
-import type { AuthenticatedUser } from '../../common/auth/types';
 import type { LoginResponse } from './dto/login.dto';
 import type { RefreshResponse } from './dto/refresh.dto';
 import type { RegisterResponse } from './dto/register.dto';
+import type { AuthenticatedUser } from '../../common/auth/types';
 
 @Controller('auth')
 export class AuthController {

--- a/apps/api/src/modules/auth/dto/register.dto.ts
+++ b/apps/api/src/modules/auth/dto/register.dto.ts
@@ -1,7 +1,7 @@
+import { UserRole } from '@prisma/client';
 import { Transform, Type } from 'class-transformer';
 import { IsEmail, IsEnum, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
-import { UserRole } from '@prisma/client';
 
 /**
  * DTO для POST /auth/register.

--- a/apps/api/src/modules/auth/services/auth.service.ts
+++ b/apps/api/src/modules/auth/services/auth.service.ts
@@ -1,10 +1,10 @@
 import { ConflictException, Injectable, Logger, UnprocessableEntityException } from '@nestjs/common';
 import { UserRole, UserStatus } from '@prisma/client';
 
+import { PasswordService } from './password.service';
 import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
 
-import { PasswordService } from './password.service';
 
 import type { RegisterDto, RegisterResponse } from '../dto/register.dto';
 

--- a/apps/api/src/modules/auth/services/login.service.ts
+++ b/apps/api/src/modules/auth/services/login.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UserStatus, type UserRole } from '@prisma/client';
 
+import { JwtTokenService } from './jwt.service';
+import { PasswordService } from './password.service';
 import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
 import { TwoFaChallengeService } from '../two-fa/two-fa-challenge.service';
 
-import { JwtTokenService } from './jwt.service';
-import { PasswordService } from './password.service';
 
 import type { LoginDto, LoginResponse, LoginTokenResponse } from '../dto/login.dto';
 

--- a/apps/api/src/modules/auth/services/refresh.service.ts
+++ b/apps/api/src/modules/auth/services/refresh.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UserStatus } from '@prisma/client';
 
+import { JwtTokenService } from './jwt.service';
+import { PasswordService } from './password.service';
 import { OutboxService } from '../../../common/outbox/outbox.service';
 import { PrismaService } from '../../../common/prisma/prisma.service';
 
-import { JwtTokenService } from './jwt.service';
-import { PasswordService } from './password.service';
 
 import type { RefreshDto, RefreshResponse } from '../dto/refresh.dto';
 

--- a/apps/api/src/modules/clients/clients.controller.ts
+++ b/apps/api/src/modules/clients/clients.controller.ts
@@ -1,0 +1,46 @@
+/**
+ * ClientsController — endpoints профиля клиента.
+ *
+ * - GET   /clients/me — текущий профиль (с расшифровкой ПДн)
+ * - PATCH /clients/me — обновить поля профиля (publishes clients.profile.updated)
+ *
+ * Доступ: только role=client (admin/concierge/manager — отдельные admin-endpoints
+ * в EPIC 13). RBAC через JwtAuthGuard + @Roles('client').
+ *
+ * Issue: #140 [M5.C.3]
+ */
+import { Body, Controller, Get, NotFoundException, Patch } from '@nestjs/common';
+
+import { ClientsService, type UpdateProfilePatch } from './clients.service';
+import { UpdateClientProfileDto } from './dto/update-profile.dto';
+import { CurrentUser, Roles } from '../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../common/auth/types';
+import type { Client, ClientProfile } from '@prisma/client';
+
+@Controller('clients')
+@Roles('client')
+export class ClientsController {
+  constructor(private readonly clients: ClientsService) {}
+
+  @Get('me')
+  async me(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<Client & { profile: ClientProfile | null }> {
+    const client = await this.clients.findByUserId(user.id);
+    if (!client) {
+      // Edge case: register прошёл, но listener ещё не отработал.
+      // 404 → клиент должен retry'нуть через секунду.
+      throw new NotFoundException('Client profile not yet provisioned');
+    }
+    return client;
+  }
+
+  @Patch('me')
+  async updateMe(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateClientProfileDto,
+  ): Promise<ClientProfile> {
+    return this.clients.updateProfile(user.id, dto as UpdateProfilePatch);
+  }
+}

--- a/apps/api/src/modules/clients/clients.module.ts
+++ b/apps/api/src/modules/clients/clients.module.ts
@@ -10,14 +10,16 @@ import { Module } from '@nestjs/common';
 
 import { ClientsController } from './clients.controller';
 import { ClientsService } from './clients.service';
+import { EmergencyContactsController } from './emergency-contacts/emergency-contacts.controller';
+import { EmergencyContactsService } from './emergency-contacts/emergency-contacts.service';
 import { ClientsListener } from './listeners/clients.listener';
 import { EventsBusModule } from '../../common/events-bus/events-bus.module';
 import { PrismaModule } from '../../common/prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule, EventsBusModule],
-  controllers: [ClientsController],
-  providers: [ClientsService, ClientsListener],
-  exports: [ClientsService],
+  controllers: [ClientsController, EmergencyContactsController],
+  providers: [ClientsService, ClientsListener, EmergencyContactsService],
+  exports: [ClientsService, EmergencyContactsService],
 })
 export class ClientsModule {}

--- a/apps/api/src/modules/clients/clients.module.ts
+++ b/apps/api/src/modules/clients/clients.module.ts
@@ -2,19 +2,21 @@
  * ClientsModule — управление профилями клиентов (ПДн).
  *
  * Создаётся автоматически при auth.user.registered (подписка через EventsBus).
- * Эндпоинты профиля — в #140 (/clients/me).
- * Шифрование ПДн — в #139.
+ * Эндпоинты профиля /clients/me — #140.
+ * Шифрование ПДн — #139.
  */
 import { Module } from '@nestjs/common';
 
+
+import { ClientsController } from './clients.controller';
+import { ClientsService } from './clients.service';
+import { ClientsListener } from './listeners/clients.listener';
 import { EventsBusModule } from '../../common/events-bus/events-bus.module';
 import { PrismaModule } from '../../common/prisma/prisma.module';
 
-import { ClientsService } from './clients.service';
-import { ClientsListener } from './listeners/clients.listener';
-
 @Module({
   imports: [PrismaModule, EventsBusModule],
+  controllers: [ClientsController],
   providers: [ClientsService, ClientsListener],
   exports: [ClientsService],
 })

--- a/apps/api/src/modules/clients/clients.module.ts
+++ b/apps/api/src/modules/clients/clients.module.ts
@@ -10,6 +10,8 @@ import { Module } from '@nestjs/common';
 
 import { ClientsController } from './clients.controller';
 import { ClientsService } from './clients.service';
+import { ConsentsController } from './consents/consents.controller';
+import { ConsentsService } from './consents/consents.service';
 import { EmergencyContactsController } from './emergency-contacts/emergency-contacts.controller';
 import { EmergencyContactsService } from './emergency-contacts/emergency-contacts.service';
 import { ClientsListener } from './listeners/clients.listener';
@@ -18,8 +20,8 @@ import { PrismaModule } from '../../common/prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule, EventsBusModule],
-  controllers: [ClientsController, EmergencyContactsController],
-  providers: [ClientsService, ClientsListener, EmergencyContactsService],
-  exports: [ClientsService, EmergencyContactsService],
+  controllers: [ClientsController, ConsentsController, EmergencyContactsController],
+  providers: [ClientsService, ClientsListener, ConsentsService, EmergencyContactsService],
+  exports: [ClientsService, ConsentsService, EmergencyContactsService],
 })
 export class ClientsModule {}

--- a/apps/api/src/modules/clients/clients.service.ts
+++ b/apps/api/src/modules/clients/clients.service.ts
@@ -8,7 +8,7 @@
  *
  * Cross-module rule: userId — soft-reference, без FK на таблицу users.
  */
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import {
   decryptClientWithProfile,
@@ -17,9 +17,23 @@ import {
   type EncryptableProfileInput,
 } from './lib/profile-encryption';
 import { CryptoService } from '../../common/crypto/crypto.service';
+import { OutboxService } from '../../common/outbox/outbox.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 
-import type { Client, ClientProfile } from '@prisma/client';
+import type { Client, ClientProfile, Prisma } from '@prisma/client';
+
+/**
+ * Поля профиля, которые можно обновлять через PATCH /clients/me.
+ * - ПДн (firstName/lastName/dateOfBirth/phone) — шифруются перед записью.
+ * - non-ПДн (citizenship/telegramHandle/preferences) — пишутся в открытом виде.
+ *
+ * Patch-семантика: omitted поле = нет изменений; явный null = очистить.
+ */
+export type UpdateProfilePatch = EncryptableProfileInput & {
+  citizenship?: string | null;
+  telegramHandle?: string | null;
+  preferences?: Prisma.InputJsonValue;
+};
 
 
 @Injectable()
@@ -29,6 +43,7 @@ export class ClientsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly crypto: CryptoService,
+    private readonly outbox: OutboxService,
   ) {}
 
   /**
@@ -81,24 +96,22 @@ export class ClientsService {
   }
 
   /**
-   * Обновить ПДн поля профиля. Используется в #140 (`PATCH /clients/me`).
+   * Обновить профиль клиента. Используется в #140 (`PATCH /clients/me`).
    *
    * Логика:
    * 1. Найти Client + Profile по userId.
-   * 2. Зашифровать переданные поля через encryptProfile().
-   * 3. Update profile.
+   * 2. Зашифровать ПДн поля через encryptProfile().
+   * 3. Update profile в транзакции + публикация `clients.profile.updated`
+   *    через outbox (changedFields = только реально присутствующие в patch).
    * 4. Расшифровать результат для возврата.
    *
-   * @throws ClientNotFoundError если у user нет Client (race-condition после
-   *   register'а — listener ещё не отработал; caller должен сделать retry или
-   *   provisionForUser явно).
+   * Patch-семантика: omitted = no change; явный null = очистить значение.
+   * Subscriber'ы события (CRM, finance — будущие) видят только список ИМЁН
+   * изменённых полей, не значения ПДн (privacy by default).
    */
   async updateProfile(
     userId: string,
-    patch: EncryptableProfileInput & {
-      citizenship?: string | null;
-      telegramHandle?: string | null;
-    },
+    patch: UpdateProfilePatch,
   ): Promise<ClientProfile> {
     const client = await this.prisma.client.findUnique({
       where: { userId },
@@ -106,33 +119,63 @@ export class ClientsService {
     });
 
     if (!client) {
-      throw new Error(`Client not found for userId=${userId}`);
+      throw new NotFoundException(`Client not found for userId=${userId}`);
     }
 
-    if (!client.profile) {
-      // ClientProfile должен быть создан в provisionForUser. Если его нет —
-      // создаём сейчас (defensive).
-      const encrypted = encryptProfile(patch, this.crypto);
-      const created = await this.prisma.clientProfile.create({
-        data: {
-          clientId: client.id,
-          ...encrypted,
-        },
+    const changedFields = Object.keys(patch).filter(
+      (k) => (patch as Record<string, unknown>)[k] !== undefined,
+    );
+
+    if (changedFields.length === 0) {
+      // Идемпотентный no-op: пустой patch не должен публиковать событие.
+      // Возвращаем текущее состояние (или 204 в контроллере — тут возвращаем профиль).
+      const current = await this.prisma.clientProfile.findUnique({
+        where: { clientId: client.id },
       });
-      return decryptProfile(created, this.crypto);
+      if (!current) {
+        throw new NotFoundException(`Profile not found for clientId=${client.id}`);
+      }
+      return decryptProfile(current, this.crypto);
     }
 
-    // Разделяем шифруемые и не-шифруемые поля
-    const { citizenship, telegramHandle, ...encryptable } = patch;
+    const { citizenship, telegramHandle, preferences, ...encryptable } = patch;
     const encrypted = encryptProfile(encryptable, this.crypto);
 
-    const updated = await this.prisma.clientProfile.update({
-      where: { id: client.profile.id },
-      data: {
-        ...encrypted,
-        ...(citizenship !== undefined ? { citizenship } : {}),
-        ...(telegramHandle !== undefined ? { telegramHandle } : {}),
-      },
+    const data: Prisma.ClientProfileUpdateInput = {
+      ...encrypted,
+      ...(citizenship !== undefined ? { citizenship } : {}),
+      ...(telegramHandle !== undefined ? { telegramHandle } : {}),
+      ...(preferences !== undefined ? { preferences } : {}),
+    };
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const result = client.profile
+        ? await tx.clientProfile.update({
+            where: { id: client.profile.id },
+            data,
+          })
+        : await tx.clientProfile.create({
+            data: {
+              clientId: client.id,
+              ...encrypted,
+              ...(citizenship !== undefined ? { citizenship } : {}),
+              ...(telegramHandle !== undefined ? { telegramHandle } : {}),
+              ...(preferences !== undefined ? { preferences } : {}),
+            },
+          });
+
+      await this.outbox.add(tx, {
+        type: 'clients.profile.updated',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          clientId: client.id,
+          changedFields,
+        },
+      });
+
+      return result;
     });
 
     return decryptProfile(updated, this.crypto);

--- a/apps/api/src/modules/clients/consent-versions.ts
+++ b/apps/api/src/modules/clients/consent-versions.ts
@@ -1,0 +1,34 @@
+import { ConsentType } from '@prisma/client';
+
+/**
+ * Текущие версии текстов согласий из docs/LEGAL/CONSENTS/.
+ *
+ * Используются как snapshot при создании Consent-записи (#142).
+ * При обновлении шаблона текста в docs/LEGAL/CONSENTS/<file>.md — инкрементируется
+ * версия здесь. Существующие Consent-записи сохраняют свою старую версию (audit
+ * для 152-ФЗ ст. 14: при споре с Роскомнадзором / клиентом мы должны показать
+ * какой именно текст подписал клиент).
+ *
+ * Формат версии: '<YYYY-MM-DD>-v<N>'. N инкрементируется в рамках одного дня.
+ *
+ * рекомендация: не превращать это в БД-таблицу до тех пор пока не нужно
+ * программное управление версиями (например через админку #323). Сейчас тексты
+ * правит юрист в Markdown, разработчик инкрементирует константу — простота.
+ */
+export const CURRENT_CONSENT_VERSIONS: Readonly<Record<ConsentType, string>> = {
+  pdn: '2026-04-25-v1',
+  photo_video: '2026-04-25-v1',
+  geo: '2026-04-25-v1',
+  emergency_contacts: '2026-04-25-v1',
+} as const;
+
+/**
+ * Mapping consent_type → markdown source. Используется в будущих endpoints
+ * (GET /consents/:type/text), чтобы клиент в ЛК мог посмотреть текущий текст.
+ */
+export const CONSENT_DOC_PATHS: Readonly<Record<ConsentType, string>> = {
+  pdn: 'docs/LEGAL/CONSENTS/PDN.md',
+  photo_video: 'docs/LEGAL/CONSENTS/PHOTO_VIDEO.md',
+  geo: 'docs/LEGAL/CONSENTS/GEO.md',
+  emergency_contacts: 'docs/LEGAL/CONSENTS/EMERGENCY_CONTACTS.md',
+} as const;

--- a/apps/api/src/modules/clients/consents/consents.controller.ts
+++ b/apps/api/src/modules/clients/consents/consents.controller.ts
@@ -1,0 +1,61 @@
+/**
+ * ConsentsController — granular consent endpoints (#143).
+ *
+ * - GET    /clients/me/consents              — все consent-записи (active + history)
+ * - POST   /clients/me/consents/:type        — grant (создать/обновить активный)
+ * - DELETE /clients/me/consents/:type        — revoke активный
+ *
+ * @Roles('client') — только клиент управляет своими согласиями.
+ *
+ * URL-param :type валидируется через ParseEnumPipe (только перечисленные типы).
+ */
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseEnumPipe,
+  Post,
+} from '@nestjs/common';
+
+import { ConsentType } from '@prisma/client';
+
+import { ConsentsService } from './consents.service';
+import { GrantConsentDto } from './dto/grant-consent.dto';
+import { CurrentUser, Roles } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+import type { Consent } from '@prisma/client';
+
+@Controller('clients/me/consents')
+@Roles('client')
+export class ConsentsController {
+  constructor(private readonly consents: ConsentsService) {}
+
+  @Get()
+  async list(@CurrentUser() user: AuthenticatedUser): Promise<Consent[]> {
+    return this.consents.list(user.id);
+  }
+
+  @Post(':type')
+  @HttpCode(HttpStatus.OK)
+  async grant(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('type', new ParseEnumPipe(ConsentType)) type: ConsentType,
+    @Body() dto: GrantConsentDto,
+  ): Promise<Consent> {
+    return this.consents.grant(user.id, type, dto);
+  }
+
+  @Delete(':type')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async revoke(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('type', new ParseEnumPipe(ConsentType)) type: ConsentType,
+  ): Promise<void> {
+    await this.consents.revoke(user.id, type);
+  }
+}

--- a/apps/api/src/modules/clients/consents/consents.service.ts
+++ b/apps/api/src/modules/clients/consents/consents.service.ts
@@ -1,0 +1,188 @@
+/**
+ * ConsentsService — granular consent management (#143).
+ *
+ * Гарантии:
+ * - При grant новой версии того же type — ставится revokedAt на старую запись,
+ *   создаётся новая (audit-trail сохраняется). Один активный по (clientId, type).
+ * - Валидация scope под конкретный type — строгая (BadRequest при несоответствии).
+ * - Outbox events:
+ *   - clients.consent.granted  при создании
+ *   - clients.consent.revoked  при отзыве
+ * - version snapshot из CURRENT_CONSENT_VERSIONS на момент grant'а.
+ */
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+import { CURRENT_CONSENT_VERSIONS } from '../consent-versions';
+
+import type { GrantConsentDto } from './dto/grant-consent.dto';
+import type { Consent, ConsentType, Prisma } from '@prisma/client';
+
+@Injectable()
+export class ConsentsService {
+  private readonly logger = new Logger(ConsentsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  async list(userId: string): Promise<Consent[]> {
+    const client = await this.findClientId(userId);
+    return this.prisma.consent.findMany({
+      where: { clientId: client.id },
+      orderBy: [{ type: 'asc' }, { grantedAt: 'desc' }],
+    });
+  }
+
+  async grant(userId: string, type: ConsentType, dto: GrantConsentDto): Promise<Consent> {
+    const client = await this.findClientId(userId);
+    const scope = this.buildScope(type, dto);
+    const version = CURRENT_CONSENT_VERSIONS[type];
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Атомарно: revoke предыдущий активный (если был) + create новый.
+      // Partial unique index на (client_id, type) WHERE revoked_at IS NULL
+      // не позволит создать второй активный без revoke первого.
+      const previousActive = await tx.consent.findFirst({
+        where: { clientId: client.id, type, revokedAt: null },
+        select: { id: true, scope: true },
+      });
+
+      if (previousActive) {
+        await tx.consent.update({
+          where: { id: previousActive.id },
+          data: { revokedAt: new Date() },
+        });
+      }
+
+      const created = await tx.consent.create({
+        data: {
+          clientId: client.id,
+          type,
+          scope: scope as Prisma.InputJsonValue,
+          version,
+        },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'clients.consent.granted',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          clientId: client.id,
+          consentType: type,
+          version,
+          // diff с предыдущей версией (для audit) — только имена ключей,
+          // не значения, т.к. сами scope могут быть PII-релевантны
+          previousVersionId: previousActive?.id ?? null,
+          newScopeKeys: Object.keys(scope),
+        },
+      });
+
+      return created;
+    });
+
+    this.logger.log(
+      { userId, consentId: result.id, type, version },
+      'consent.granted',
+    );
+    return result;
+  }
+
+  async revoke(userId: string, type: ConsentType): Promise<void> {
+    const client = await this.findClientId(userId);
+
+    const active = await this.prisma.consent.findFirst({
+      where: { clientId: client.id, type, revokedAt: null },
+      select: { id: true },
+    });
+    if (!active) {
+      throw new NotFoundException('Активный consent данного типа не найден');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.consent.update({
+        where: { id: active.id },
+        data: { revokedAt: new Date() },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'clients.consent.revoked',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          clientId: client.id,
+          consentType: type,
+          consentId: active.id,
+        },
+      });
+    });
+
+    this.logger.log({ userId, consentId: active.id, type }, 'consent.revoked');
+  }
+
+  /**
+   * Валидация и нормализация scope под конкретный consent type.
+   *
+   * Throws BadRequestException если обязательные для type поля отсутствуют
+   * или присутствуют посторонние.
+   */
+  private buildScope(type: ConsentType, dto: GrantConsentDto): Record<string, unknown> {
+    switch (type) {
+      case 'pdn':
+        // Пустой scope — pdn это всё-или-ничего, без granular уровней.
+        return {};
+
+      case 'photo_video': {
+        if (dto.level === undefined) {
+          throw new BadRequestException(
+            'photo_video: обязательное поле level (1..4)',
+          );
+        }
+        const scope: Record<string, unknown> = { level: dto.level };
+        if (dto.useName !== undefined) {
+          scope['useName'] = dto.useName;
+        }
+        return scope;
+      }
+
+      case 'geo': {
+        if (!dto.modes || dto.modes.length === 0) {
+          throw new BadRequestException(
+            'geo: обязательное поле modes (массив из A/B/C/D)',
+          );
+        }
+        return { modes: dto.modes };
+      }
+
+      case 'emergency_contacts': {
+        if (dto.allowed !== true) {
+          throw new BadRequestException(
+            'emergency_contacts: scope.allowed должен быть true (отзыв — через DELETE)',
+          );
+        }
+        return { allowed: true };
+      }
+    }
+  }
+
+  private async findClientId(userId: string): Promise<{ id: string }> {
+    const client = await this.prisma.client.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+    if (!client) {
+      throw new NotFoundException('Client profile not yet provisioned');
+    }
+    return client;
+  }
+}

--- a/apps/api/src/modules/clients/consents/dto/grant-consent.dto.ts
+++ b/apps/api/src/modules/clients/consents/dto/grant-consent.dto.ts
@@ -1,0 +1,61 @@
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
+
+import type { ConsentType } from '@prisma/client';
+
+/**
+ * Granular consent request body. Поля опциональные на DTO-уровне; service
+ * валидирует обязательность под конкретный `type` (URL-param):
+ *
+ * - pdn:                все поля пропускаются (scope = {})
+ * - photo_video:        level: 1..4 (req), useName?: boolean
+ * - geo:                modes: ('A'|'B'|'C'|'D')[] (req, 1-4 items)
+ * - emergency_contacts: allowed: true (req)
+ */
+export class GrantConsentDto {
+  /** photo_video: 1=личный альбом, 2=внутреннее, 3=сайт, 4=соцсети */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(4)
+  level?: number;
+
+  /** photo_video: разрешить указывать имя при публикации */
+  @IsOptional()
+  @IsBoolean()
+  useName?: boolean;
+
+  /** geo: A=SOS, B=tracking, C=geofence, D=analytics */
+  @IsOptional()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(4)
+  @ArrayUnique()
+  @IsIn(['A', 'B', 'C', 'D'], { each: true })
+  modes?: ('A' | 'B' | 'C' | 'D')[];
+
+  /** emergency_contacts: явное согласие на хранение контактов третьих лиц */
+  @IsOptional()
+  @IsBoolean()
+  allowed?: boolean;
+}
+
+/**
+ * Public DTO ответа — GET /clients/me/consents и результат POST/DELETE.
+ */
+export interface ConsentResponse {
+  id: string;
+  type: ConsentType;
+  scope: Record<string, unknown>;
+  version: string;
+  grantedAt: Date;
+  revokedAt: Date | null;
+}

--- a/apps/api/src/modules/clients/dto/update-profile.dto.ts
+++ b/apps/api/src/modules/clients/dto/update-profile.dto.ts
@@ -1,0 +1,95 @@
+import { Transform } from 'class-transformer';
+import {
+  IsISO31661Alpha2,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+
+/**
+ * DTO для PATCH /clients/me.
+ *
+ * Patch-семантика:
+ * - omitted поле = нет изменений
+ * - явный null = очистить значение (для nullable полей)
+ *
+ * Шифрование ПДн (firstName, lastName, dateOfBirth, phone) делает
+ * ClientsService.updateProfile через encryptProfile().
+ *
+ * Issue: #140 [M5.C.3]
+ */
+export class UpdateClientProfileDto {
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsString()
+  @MaxLength(100)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  firstName?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsString()
+  @MaxLength(100)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  lastName?: string | null;
+
+  /**
+   * ISO date YYYY-MM-DD. Контроллер проверяет формат через @Matches.
+   * Шифрование как plaintext-string (не Date) — простота indexing'а
+   * и совместимость с EncryptableProfileInput.
+   */
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'dateOfBirth должен быть в формате YYYY-MM-DD' })
+  dateOfBirth?: string | null;
+
+  /**
+   * ISO 3166-1 alpha-2 (например "RU", "IN"). Не шифруется.
+   */
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsISO31661Alpha2({ message: 'citizenship должен быть ISO 3166-1 alpha-2 (например RU)' })
+  citizenship?: string | null;
+
+  /**
+   * E.164: + и 10–15 цифр. Хранится зашифрованным.
+   */
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsString()
+  @Matches(/^\+\d{10,15}$/, { message: 'phone должен быть в формате E.164: +<country><number>' })
+  phone?: string | null;
+
+  /**
+   * Telegram username без @. Не шифруется (публичный handle).
+   * Лимит 32 — по правилам Telegram.
+   */
+  @IsOptional()
+  @ValidateIf((_obj, value: unknown) => value !== null)
+  @IsString()
+  @MaxLength(32)
+  @Matches(/^[A-Za-z0-9_]{5,32}$/, {
+    message: 'telegramHandle: 5–32 символа, латиница/цифры/подчёркивание, без @',
+  })
+  telegramHandle?: string | null;
+
+  /**
+   * JSONB-объект: языки, диеты, специальные требования.
+   * Пример: { "languages": ["ru", "en"], "diet": "vegetarian" }.
+   *
+   * Глубокую валидацию структуры не делаем — это V1 «свободный JSON».
+   * Когда появятся бизнес-фичи завязанные на конкретные ключи (например
+   * filter по `diet`) — добавим конкретные DTO-поля.
+   */
+  @IsOptional()
+  @IsObject()
+  preferences?: Record<string, unknown>;
+}

--- a/apps/api/src/modules/clients/emergency-contacts/dto/upsert-emergency-contact.dto.ts
+++ b/apps/api/src/modules/clients/emergency-contacts/dto/upsert-emergency-contact.dto.ts
@@ -1,0 +1,38 @@
+import { IsEnum, IsString, Length, Matches, MaxLength, MinLength } from 'class-validator';
+
+import { EmergencyContactPriority } from '@prisma/client';
+
+/**
+ * DTO для POST/PATCH /clients/me/emergency-contacts (#144).
+ *
+ * - name: ФИО (2-100 chars)
+ * - phone: E.164 (+ и 10–15 цифр)
+ * - relation: «Отец», «Жена» — свободный текст
+ * - language: ISO 639-1 (ru/en/...)
+ * - priority: primary | secondary (один на каждый — uniqueness в БД)
+ */
+export class UpsertEmergencyContactDto {
+  @IsString()
+  @MinLength(2, { message: 'name минимум 2 символа' })
+  @MaxLength(100)
+  name!: string;
+
+  @IsString()
+  @Matches(/^\+\d{10,15}$/, { message: 'phone в формате E.164: +<country><number>' })
+  phone!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  relation!: string;
+
+  @IsString()
+  @Length(2, 2, { message: 'language — ISO 639-1 (2 символа), например "ru" или "en"' })
+  @Matches(/^[a-z]{2}$/, { message: 'language — нижний регистр' })
+  language!: string;
+
+  @IsEnum(EmergencyContactPriority, {
+    message: 'priority — primary или secondary',
+  })
+  priority!: EmergencyContactPriority;
+}

--- a/apps/api/src/modules/clients/emergency-contacts/emergency-contacts.controller.ts
+++ b/apps/api/src/modules/clients/emergency-contacts/emergency-contacts.controller.ts
@@ -1,0 +1,61 @@
+/**
+ * EmergencyContactsController — endpoints контактов экстренной связи (#144).
+ *
+ * - POST   /clients/me/emergency-contacts        — upsert (по priority)
+ * - GET    /clients/me/emergency-contacts        — список (1-2 шт.)
+ * - DELETE /clients/me/emergency-contacts/:id    — удалить
+ *
+ * @Roles('client') — только клиент управляет своими контактами. Админ-доступ
+ * к чужим контактам — отдельный endpoint (EPIC 13 admin panel) при необходимости.
+ */
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+
+import { UpsertEmergencyContactDto } from './dto/upsert-emergency-contact.dto';
+import {
+  EmergencyContactsService,
+  type EmergencyContactDecrypted,
+} from './emergency-contacts.service';
+import { CurrentUser, Roles } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+
+@Controller('clients/me/emergency-contacts')
+@Roles('client')
+export class EmergencyContactsController {
+  constructor(private readonly contacts: EmergencyContactsService) {}
+
+  @Get()
+  async list(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<EmergencyContactDecrypted[]> {
+    return this.contacts.list(user.id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async upsert(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpsertEmergencyContactDto,
+  ): Promise<EmergencyContactDecrypted> {
+    return this.contacts.upsert(user.id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<void> {
+    await this.contacts.remove(user.id, id);
+  }
+}

--- a/apps/api/src/modules/clients/emergency-contacts/emergency-contacts.service.ts
+++ b/apps/api/src/modules/clients/emergency-contacts/emergency-contacts.service.ts
@@ -1,0 +1,192 @@
+/**
+ * EmergencyContactsService — CRUD контактов экстренной связи (#144).
+ *
+ * Гарантии:
+ * - Шифруем name + phone (ПДн третьих лиц) через CryptoService.
+ * - Перед save проверяем активный Consent типа `emergency_contacts` со scope.allowed=true.
+ *   Без него — 403 (152-ФЗ ст. 9 § granular consent, см. docs/LEGAL/CONSENTS/EMERGENCY_CONTACTS.md).
+ * - Максимум 2 контакта на client (primary + secondary) — DB unique constraint;
+ *   upsert по (clientId, priority) — повторный POST с тем же priority обновляет
+ *   существующий вместо ошибки duplicate.
+ * - Публикуем `clients.emergency_contact.added` в outbox при первом save'е.
+ */
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { CryptoService } from '../../../common/crypto/crypto.service';
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import type {
+  EmergencyContact,
+  EmergencyContactPriority,
+  Prisma,
+} from '@prisma/client';
+
+export interface EmergencyContactDecrypted
+  extends Omit<EmergencyContact, 'name' | 'phone'> {
+  name: string;
+  phone: string;
+}
+
+interface UpsertInput {
+  name: string;
+  phone: string;
+  relation: string;
+  language: string;
+  priority: EmergencyContactPriority;
+}
+
+@Injectable()
+export class EmergencyContactsService {
+  private readonly logger = new Logger(EmergencyContactsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  async list(userId: string): Promise<EmergencyContactDecrypted[]> {
+    const client = await this.findClientId(userId);
+    const contacts = await this.prisma.emergencyContact.findMany({
+      where: { clientId: client.id },
+      orderBy: { priority: 'asc' }, // primary раньше secondary
+    });
+    return contacts.map((c) => this.decrypt(c));
+  }
+
+  /**
+   * Upsert по (clientId, priority): создаёт или обновляет контакт указанного
+   * приоритета. Повторный POST primary — обновит, не сломается на duplicate.
+   *
+   * Публикует событие только при CREATE. UPDATE — без события (при необходимости
+   * отдельный issue с `clients.emergency_contact.updated`).
+   */
+  async upsert(userId: string, input: UpsertInput): Promise<EmergencyContactDecrypted> {
+    const client = await this.findClientId(userId);
+    await this.assertConsent(client.id);
+
+    const encryptedName = this.crypto.encrypt(input.name);
+    const encryptedPhone = this.crypto.encrypt(input.phone);
+
+    const existing = await this.prisma.emergencyContact.findUnique({
+      where: { clientId_priority: { clientId: client.id, priority: input.priority } },
+      select: { id: true },
+    });
+
+    const data: Prisma.EmergencyContactUpdateInput = {
+      name: encryptedName,
+      phone: encryptedPhone,
+      relation: input.relation,
+      language: input.language,
+    };
+
+    if (existing) {
+      const updated = await this.prisma.emergencyContact.update({
+        where: { id: existing.id },
+        data,
+      });
+      this.logger.log(
+        { userId, contactId: updated.id, priority: input.priority, action: 'update' },
+        'emergency-contact.upsert',
+      );
+      return this.decrypt(updated);
+    }
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const result = await tx.emergencyContact.create({
+        data: {
+          clientId: client.id,
+          ...data,
+          priority: input.priority,
+        } as Prisma.EmergencyContactUncheckedCreateInput,
+      });
+
+      await this.outbox.add(tx, {
+        type: 'clients.emergency_contact.added',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          clientId: client.id,
+          contactId: result.id,
+          priority: input.priority,
+          // ПДн (name/phone) НЕ публикуем в payload — privacy by default
+        },
+      });
+
+      return result;
+    });
+
+    this.logger.log(
+      { userId, contactId: created.id, priority: input.priority, action: 'create' },
+      'emergency-contact.added',
+    );
+    return this.decrypt(created);
+  }
+
+  async remove(userId: string, contactId: string): Promise<void> {
+    const client = await this.findClientId(userId);
+    const result = await this.prisma.emergencyContact.deleteMany({
+      where: { id: contactId, clientId: client.id },
+    });
+    if (result.count === 0) {
+      throw new NotFoundException('Контакт не найден');
+    }
+    this.logger.log({ userId, contactId, action: 'delete' }, 'emergency-contact.removed');
+  }
+
+  private async findClientId(userId: string): Promise<{ id: string }> {
+    const client = await this.prisma.client.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+    if (!client) {
+      // Race condition: register прошёл, но listener ещё не отработал.
+      throw new NotFoundException('Client profile not yet provisioned');
+    }
+    return client;
+  }
+
+  /**
+   * Проверка наличия активного консента emergency_contacts со scope.allowed=true.
+   * Без него — 403 (152-ФЗ требует явного согласия на обработку контактов
+   * третьих лиц, документация в docs/LEGAL/CONSENTS/EMERGENCY_CONTACTS.md).
+   */
+  private async assertConsent(clientId: string): Promise<void> {
+    const consent = await this.prisma.consent.findFirst({
+      where: {
+        clientId,
+        type: 'emergency_contacts',
+        revokedAt: null,
+      },
+      select: { scope: true },
+    });
+
+    const allowed =
+      consent != null &&
+      typeof consent.scope === 'object' &&
+      consent.scope !== null &&
+      !Array.isArray(consent.scope) &&
+      (consent.scope as Record<string, unknown>)['allowed'] === true;
+
+    if (!allowed) {
+      throw new ForbiddenException(
+        'Требуется активное согласие на обработку контактов экстренной связи',
+      );
+    }
+  }
+
+  private decrypt(c: EmergencyContact): EmergencyContactDecrypted {
+    return {
+      ...c,
+      name: this.crypto.tryDecrypt(c.name) ?? c.name,
+      phone: this.crypto.tryDecrypt(c.phone) ?? c.phone,
+    };
+  }
+}

--- a/apps/api/src/modules/clients/listeners/clients.listener.ts
+++ b/apps/api/src/modules/clients/listeners/clients.listener.ts
@@ -10,7 +10,6 @@
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
 
 import { EventsBusService } from '../../../common/events-bus/events-bus.service';
-
 import { ClientsService } from '../clients.service';
 
 interface UserRegisteredPayload {


### PR DESCRIPTION
## Summary

Полный домен Clients: профиль /me, granular consent system (152-ФЗ ст. 9), emergency contacts с consent-guard'ом.

| Commit | Closes |
|--------|--------|
| GET/PATCH /clients/me + outbox event | #140 |
| Consent model + 4 типа scope-shape | #142 |
| EmergencyContact CRUD + consent guard | #144 |
| Granular consent endpoints (POST/DELETE/GET) | #143 |

## Что внутри

### #140 GET/PATCH /clients/me

- `GET /clients/me` — расшифрованный профиль (404 если Client ещё не provisioned после register'а)
- `PATCH /clients/me` — обновить ПДн+non-ПДн поля (firstName, lastName, dateOfBirth, phone, citizenship, telegramHandle, preferences). ПДн поля шифруются.
- Patch-семантика: omitted = no-change, явный null = clear
- Validation: dateOfBirth YYYY-MM-DD, phone E.164, citizenship ISO 3166-1, telegramHandle regex tg-username
- Outbox event `clients.profile.updated` с `changedFields` (имена полей, без значений — privacy by default)
- `@Roles('client')` на класс
- Bonus: `Roles` decorator теперь применим к классу тоже (был ошибочно типизирован `MethodDecorator`)

### #142 Consent model

- Enum `ConsentType`: pdn | photo_video | geo | emergency_contacts
- Model: id, clientId, type, scope (JSONB), version, grantedAt, revokedAt
- **Partial unique index** (raw SQL): `WHERE revoked_at IS NULL` — один активный consent на пару (clientId, type), revoked-записи остаются как audit-trail (152-ФЗ ст. 14)
- Scope shape per type:
  - `pdn`: `{}`
  - `photo_video`: `{level: 1|2|3|4, useName?: boolean}`
  - `geo`: `{modes: ('A'|'B'|'C'|'D')[]}`
  - `emergency_contacts`: `{allowed: boolean}`
- `CURRENT_CONSENT_VERSIONS` constants — snapshot текущих версий из `docs/LEGAL/CONSENTS/`. Меняется в коде когда юрист правит шаблоны.

### #143 Granular consent endpoints

```
GET    /clients/me/consents          → все Consent-записи (active + history)
POST   /clients/me/consents/:type    → grant (атомарный upsert)
DELETE /clients/me/consents/:type    → revoke активный
```

- `grant`: транзакция revoke previous active + create new + outbox event
- Валидация scope под type (BadRequestException иначе)
- Outbox events: `clients.consent.granted` (с `previousVersionId`, `newScopeKeys` для audit-diff), `clients.consent.revoked`
- URL-param `:type` через `ParseEnumPipe(ConsentType)` — невалидный type → 400

### #144 EmergencyContact CRUD

```
GET    /clients/me/emergency-contacts
POST   /clients/me/emergency-contacts (upsert по priority)
DELETE /clients/me/emergency-contacts/:id
```

- Schema: enum `Priority`: primary | secondary; модель с шифрованными name/phone
- Unique constraint `(client_id, priority)` → max 2 контакта (primary + secondary)
- **Consent guard**: перед save проверяем активный Consent типа `emergency_contacts` со scope.allowed=true. Без него — 403.
- Outbox event `clients.emergency_contact.added` (только при CREATE; payload без name/phone — privacy)
- `@Roles('client')`

## Schema changes

- Добавлены enum'ы `ConsentType`, `EmergencyContactPriority`
- Добавлены модели `Consent`, `EmergencyContact`
- `Client` += backref `consents` и `emergencyContacts`
- 2 миграции: `20260428120000_M5_C_005_consent_model`, `20260428130000_M5_C_007_emergency_contacts`

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после `db:migrate:deploy`):**
  - Roman логинится → `GET /clients/me` возвращает пустой профиль
  - `PATCH /clients/me` сохраняет ФИО (зашифрованно)
  - `POST /consents/emergency_contacts` создаёт consent
  - `POST /emergency-contacts` создаёт primary контакт
  - `DELETE /consents/emergency_contacts` → следующий `POST /emergency-contacts` → 403

## Closes

- Closes #140, closes #142, closes #143, closes #144

## Зависимости

- Базируется на main (PR #331, #332 уже merged)
- Не блокирует PR 4 (trips)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_