### PR TITLE
fix(db): hotfix — missing sessions table migration (#329)

### DIFF
--- a/apps/api/prisma/migrations/20260428140000_M5_B_003_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260428140000_M5_B_003_sessions/migration.sql
@@ -1,0 +1,28 @@
+-- M5.B.003 hotfix — Sessions table (login + refresh + logout)
+--
+-- Backfill: Session model был добавлен в schema.prisma в #128 (login + JWT)
+-- но миграция CREATE TABLE для него никогда не была сгенерирована. На staging
+-- /login падал с «table sessions does not exist» (см. отчёт Вики по issue #329).
+--
+-- Этот hotfix дополняет 0_init без изменений в применённой схеме где table уже
+-- была создана вручную (через Прислугу-Вику). Идемпотентность через IF NOT EXISTS,
+-- чтобы повторный применение на dev'е не упало.
+
+CREATE TABLE IF NOT EXISTS "sessions" (
+  "id"                 UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"            UUID NOT NULL,
+  "refresh_token_hash" TEXT NOT NULL,
+  "ip"                 TEXT,
+  "user_agent"         TEXT,
+  "created_at"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at"         TIMESTAMP(3) NOT NULL,
+  "revoked_at"         TIMESTAMP(3),
+  "revoke_reason"      TEXT,
+
+  CONSTRAINT "sessions_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id")
+    REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "idx_sessions_user_active" ON "sessions" ("user_id", "revoked_at");
+CREATE INDEX IF NOT EXISTS "idx_sessions_expires_ttl" ON "sessions" ("expires_at");


### PR DESCRIPTION
## Summary

Hotfix: добавляю отсутствующую миграцию для таблицы `sessions`.

## Что произошло

Вика на сервере 2.56.241.126 после `db:migrate:deploy` запустила `seed:admin` (#328), Admin создан. Roman попытался войти в `/login` → **«Не удалось войти»**. В логах api:
```
table "sessions" does not exist
```

Вика расследовала: `Session` model добавлен в `schema.prisma` в #128 (login + JWT, коммит `1fd944d`), но миграция, создающая таблицу `sessions`, **никогда не была сгенерирована**. Видимо разработчик #128 не запустил `prisma migrate dev`. `0_init` создаёт `users`, но не `sessions`.

Вика временно **создала таблицу вручную** на dev-БД — Roman залогинился. ✅

Но в репо миграция всё равно отсутствует — на любой свежей БД (другие dev-окружения, staging, prod в будущем) deploy упадёт. Этот PR дополняет недостающее.

## Что в PR

`apps/api/prisma/migrations/20260428140000_M5_B_003_sessions/migration.sql`:

```sql
CREATE TABLE IF NOT EXISTS "sessions" (
  id, user_id, refresh_token_hash, ip, user_agent,
  created_at, expires_at, revoked_at, revoke_reason
);
CREATE INDEX IF NOT EXISTS idx_sessions_user_active ...
CREATE INDEX IF NOT EXISTS idx_sessions_expires_ttl ...
```

**Ключевое: `IF NOT EXISTS`** — идемпотентность. На Викином dev'е таблица УЖЕ есть (она руками создала). Повторное применение не упадёт. На свежей БД — создастся нормально.

> **Рекомендация:** В CI на каждом PR'е добавить шаг `prisma migrate diff --from-schema-datamodel … --to-empty` или `prisma migrate status` — поймает рассинхронизацию schema.prisma vs migrations/ автоматически. **Почему:** этот баг должен был ловиться до merge, а не на проде. Открою отдельный issue после merge.

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] Вика на сервере: `docker compose run --rm api pnpm --filter api db:migrate:deploy` — миграция применится без ошибок (IF NOT EXISTS пропустит уже-существующую таблицу)
- [ ] Roman снова пробует `/login` — теперь должно сработать (Вика уже подтвердила что после ручной таблицы login работает)

## Closes

- Не закрывает отдельных issue (это hotfix). Косвенно завершает разблокировку #329.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_