### PR TITLE
feat(comm): ChatThread + ChatMessage Prisma модели (#167)

### DIFF
--- a/apps/api/prisma/migrations/20260428160000_M5_E_006_chat_models/migration.sql
+++ b/apps/api/prisma/migrations/20260428160000_M5_E_006_chat_models/migration.sql
@@ -1,0 +1,43 @@
+-- M5.E.006 — Chat models (issue #167)
+--
+-- ChatThread + ChatMessage. Schema-only (#167). REST endpoints — #169.
+-- WebSocket gateway — #168.
+--
+-- Cross-module rules:
+-- - subject_id, from_user_id, participants[] — soft-refs (нет FK)
+-- - thread_id (ChatMessage → ChatThread) — FK OK (один модуль)
+
+CREATE TYPE "chat_thread_kind" AS ENUM ('trip', 'sos', 'sales');
+CREATE TYPE "chat_thread_status" AS ENUM ('open', 'closed', 'archived');
+
+CREATE TABLE "chat_threads" (
+  "id"           UUID NOT NULL DEFAULT gen_random_uuid(),
+  "kind"         "chat_thread_kind" NOT NULL,
+  "subject_id"   UUID NOT NULL,
+  "participants" UUID[] NOT NULL DEFAULT '{}',
+  "status"       "chat_thread_status" NOT NULL DEFAULT 'open',
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"   TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "chat_threads_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "idx_chat_threads_kind_subject" ON "chat_threads" ("kind", "subject_id");
+CREATE INDEX "idx_chat_threads_status_updated" ON "chat_threads" ("status", "updated_at" DESC);
+
+CREATE TABLE "chat_messages" (
+  "id"            UUID NOT NULL DEFAULT gen_random_uuid(),
+  "thread_id"     UUID NOT NULL,
+  "from_user_id"  UUID NOT NULL,
+  "body"          TEXT NOT NULL,
+  "attachments"   UUID[] NOT NULL DEFAULT '{}',
+  "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "read_by"       JSONB NOT NULL DEFAULT '{}',
+
+  CONSTRAINT "chat_messages_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "chat_messages_thread_id_fkey" FOREIGN KEY ("thread_id")
+    REFERENCES "chat_threads" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "idx_chat_messages_thread_created" ON "chat_messages" ("thread_id", "created_at" DESC);
+CREATE INDEX "idx_chat_messages_from_user_created" ON "chat_messages" ("from_user_id", "created_at" DESC);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -723,3 +723,94 @@ model Booking {
   @@index([status, createdAt], map: "idx_bookings_status_created")
   @@map("bookings")
 }
+
+// === comm модуль (#162+ [M5.E]) ===
+//
+// Источник: docs/BACKLOG/M5/E_COMM.md, docs/ARCH/MICROSERVICES.md § comm-svc.
+// comm — переписка между клиентом, менеджером, concierge, гидом + нотификации.
+// Чат — основная коммуникация в активной поездке (вместо WhatsApp/Telegram).
+//
+// Cross-module rule:
+// - ChatThread.subjectId — soft-ref на Trip/SosEvent/Lead (cross-module)
+// - ChatMessage.fromUserId — soft-ref на User
+// - ChatMessage → ChatThread — FK ОК (один модуль)
+
+/// Тип чата определяет subjectId и default-participant'ов.
+/// - trip:  переписка по поездке (clientId + managerId + concierge'и)
+/// - sos:   SOS-инцидент (clientId + concierge + гид)
+/// - sales: pre-trip переписка (leadId + manager)
+enum ChatThreadKind {
+  trip
+  sos
+  sales
+
+  @@map("chat_thread_kind")
+}
+
+enum ChatThreadStatus {
+  open
+  closed
+  archived
+
+  @@map("chat_thread_status")
+}
+
+/// ChatThread — переписка по конкретному объекту (trip/sos/sales-deal).
+/// participants — массив user.id; меняется при escalation (concierge на дежурстве,
+/// гид присоединяется при старте поездки).
+///
+/// Один Thread на subjectId+kind в идеале — но не enforced unique (для legacy
+/// переписок при reopened sales-deal'е). Если важно — добавим partial unique
+/// `(kind, subject_id) WHERE status='open'` в отдельной миграции.
+model ChatThread {
+  id           String           @id @default(uuid()) @db.Uuid
+  kind         ChatThreadKind
+  /// Soft-reference на основной объект:
+  /// - kind=trip  → Trip.id
+  /// - kind=sos   → SosEvent.id (модель будет в #192)
+  /// - kind=sales → Lead.id (модель из #297)
+  subjectId    String           @map("subject_id") @db.Uuid
+  /// Массив user.id (UUID) — soft-refs на User. cross-module policy.
+  participants String[]         @default([])
+  status       ChatThreadStatus @default(open)
+  createdAt    DateTime         @default(now()) @map("created_at")
+  updatedAt    DateTime         @updatedAt @map("updated_at")
+
+  messages ChatMessage[]
+
+  /// Поиск всех threads по конкретному объекту: GET /trips/:id → его chat thread.
+  @@index([kind, subjectId], map: "idx_chat_threads_kind_subject")
+  /// Inbox-стиль листинг: открытые threads, отсортированные по последней активности.
+  @@index([status, updatedAt(sort: Desc)], map: "idx_chat_threads_status_updated")
+  @@map("chat_threads")
+}
+
+/// ChatMessage — одно сообщение в thread'е.
+/// readBy — JSONB: { userId: ISO-timestamp }, заполняется при просмотре сообщения
+/// клиентом (UI делает PATCH /messages/:id/read).
+///
+/// attachments — массив MediaAsset.id (модель будет в #173). Сейчас просто
+/// String[] — без FK, без валидации существования asset'а на schema-уровне.
+/// Service будет проверять при write (когда media-svc появится).
+model ChatMessage {
+  id          String   @id @default(uuid()) @db.Uuid
+  threadId    String   @map("thread_id") @db.Uuid
+  /// Soft-reference на users.id. cross-module policy.
+  fromUserId  String   @map("from_user_id") @db.Uuid
+  /// Plain-text сообщение. Markdown rendering на клиенте (V2).
+  body        String
+  /// MediaAsset.id (UUID) массив. Поддержка после #173.
+  attachments String[] @default([])
+  createdAt   DateTime @default(now()) @map("created_at")
+  /// JSONB: { "<userId>": "<ISO timestamp>" }. Кто и когда прочитал.
+  /// `{}` = ещё никто (включая отправителя — отправка ≠ чтение).
+  readBy      Json     @default("{}") @map("read_by")
+
+  thread ChatThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+
+  /// Главный hot-path: загрузка thread'а — последние N сообщений.
+  @@index([threadId, createdAt(sort: Desc)], map: "idx_chat_messages_thread_created")
+  /// Поиск «всё что писал user» — для расследования (#218 audit cross-ref).
+  @@index([fromUserId, createdAt(sort: Desc)], map: "idx_chat_messages_from_user_created")
+  @@map("chat_messages")
+}


### PR DESCRIPTION
## Summary

Schema-only PR для модуля comm: ChatThread + ChatMessage. Закрывает #167.

REST endpoints — #169, WebSocket gateway — #168, оба отдельными PR'ами.

## Что внутри

### Schema

```prisma
enum ChatThreadKind   { trip | sos | sales }
enum ChatThreadStatus { open | closed | archived }

model ChatThread {
  id, kind, subject_id (soft-ref → Trip/SosEvent/Lead),
  participants UUID[] (soft-refs → User),
  status, timestamps
}

model ChatMessage {
  id, thread_id (FK), from_user_id (soft-ref → User),
  body, attachments UUID[] (future MediaAsset #173), 
  read_by JSONB { userId: ISO-timestamp },
  created_at
}
```

### Cross-module rules (CLAUDE.md princip 5)

| Reference | Тип | Why |
|---|---|---|
| `subject_id` → Trip/SosEvent/Lead | soft-ref | cross-module (trips/sos/leads разные модули) |
| `participants` → User | soft-ref UUID[] | cross-module (auth) |
| `from_user_id` → User | soft-ref | cross-module (auth) |
| `attachments` → MediaAsset | soft-ref | модели ещё нет (#173 запланирован) |
| `thread_id` → ChatThread | FK | один модуль comm — OK |

### Индексы

- `chat_threads (kind, subject_id)` — поиск thread по конкретному объекту, например `GET /trips/:id` → его chat
- `chat_threads (status, updated_at DESC)` — inbox-стиль листинг открытых threads
- `chat_messages (thread_id, created_at DESC)` — hot-path загрузки последних N сообщений в thread'е
- `chat_messages (from_user_id, created_at DESC)` — для cross-ref в audit-log (#218)

### `read_by` shape

```json
{
  "userId-uuid-1": "2026-04-28T10:00:00Z",
  "userId-uuid-2": "2026-04-28T10:05:30Z"
}
```

Заполняется в #169 endpoint'е `PATCH /messages/:id/read`. `{}` = никто не прочитал (отправитель тоже не считается прочитавшим автоматически — в современных мессенджерах он сам ставит read mark когда возвращается в чат).

## Что НЕ в этом PR

- **REST endpoints** (POST /chat-threads, GET /chat-threads/:id/messages, etc.) → **#169**
- **WebSocket gateway** для realtime → **#168**  
- **Notification preferences** → **#166**
- **Sales/SOS-специфичный flow** (escalation, AML-flagging chat) → отдельные issues после #169

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после `db:migrate:deploy`):**
  - Таблицы `chat_threads` и `chat_messages` созданы
  - Enums `chat_thread_kind`, `chat_thread_status` существуют
  - Все 4 индекса присутствуют (`\d chat_threads`, `\d chat_messages`)

## Closes

- Closes #167

## Связано

- Базируется на main (PR #339 audit endpoint уже merged)
- Разблокирует: #168 WebSocket gateway, #169 REST endpoints
- Не блокирует: #166 notification preferences, #162 comm-svc base

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_