### PR TITLE
feat(trips): Trip + Itinerary + DayPlan + Booking + POST /trips (#149, #150)

### DIFF
--- a/apps/api/prisma/migrations/20260428110000_M5_D_001_trip_models/migration.sql
+++ b/apps/api/prisma/migrations/20260428110000_M5_D_001_trip_models/migration.sql
@@ -1,0 +1,78 @@
+-- M5.D.001 — Trip + Itinerary + DayPlan + Booking models (issue #149)
+
+CREATE TYPE "trip_status" AS ENUM ('draft', 'paid', 'in_progress', 'completed', 'cancelled');
+CREATE TYPE "booking_type" AS ENUM ('hotel', 'transfer', 'activity', 'guide');
+CREATE TYPE "booking_status" AS ENUM ('pending', 'confirmed', 'cancelled', 'failed');
+
+CREATE TABLE "trips" (
+  "id"           UUID NOT NULL DEFAULT gen_random_uuid(),
+  "client_id"    UUID NOT NULL,
+  "status"       "trip_status" NOT NULL DEFAULT 'draft',
+  "starts_at"    TIMESTAMP(3) NOT NULL,
+  "ends_at"      TIMESTAMP(3) NOT NULL,
+  "region"       TEXT NOT NULL,
+  "total_amount" BIGINT,
+  "currency"     CHAR(3) NOT NULL DEFAULT 'RUB',
+  "created_by"   UUID NOT NULL,
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"   TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "trips_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "idx_trips_client_status" ON "trips" ("client_id", "status");
+CREATE INDEX "idx_trips_starts" ON "trips" ("starts_at");
+CREATE INDEX "idx_trips_created_by" ON "trips" ("created_by");
+
+CREATE TABLE "itineraries" (
+  "id"           UUID NOT NULL DEFAULT gen_random_uuid(),
+  "trip_id"      UUID NOT NULL,
+  "version"      INTEGER NOT NULL DEFAULT 1,
+  "published_at" TIMESTAMP(3),
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "itineraries_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "itineraries_trip_id_fkey" FOREIGN KEY ("trip_id")
+    REFERENCES "trips" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "uq_itineraries_trip_version" ON "itineraries" ("trip_id", "version");
+CREATE INDEX "idx_itineraries_trip_published" ON "itineraries" ("trip_id", "published_at");
+
+CREATE TABLE "day_plans" (
+  "id"            UUID NOT NULL DEFAULT gen_random_uuid(),
+  "itinerary_id"  UUID NOT NULL,
+  "day_number"    INTEGER NOT NULL,
+  "date"          DATE NOT NULL,
+  "summary"       TEXT NOT NULL,
+  "items"         JSONB NOT NULL,
+  "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"    TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "day_plans_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "day_plans_itinerary_id_fkey" FOREIGN KEY ("itinerary_id")
+    REFERENCES "itineraries" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "uq_day_plans_itinerary_day" ON "day_plans" ("itinerary_id", "day_number");
+CREATE INDEX "idx_day_plans_itinerary_date" ON "day_plans" ("itinerary_id", "date");
+
+CREATE TABLE "bookings" (
+  "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+  "trip_id"    UUID NOT NULL,
+  "type"       "booking_type" NOT NULL,
+  "vendor_id"  TEXT NOT NULL,
+  "status"     "booking_status" NOT NULL DEFAULT 'pending',
+  "payload"    JSONB NOT NULL,
+  "amount"     BIGINT,
+  "currency"   CHAR(3) NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "bookings_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "bookings_trip_id_fkey" FOREIGN KEY ("trip_id")
+    REFERENCES "trips" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "idx_bookings_trip_type" ON "bookings" ("trip_id", "type");
+CREATE INDEX "idx_bookings_status_created" ON "bookings" ("status", "created_at");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -286,24 +286,24 @@ model EmergencyContact {
 /// потому что encrypted-payload — base64-строка, не date/etc.
 /// preferences — свободный JSONB (языки, диеты, хобби).
 model ClientProfile {
-  id             String    @id @default(uuid()) @db.Uuid
-  clientId       String    @unique @map("client_id") @db.Uuid
+  id             String   @id @default(uuid()) @db.Uuid
+  clientId       String   @unique @map("client_id") @db.Uuid
   /// Зашифровано (#139). plaintext: ФИО.
-  firstName      String?   @map("first_name")
+  firstName      String?  @map("first_name")
   /// Зашифровано (#139). plaintext: ФИО.
-  lastName       String?   @map("last_name")
+  lastName       String?  @map("last_name")
   /// Зашифровано (#139). plaintext: ISO date 'YYYY-MM-DD'.
-  dateOfBirth    String?   @map("date_of_birth")
+  dateOfBirth    String?  @map("date_of_birth")
   /// ISO 3166-1 alpha-2, например "RU", "IN". НЕ шифруется (не ПДн сама по себе).
-  citizenship    String?   @db.Char(2)
+  citizenship    String?  @db.Char(2)
   /// Зашифровано (#139). plaintext: E.164 формат, например "+79161234567".
   phone          String?
   /// Telegram username без @, публичный handle. НЕ шифруется.
-  telegramHandle String?   @map("telegram_handle")
+  telegramHandle String?  @map("telegram_handle")
   /// Свободный JSONB: языки, диеты, специальные требования.
   /// Пример: { "languages": ["ru", "en"], "diet": "vegetarian" }
-  preferences    Json?     @default("{}")
-  updatedAt      DateTime  @updatedAt @map("updated_at")
+  preferences    Json?    @default("{}")
+  updatedAt      DateTime @updatedAt @map("updated_at")
 
   client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
 
@@ -483,32 +483,201 @@ enum LeadStatus {
 /// status workflow: NEW → CONTACTED → CONVERTED|REJECTED. Переходы делает
 /// менеджер через будущую CRM (EPIC 14). До этого — все Lead'ы NEW.
 model Lead {
-  id          String     @id @default(uuid()) @db.Uuid
+  id                 String     @id @default(uuid()) @db.Uuid
   /// Источник заявки. Свободный slug:
   /// - "tour-tury-kerala-oktyabr-2026" — кнопка с tour landing page
   /// - "general" — общая форма с главной (когда будет)
-  source      String
+  source             String
   /// Зашифровано (#139). plaintext: имя клиента (2–100 символов).
-  name        String
+  name               String
   /// Тип контакта: 'phone' | 'telegram' | 'email'. Не шифруется (enum-like).
-  contactType String     @map("contact_type")
+  contactType        String     @map("contact_type")
   /// Зашифровано (#139). plaintext: телефон / @username / email.
-  contact     String
+  contact            String
   /// Зашифровано (#139). plaintext: свободный комментарий клиента (опционально).
-  comment     String?
+  comment            String?
   /// Версия текста consent на момент согласия. При обновлении Политики
   /// конфиденциальности версия меняется → новый клиент подписывает новую,
   /// старый Lead.consentTextVersion сохраняет старую (для аудита 152-ФЗ).
   /// Формат: 'YYYY-MM-DD-vN'.
-  consentTextVersion String @map("consent_text_version")
+  consentTextVersion String     @map("consent_text_version")
   /// sha256(ip) — для rate-limit и антифрод-аналитики, не raw IP (privacy).
-  ipHash      String?    @map("ip_hash")
-  userAgent   String?    @map("user_agent")
-  status      LeadStatus @default(NEW)
-  createdAt   DateTime   @default(now()) @map("created_at")
-  updatedAt   DateTime   @updatedAt @map("updated_at")
+  ipHash             String?    @map("ip_hash")
+  userAgent          String?    @map("user_agent")
+  status             LeadStatus @default(NEW)
+  createdAt          DateTime   @default(now()) @map("created_at")
+  updatedAt          DateTime   @updatedAt @map("updated_at")
 
   @@index([status, createdAt], map: "idx_leads_status_created")
   @@index([source], map: "idx_leads_source")
   @@map("leads")
+}
+
+// === trips модуль (#149+ [M5.D]) ===
+//
+// Источник: docs/BACKLOG/M5/D_TRIPS.md, docs/ARCH/MICROSERVICES.md § trips-svc.
+// trips — ядро домена путешествий: Trip = одна поездка клиента.
+// Itinerary = версия маршрута; одной Trip может принадлежать несколько Itinerary
+// (для версионирования при правках после publish).
+// DayPlan = детализация одного дня поездки (отель, переезды, активности).
+// Booking = конкретная бронь (отель/трансфер/активность/гид) — сама по себе
+// независима от DayPlan'а (для агрегатной маржинальности и расчётов).
+//
+// Cross-module rule (CLAUDE.md princip 5):
+// - clientId → soft-reference на clients.id (без FK)
+// - createdBy → soft-reference на users.id (без FK; обычно manager)
+// - vendorId → свободный string (внешний vendor / partner-id)
+
+enum TripStatus {
+  draft
+  paid
+  in_progress
+  completed
+  cancelled
+
+  @@map("trip_status")
+}
+
+enum BookingType {
+  hotel
+  transfer
+  activity
+  guide
+
+  @@map("booking_type")
+}
+
+enum BookingStatus {
+  pending
+  confirmed
+  cancelled
+  failed
+
+  @@map("booking_status")
+}
+
+/// Trip — одна поездка клиента.
+/// Создаётся менеджером (createdBy = userId менеджера). status переходит:
+/// draft → paid (после оплаты, #275) → in_progress (с момента startsAt) →
+/// completed (по факту endsAt) → cancelled (anywhere).
+///
+/// totalAmount/currency — итог цены тура для клиента (RUB по умолчанию).
+/// Для маржи — агрегируем Booking.amount в INR (см. будущий margin-report).
+model Trip {
+  id          String     @id @default(uuid()) @db.Uuid
+  /// Soft-reference на clients.id (cross-module).
+  clientId    String     @map("client_id") @db.Uuid
+  status      TripStatus @default(draft)
+  startsAt    DateTime   @map("starts_at")
+  endsAt      DateTime   @map("ends_at")
+  /// Свободный текст: "Керала", "Раджастан", "Гоа+Хампи".
+  region      String
+  /// Стоимость тура для клиента. Хранится в копейках, чтобы избежать float-проблем
+  /// (Decimal требовал бы pg_decimal-плагин и более тяжёлых RPC; копейки — простой и точный).
+  /// NULL до оплаты / финализации сметы.
+  totalAmount BigInt?    @map("total_amount")
+  currency    String     @default("RUB") @db.Char(3)
+  /// Soft-reference на users.id (cross-module). Обычно manager, иногда admin.
+  createdBy   String     @map("created_by") @db.Uuid
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
+
+  itineraries Itinerary[]
+  bookings    Booking[]
+
+  @@index([clientId, status], map: "idx_trips_client_status")
+  @@index([startsAt], map: "idx_trips_starts")
+  @@index([createdBy], map: "idx_trips_created_by")
+  @@map("trips")
+}
+
+/// Itinerary — версия маршрута.
+/// version инкрементируется при каждом значимом change'е (новый отель, перенос дня).
+/// publishedAt = NULL → DRAFT (виден только менеджеру). Заполнен → PUBLISHED
+/// (виден клиенту в trip dashboard, кешируется в его offline storage).
+///
+/// Versioning нужен для:
+/// 1. Аудита (что показывали клиенту до правки)
+/// 2. Offline-cache: клиент может видеть старую version'у пока не синхронизировал
+model Itinerary {
+  id          String    @id @default(uuid()) @db.Uuid
+  tripId      String    @map("trip_id") @db.Uuid
+  version     Int       @default(1)
+  /// NULL = draft. Set при publish'е.
+  publishedAt DateTime? @map("published_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+
+  trip Trip      @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  days DayPlan[]
+
+  @@unique([tripId, version], map: "uq_itineraries_trip_version")
+  @@index([tripId, publishedAt], map: "idx_itineraries_trip_published")
+  @@map("itineraries")
+}
+
+/// DayPlan — один день в маршруте.
+/// items: массив plan-объектов одного дня. Свободный JSON для гибкости —
+/// разные дни имеют разную структуру (морской день / город / трекинг).
+///
+/// Пример items:
+/// [
+///   { kind: 'transfer', from: 'TRV airport', to: 'Hotel X', time: '14:00' },
+///   { kind: 'activity', label: 'Welcome dinner', time: '19:00', notes: '...' }
+/// ]
+///
+/// Активности из tour'а (catalog domain) сюда копируются как snapshot —
+/// чтобы trip dashboard не зависел от изменений в каталоге после publish.
+model DayPlan {
+  id          String   @id @default(uuid()) @db.Uuid
+  itineraryId String   @map("itinerary_id") @db.Uuid
+  dayNumber   Int      @map("day_number")
+  /// Конкретная дата дня (в отличие от TourDay где относительный dayNumber).
+  date        DateTime @db.Date
+  /// Короткое описание дня (1-2 предложения для timeline preview).
+  summary     String
+  /// JSONB array (см. описание выше).
+  items       Json
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  itinerary Itinerary @relation(fields: [itineraryId], references: [id], onDelete: Cascade)
+
+  @@unique([itineraryId, dayNumber], map: "uq_day_plans_itinerary_day")
+  @@index([itineraryId, date], map: "idx_day_plans_itinerary_date")
+  @@map("day_plans")
+}
+
+/// Booking — одна бронь в рамках Trip.
+/// type определяет shape payload'а (hotel: {hotelName, checkIn, checkOut, rooms},
+/// transfer: {from, to, time, vehicle}, activity: {label, time, vendor}, guide: {guideId, days}).
+///
+/// vendorId — внешний идентификатор: ID отеля в booking-провайдере, slug гида,
+/// ID такси-сервиса. В фазе 3 — свободный string; в фазе 4 — отдельная модель Vendor.
+///
+/// status workflow:
+/// pending → confirmed (подтверждение от vendor'а)
+/// pending → failed (vendor отказал, нужно переоформить)
+/// confirmed → cancelled (отменено клиентом / нами).
+model Booking {
+  id        String        @id @default(uuid()) @db.Uuid
+  tripId    String        @map("trip_id") @db.Uuid
+  type      BookingType
+  /// Свободный string. Внешний vendor identifier.
+  vendorId  String        @map("vendor_id")
+  status    BookingStatus @default(pending)
+  /// JSONB — type-specific shape (см. описание выше).
+  payload   Json
+  /// Стоимость в native currency vendor'а (обычно INR для индийских поставщиков).
+  /// Хранится в копейках/paise для точности. NULL = ещё не зафиксировано.
+  amount    BigInt?
+  /// ISO 4217 валюта стоимости (INR, USD, RUB).
+  currency  String        @db.Char(3)
+  createdAt DateTime      @default(now()) @map("created_at")
+  updatedAt DateTime      @updatedAt @map("updated_at")
+
+  trip Trip @relation(fields: [tripId], references: [id], onDelete: Cascade)
+
+  @@index([tripId, type], map: "idx_bookings_trip_type")
+  @@index([status, createdAt], map: "idx_bookings_status_created")
+  @@map("bookings")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { CatalogModule } from './modules/catalog/catalog.module';
 import { ClientsModule } from './modules/clients/clients.module';
 import { HealthModule } from './modules/health/health.module';
 import { LeadsModule } from './modules/leads/leads.module';
+import { TripsModule } from './modules/trips/trips.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { LeadsModule } from './modules/leads/leads.module';
     ClientsModule,
     CatalogModule,
     LeadsModule,
+    TripsModule,
     CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
     HealthModule,
   ],

--- a/apps/api/src/modules/trips/dto/create-trip.dto.ts
+++ b/apps/api/src/modules/trips/dto/create-trip.dto.ts
@@ -1,0 +1,63 @@
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+/**
+ * DTO для POST /trips (#150).
+ *
+ * Только manager / admin (см. controller). Создаётся всегда в статусе `draft`.
+ * status workflow → paid → in_progress → completed/cancelled — отдельные
+ * endpoints (#160).
+ *
+ * totalAmount — в копейках/paise (BigInt в БД), для точного матча копеек
+ * без float-проблем. NULL допустим: смета формируется итеративно после draft.
+ *
+ * Валидация `endsAt > startsAt` — на уровне сервиса (нужен парсинг дат).
+ * Существование clientId — также сервис (DB-lookup).
+ */
+export class CreateTripDto {
+  @IsUUID(4, { message: 'clientId должен быть UUIDv4' })
+  clientId!: string;
+
+  @IsDateString({}, { message: 'startsAt должен быть ISO-date' })
+  startsAt!: string;
+
+  @IsDateString({}, { message: 'endsAt должен быть ISO-date' })
+  endsAt!: string;
+
+  @IsString()
+  @MinLength(2, { message: 'region не может быть пустым' })
+  @MaxLength(100)
+  region!: string;
+
+  /**
+   * Опциональная стартовая смета в копейках. Можно оставить NULL — заполнится
+   * позже при формировании предложения (PATCH /trips/:id, #151).
+   */
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'totalAmount — целое число (копейки)' })
+  @Min(0)
+  totalAmount?: number;
+
+  /**
+   * ISO 4217. Default RUB на уровне БД.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(3)
+  @MinLength(3)
+  currency?: string;
+}
+
+export interface CreateTripResponse {
+  tripId: string;
+}

--- a/apps/api/src/modules/trips/trips.controller.ts
+++ b/apps/api/src/modules/trips/trips.controller.ts
@@ -1,0 +1,38 @@
+/**
+ * TripsController — endpoints управления поездками.
+ *
+ * - POST /trips — создание Trip менеджером/админом (#150)
+ *
+ * Будущее: PATCH/DELETE/list, bookings nested — отдельные issues.
+ */
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+
+import { CreateTripDto, type CreateTripResponse } from './dto/create-trip.dto';
+import { TripsService } from './trips.service';
+import { CurrentUser, Roles } from '../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../common/auth/types';
+
+@Controller('trips')
+@Roles('manager', 'admin')
+export class TripsController {
+  constructor(private readonly trips: TripsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateTripDto,
+  ): Promise<CreateTripResponse> {
+    const totalAmount = dto.totalAmount !== undefined ? BigInt(dto.totalAmount) : undefined;
+    return this.trips.createTrip({
+      clientId: dto.clientId,
+      startsAt: new Date(dto.startsAt),
+      endsAt: new Date(dto.endsAt),
+      region: dto.region,
+      ...(totalAmount !== undefined ? { totalAmount } : {}),
+      ...(dto.currency !== undefined ? { currency: dto.currency } : {}),
+      createdBy: user.id,
+    });
+  }
+}

--- a/apps/api/src/modules/trips/trips.module.ts
+++ b/apps/api/src/modules/trips/trips.module.ts
@@ -1,0 +1,20 @@
+/**
+ * TripsModule — управление поездками клиентов.
+ *
+ * #149 — Prisma модели (Trip, Itinerary, DayPlan, Booking)
+ * #150 — POST /trips (manager/admin only)
+ * #151+ — editor versioning, status transitions, bookings nesting
+ */
+import { Module } from '@nestjs/common';
+
+import { TripsController } from './trips.controller';
+import { TripsService } from './trips.service';
+import { PrismaModule } from '../../common/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TripsController],
+  providers: [TripsService],
+  exports: [TripsService],
+})
+export class TripsModule {}

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -1,0 +1,95 @@
+/**
+ * TripsService — бизнес-логика модуля trips.
+ *
+ * Currently:
+ * - createTrip (#150) — создание Trip + outbox `trips.created`
+ *
+ * Будущее (#151+): editor versioning, status transitions, bookings nesting.
+ */
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import { OutboxService } from '../../common/outbox/outbox.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+export interface CreateTripInput {
+  clientId: string;
+  startsAt: Date;
+  endsAt: Date;
+  region: string;
+  totalAmount?: bigint | undefined;
+  currency?: string | undefined;
+  /** userId менеджера / admin'а, который создаёт поездку */
+  createdBy: string;
+}
+
+@Injectable()
+export class TripsService {
+  private readonly logger = new Logger(TripsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  /**
+   * Создание Trip в статусе draft. Публикует `trips.created` через outbox.
+   *
+   * Валидация:
+   * - endsAt > startsAt (пустой/обратный диапазон отклоняем)
+   * - clientId существует (cross-module lookup без FK)
+   *
+   * @throws BadRequestException — если endsAt <= startsAt
+   * @throws NotFoundException — если clientId не найден
+   */
+  async createTrip(input: CreateTripInput): Promise<{ tripId: string }> {
+    if (input.endsAt.getTime() <= input.startsAt.getTime()) {
+      throw new BadRequestException('endsAt должен быть позже startsAt');
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { id: input.clientId },
+      select: { id: true },
+    });
+    if (!client) {
+      throw new NotFoundException(`Client не найден: ${input.clientId}`);
+    }
+
+    const tripId = await this.prisma.$transaction(async (tx) => {
+      const trip = await tx.trip.create({
+        data: {
+          clientId: input.clientId,
+          startsAt: input.startsAt,
+          endsAt: input.endsAt,
+          region: input.region,
+          ...(input.totalAmount !== undefined ? { totalAmount: input.totalAmount } : {}),
+          ...(input.currency !== undefined ? { currency: input.currency } : {}),
+          createdBy: input.createdBy,
+          // status default = 'draft' в схеме
+        },
+        select: { id: true, region: true, startsAt: true, endsAt: true },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'trips.created',
+        schemaVersion: 1,
+        actor: { type: 'user', id: input.createdBy },
+        payload: {
+          tripId: trip.id,
+          clientId: input.clientId,
+          createdBy: input.createdBy,
+          region: trip.region,
+          startsAt: trip.startsAt.toISOString(),
+          endsAt: trip.endsAt.toISOString(),
+        },
+      });
+
+      return trip.id;
+    });
+
+    this.logger.log(
+      { tripId, clientId: input.clientId, createdBy: input.createdBy },
+      'trips.created',
+    );
+    return { tripId };
+  }
+}


### PR DESCRIPTION
## Summary

Ядро домена путешествий (Slice D): 4 Prisma модели + первый endpoint `POST /trips`.

| Commit | Closes |
|--------|--------|
| Trip + Itinerary + DayPlan + Booking schema + migration | #149 |
| POST /trips — manager/admin only | #150 |

## Что внутри

### #149 Schema

4 модели + 3 enum'а в `apps/api/prisma/schema.prisma`:

**Trip** — одна поездка клиента
- clientId (soft-ref на Client, cross-module no-FK)
- status: `draft | paid | in_progress | completed | cancelled`
- startsAt, endsAt, region (свободный текст: «Керала», «Раджастан»)
- totalAmount (BigInt копейки), currency (CHAR(3) default 'RUB')
- createdBy (soft-ref на User — обычно manager)

**Itinerary** — версия маршрута
- tripId, version (1..N), publishedAt (NULL = draft)
- Versioning для аудита и offline-cache (клиент видит старую пока не sync'нул)

**DayPlan** — детализация одного дня
- itineraryId, dayNumber, date (конкретная, не относительная как TourDay), summary, items (JSONB)
- items: массив plan-объектов (transfer/activity/etc.) — type-flexible JSON

**Booking** — одна бронь
- tripId, type: `hotel | transfer | activity | guide`
- vendorId (свободный string), status: `pending | confirmed | cancelled | failed`
- payload (JSONB type-specific shape), amount (BigInt в native currency)

Cross-module rule: Trip.clientId, Trip.createdBy — soft-refs без FK. Booking → Trip — FK ОК (тот же модуль).

Migration: `20260428110000_M5_D_001_trip_models`.

### #150 POST /trips

```
POST /trips → 201 + { tripId }
```

- `@Roles('manager', 'admin')` — клиент/гид/concierge не могут создавать поездки
- Validation: `endsAt > startsAt` (BadRequest), `clientId` существует (NotFound)
- Транзакция: trip.create + outbox event `trips.created`
- BigInt для totalAmount (точность копеек без float-проблем)
- createdBy = текущий user из JWT

DTO:
- clientId UUIDv4
- startsAt/endsAt ISO date
- region 2-100 chars
- totalAmount optional integer (копейки)
- currency optional 3-letter

## Что НЕ в этом PR (отдельные issues)

- **#151** itinerary versioning (PATCH /trips/:id/itinerary) — 6h, требует diff-engine
- **#160** trip status transitions — зависит от `finance.payment.received` event + cron
- **GET /trips, GET /trips/:id** — нет в backlog как отдельных issues; добавим когда будет фронтенд (`/trips/:id/today` #152)

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после `db:migrate:deploy`):**
  - Manager логинится
  - `POST /trips` с валидным clientId+startsAt+endsAt → 201, tripId
  - `POST /trips` с endsAt < startsAt → 400
  - `POST /trips` с несуществующим clientId → 404
  - Client (role=client) делает `POST /trips` → 403

## Closes

- Closes #149
- Closes #150

## Зависимости

- Базируется на main (PR #331, #332, #333 уже merged)
- Финальный PR из серии разбивки. Ветка `claude/setup-docker-compose-q2bde` после merge — можно удалить.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_