### PR TITLE
feat(comm): notification base + email-провайдер + welcome listener (#162)

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -3,6 +3,13 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      {
+        "include": "modules/comm/templates/**/*.hbs",
+        "outDir": "dist"
+      }
+    ],
+    "watchAssets": true
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,9 @@
     "argon2": "^0.41.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "handlebars": "^4.7.9",
     "ioredis": "^5.4.1",
+    "nodemailer": "^8.0.7",
     "otplib": "^13.4.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
@@ -47,6 +49,7 @@
     "@nestjs/schematics": "^10.2.3",
     "@types/express": "^4.17.21",
     "@types/node": "^20.16.13",
+    "@types/nodemailer": "^8.0.0",
     "@types/zxcvbn": "^4.4.5",
     "prisma": "^5.21.1",
     "ts-node": "^10.9.2"

--- a/apps/api/prisma/migrations/20260428170000_M5_E_001_notifications/migration.sql
+++ b/apps/api/prisma/migrations/20260428170000_M5_E_001_notifications/migration.sql
@@ -1,0 +1,28 @@
+-- M5.E.001 — Notification base модель (issue #162)
+--
+-- Запись об отправке любой нотификации (email/push/sms/telegram).
+-- Provider-specific детали (SMTP server, FCM token, etc.) — НЕ в этой таблице,
+-- а в env. Notification — bookkeeping что и кому отправили.
+
+CREATE TYPE "notification_channel" AS ENUM ('email', 'push', 'sms', 'telegram');
+CREATE TYPE "notification_status" AS ENUM ('pending', 'sent', 'failed');
+
+CREATE TABLE "notifications" (
+  "id"            UUID NOT NULL DEFAULT gen_random_uuid(),
+  "channel"       "notification_channel" NOT NULL,
+  "recipient"     TEXT NOT NULL,
+  "template_id"   TEXT NOT NULL,
+  "payload"       JSONB NOT NULL,
+  "status"        "notification_status" NOT NULL DEFAULT 'pending',
+  "sent_at"       TIMESTAMP(3),
+  "failed_at"     TIMESTAMP(3),
+  "error_message" TEXT,
+  "user_id"       UUID,
+  "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "idx_notifications_status_created" ON "notifications" ("status", "created_at");
+CREATE INDEX "idx_notifications_recipient_created" ON "notifications" ("recipient", "created_at" DESC);
+CREATE INDEX "idx_notifications_user_created" ON "notifications" ("user_id", "created_at" DESC);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -814,3 +814,68 @@ model ChatMessage {
   @@index([fromUserId, createdAt(sort: Desc)], map: "idx_chat_messages_from_user_created")
   @@map("chat_messages")
 }
+
+/// Канал доставки нотификации (#162). Сначала email; push/sms/telegram —
+/// последующие issue (#163, #164, #165). Каждый канал имеет свой провайдер
+/// (EmailProvider, PushProvider, etc.) с общим интерфейсом NotifyService.
+enum NotificationChannel {
+  email
+  push
+  sms
+  telegram
+
+  @@map("notification_channel")
+}
+
+enum NotificationStatus {
+  /// Создана, ещё не отправлялась (или в очереди retry).
+  pending
+  /// Успешно отправлена провайдером (delivered=ok с точки зрения SMTP/FCM).
+  sent
+  /// Permanent fail (invalid address, blocked by recipient, etc.).
+  /// Retry уже не имеет смысла.
+  failed
+
+  @@map("notification_status")
+}
+
+/// Notification — запись об отправке сообщения по любому каналу (#162).
+///
+/// Создаётся при NotifyService.send(). Status pending → sent | failed после
+/// попытки доставки провайдером. Outbox-event `comm.message.sent` или
+/// `comm.message.failed` публикуется в той же транзакции.
+///
+/// payload — данные для template-render'а (НЕ финальный текст). Финальный
+/// текст рендерится из template (apps/api/src/modules/comm/templates/) +
+/// payload во время send. Это позволяет задним числом изменить шаблон без
+/// изменения исторических Notification-записей.
+///
+/// Cross-module: recipient — свободный string (email/phone/push-token).
+/// userId опционален — для transactional notifications привязан к юзеру,
+/// для marketing/system без user'а.
+model Notification {
+  id           String              @id @default(uuid()) @db.Uuid
+  channel      NotificationChannel
+  /// email-address / E.164 phone / FCM-token / Telegram chat_id.
+  recipient    String
+  /// Имя template'а (например 'welcome', 'password-reset', 'sos-alert').
+  /// Файл template — apps/api/src/modules/comm/templates/<id>/{subject,body}.hbs.
+  templateId   String              @map("template_id")
+  /// JSONB — данные для подстановки в Handlebars-шаблон.
+  payload      Json
+  status       NotificationStatus  @default(pending)
+  /// NULL до успешной отправки.
+  sentAt       DateTime?           @map("sent_at")
+  /// NULL пока не упало; заполняется при permanent fail.
+  failedAt     DateTime?           @map("failed_at")
+  /// Сообщение об ошибке провайдера (для diag). Не показываем клиенту.
+  errorMessage String?             @map("error_message")
+  /// Soft-ref на User (cross-module), опционально. Для transactional notifications.
+  userId       String?             @map("user_id") @db.Uuid
+  createdAt    DateTime            @default(now()) @map("created_at")
+
+  @@index([status, createdAt], map: "idx_notifications_status_created")
+  @@index([recipient, createdAt(sort: Desc)], map: "idx_notifications_recipient_created")
+  @@index([userId, createdAt(sort: Desc)], map: "idx_notifications_user_created")
+  @@map("notifications")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuditModule } from './modules/audit/audit.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { CatalogModule } from './modules/catalog/catalog.module';
 import { ClientsModule } from './modules/clients/clients.module';
+import { CommModule } from './modules/comm/comm.module';
 import { HealthModule } from './modules/health/health.module';
 import { LeadsModule } from './modules/leads/leads.module';
 import { TripsModule } from './modules/trips/trips.module';
@@ -33,6 +34,7 @@ import { TripsModule } from './modules/trips/trips.module';
     CatalogModule,
     LeadsModule,
     TripsModule,
+    CommModule,
     AuditModule,
     CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
     HealthModule,

--- a/apps/api/src/modules/comm/comm.module.ts
+++ b/apps/api/src/modules/comm/comm.module.ts
@@ -1,0 +1,61 @@
+/**
+ * CommModule — comm-svc base + email (#162).
+ *
+ * Provides:
+ * - NotifyService — единая точка отправки нотификаций
+ * - TemplateService — Handlebars-рендер шаблонов
+ * - EmailProvider — switchable: SmtpEmailProvider если SMTP_HOST задан,
+ *   LogEmailProvider иначе (dev fallback)
+ *
+ * Listeners:
+ * - WelcomeEmailListener — auth.user.registered → welcome email
+ *   (см. welcome.listener.ts; через subscribe в onModuleInit)
+ *
+ * Будущее (отдельные issues):
+ * - #163 push (FCM/APNs)
+ * - #164 SMS (Twilio + российский провайдер)
+ * - #165 Telegram bot
+ * - #166 notification preferences
+ * - #134 password reset (использует NotifyService)
+ * - #136 suspicious-session alert (использует NotifyService)
+ */
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+import { NotifyService } from './notify.service';
+import { EMAIL_PROVIDER, type EmailProvider } from './providers/email.provider';
+import { LogEmailProvider } from './providers/log-email.provider';
+import { SmtpEmailProvider } from './providers/smtp-email.provider';
+import { TemplateService } from './template.service';
+import { WelcomeEmailListener } from './listeners/welcome.listener';
+import { EventsBusModule } from '../../common/events-bus/events-bus.module';
+import { PrismaModule } from '../../common/prisma/prisma.module';
+
+@Global()
+@Module({
+  imports: [PrismaModule, EventsBusModule, ConfigModule],
+  providers: [
+    NotifyService,
+    TemplateService,
+    LogEmailProvider,
+    SmtpEmailProvider,
+    {
+      // Switchable provider: SMTP в проде если SMTP_HOST задан, иначе log-stub.
+      // Это позволяет dev-окружениям без SMTP-credentials всё равно проходить
+      // тесты и smoke-проверки (NotifyService.send() работает, просто пишет в логи).
+      provide: EMAIL_PROVIDER,
+      inject: [ConfigService, SmtpEmailProvider, LogEmailProvider],
+      useFactory: (
+        config: ConfigService,
+        smtp: SmtpEmailProvider,
+        log: LogEmailProvider,
+      ): EmailProvider => {
+        const host = config.get<string>('SMTP_HOST');
+        return host ? smtp : log;
+      },
+    },
+    WelcomeEmailListener,
+  ],
+  exports: [NotifyService],
+})
+export class CommModule {}

--- a/apps/api/src/modules/comm/listeners/welcome.listener.ts
+++ b/apps/api/src/modules/comm/listeners/welcome.listener.ts
@@ -1,0 +1,98 @@
+/**
+ * WelcomeEmailListener — отправка welcome email при auth.user.registered (#162).
+ *
+ * Подписывается на event_type=`auth.user.registered`. При получении:
+ * 1. Извлекает email + role из payload
+ * 2. Вызывает NotifyService.send({channel: 'email', templateId: 'welcome', ...})
+ * 3. NotifyService уже сам пишет Notification record + outbox events
+ *
+ * Идемпотентность: гарантирована через events-bus → idempotency.service
+ * (processed_events таблица). Этот listener — обычный consumer, при retry
+ * пропускается.
+ *
+ * Failure handling: если email не отправился, throw'аем — events-bus не ack'нет
+ * сообщение, оно попадёт в retry. После N попыток → DLQ (см. outbox-relay.worker
+ * MAX_ATTEMPTS).
+ */
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { NotifyService } from '../notify.service';
+import { EventsBusService } from '../../../common/events-bus/events-bus.service';
+
+import type { DomainEvent } from '../../../common/events-bus/types';
+
+interface UserRegisteredPayload {
+  userId: string;
+  email: string;
+  role: string;
+  source?: string;
+}
+
+@Injectable()
+export class WelcomeEmailListener implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WelcomeEmailListener.name);
+  private subscription: { stop: () => void } | null = null;
+
+  constructor(
+    private readonly bus: EventsBusService,
+    private readonly notify: NotifyService,
+    private readonly config: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscription = this.bus.subscribe<UserRegisteredPayload>(
+      'auth.user.registered',
+      this.handleEvent.bind(this),
+      {
+        consumerGroup: 'comm-svc-welcome',
+        consumerName: 'welcome-1',
+      },
+    );
+    this.logger.log('welcome.listener.started');
+  }
+
+  onModuleDestroy(): void {
+    this.subscription?.stop();
+    this.subscription = null;
+  }
+
+  private async handleEvent(event: DomainEvent<UserRegisteredPayload>): Promise<void> {
+    const { userId, email, role } = event.payload;
+
+    // Welcome email только для роли client. Manager/admin/finance заводятся
+    // вручную и не нуждаются в onboarding-emails.
+    if (role !== 'client') {
+      this.logger.debug({ userId, role }, 'welcome.skip.non-client');
+      return;
+    }
+
+    const appUrl = this.config.get<string>('APP_URL', 'https://indiahorizone.ru');
+
+    try {
+      await this.notify.send({
+        channel: 'email',
+        to: email,
+        templateId: 'welcome',
+        data: {
+          // firstName пока недоступен (профиль ещё пустой при register).
+          // При появлении ProfileCompleted event'а — отдельный onboarding email.
+          firstName: '',
+          appUrl,
+        },
+        userId,
+      });
+    } catch (err) {
+      // Re-throw — events-bus retry-цикл подхватит. После MAX_ATTEMPTS попыток
+      // outbox пометит как DLQ (#218 audit видит auth.user.registered в любом
+      // случае, даже без welcome email).
+      this.logger.error({ err, userId, email }, 'welcome.email.failed');
+      throw err;
+    }
+  }
+}

--- a/apps/api/src/modules/comm/notify.service.ts
+++ b/apps/api/src/modules/comm/notify.service.ts
@@ -1,0 +1,145 @@
+/**
+ * NotifyService — единая точка отправки нотификаций (#162).
+ *
+ * Поток:
+ * 1. Создаём Notification record (status=pending).
+ * 2. Render template (subject + body) через TemplateService.
+ * 3. Provider.send() — для email = SmtpEmailProvider или LogEmailProvider.
+ * 4. Update status (sent/failed) + outbox event:
+ *    - comm.message.sent — успешная отправка
+ *    - comm.message.failed — permanent fail (не для retry, а для алертов)
+ *
+ * Failure handling:
+ * - throw на ошибке провайдера → caller (например auth-listener) увидит
+ *   не-критичный fail в логах. Email-fail не должен ломать business-flow
+ *   (например, register прошёл — даже если welcome email не ушёл).
+ * - Retry mechanism — НЕ в этом V1. Будущее: scheduled-job для pending
+ *   старше 5 минут с exponential backoff.
+ *
+ * V1 ограничения:
+ * - Только email channel поддерживается. Push/SMS/Telegram — в #163/#164/#165.
+ * - Templates только email/welcome. Расширяется добавлением директорий.
+ */
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import {
+  EMAIL_PROVIDER,
+  type EmailProvider,
+} from './providers/email.provider';
+import { TemplateService } from './template.service';
+import { OutboxService } from '../../common/outbox/outbox.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+import type { NotificationChannel } from '@prisma/client';
+
+export interface SendInput {
+  channel: NotificationChannel;
+  to: string;
+  templateId: string;
+  data: Record<string, unknown>;
+  /** Опционально: связать notification с user'ом (transactional context) */
+  userId?: string;
+}
+
+@Injectable()
+export class NotifyService {
+  private readonly logger = new Logger(NotifyService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+    private readonly templates: TemplateService,
+    @Inject(EMAIL_PROVIDER) private readonly emailProvider: EmailProvider,
+  ) {}
+
+  async send(input: SendInput): Promise<{ notificationId: string }> {
+    if (input.channel !== 'email') {
+      throw new NotFoundException(
+        `Channel "${input.channel}" пока не реализован (#163/#164/#165)`,
+      );
+    }
+    if (!this.templates.exists(input.templateId)) {
+      throw new NotFoundException(`Template "${input.templateId}" не найден`);
+    }
+
+    const notification = await this.prisma.notification.create({
+      data: {
+        channel: input.channel,
+        recipient: input.to,
+        templateId: input.templateId,
+        payload: input.data as object,
+        status: 'pending',
+        ...(input.userId !== undefined ? { userId: input.userId } : {}),
+      },
+      select: { id: true },
+    });
+
+    const rendered = this.templates.render(input.templateId, input.data);
+
+    try {
+      const result = await this.emailProvider.send({
+        to: input.to,
+        subject: rendered.subject,
+        html: rendered.body,
+      });
+
+      await this.prisma.$transaction(async (tx) => {
+        await tx.notification.update({
+          where: { id: notification.id },
+          data: { status: 'sent', sentAt: new Date() },
+        });
+
+        await this.outbox.add(tx, {
+          type: 'comm.message.sent',
+          schemaVersion: 1,
+          actor: { type: 'system' },
+          payload: {
+            notificationId: notification.id,
+            channel: input.channel,
+            templateId: input.templateId,
+            // recipient НЕ публикуем — может быть ПДн (email/phone)
+            providerMessageId: result.messageId,
+            ...(input.userId !== undefined ? { userId: input.userId } : {}),
+          },
+        });
+      });
+
+      this.logger.log(
+        { notificationId: notification.id, templateId: input.templateId },
+        'comm.message.sent',
+      );
+      return { notificationId: notification.id };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+
+      await this.prisma.$transaction(async (tx) => {
+        await tx.notification.update({
+          where: { id: notification.id },
+          data: { status: 'failed', failedAt: new Date(), errorMessage },
+        });
+
+        await this.outbox.add(tx, {
+          type: 'comm.message.failed',
+          schemaVersion: 1,
+          actor: { type: 'system' },
+          payload: {
+            notificationId: notification.id,
+            channel: input.channel,
+            templateId: input.templateId,
+            errorMessage,
+            ...(input.userId !== undefined ? { userId: input.userId } : {}),
+          },
+        });
+      });
+
+      this.logger.error(
+        { err, notificationId: notification.id, templateId: input.templateId },
+        'comm.message.failed',
+      );
+      // Re-throw чтобы caller знал. Но: caller (например auth-listener)
+      // должен ОБРАБОТАТЬ ошибку и не падать — email-fail не критичен для
+      // основного business flow.
+      throw err;
+    }
+  }
+}

--- a/apps/api/src/modules/comm/providers/email.provider.ts
+++ b/apps/api/src/modules/comm/providers/email.provider.ts
@@ -1,0 +1,34 @@
+/**
+ * EmailProvider — общий интерфейс для всех email-транспортов (#162).
+ *
+ * Реализации:
+ * - LogEmailProvider — dev/test stub. Логирует и возвращает success.
+ * - SmtpEmailProvider — production. nodemailer с SMTP relay (Yandex/Mailgun/etc.)
+ *
+ * Выбор реализации в comm.module.ts по env (SMTP_HOST задан → smtp; иначе log).
+ *
+ * DKIM: при использовании SMTP relay (Mailgun, Postmark, Yandex.Mail Business)
+ * подпись DKIM делается на их стороне — доменная аутентификация настраивается
+ * через DNS-записи провайдера. Inline DKIM (через приватный ключ в env) можно
+ * добавить позже опцией `dkim` у nodemailer.createTransport — но для V1
+ * relay-side подпись проще и надёжнее.
+ */
+
+export interface EmailMessage {
+  to: string;
+  /** Subject отрендеренный из шаблона. */
+  subject: string;
+  /** HTML-body. Plain-text fallback генерируется автоматом из HTML. */
+  html: string;
+}
+
+export interface EmailSendResult {
+  /** ID сообщения от провайдера (для трейсинга в логах SMTP relay). */
+  messageId: string;
+}
+
+export const EMAIL_PROVIDER = Symbol('EmailProvider');
+
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<EmailSendResult>;
+}

--- a/apps/api/src/modules/comm/providers/log-email.provider.ts
+++ b/apps/api/src/modules/comm/providers/log-email.provider.ts
@@ -1,0 +1,39 @@
+/**
+ * LogEmailProvider — dev/test stub email-провайдера (#162).
+ *
+ * Не отправляет email-ы реально. Только логирует subject + recipient + первые
+ * 200 символов HTML. Используется когда SMTP_HOST не задан в env (типично dev
+ * без credentials и CI-тесты).
+ *
+ * Возвращает синтетический messageId с timestamp'ом, чтобы caller имел
+ * стабильный ID в логах.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { Injectable, Logger } from '@nestjs/common';
+
+import {
+  type EmailMessage,
+  type EmailProvider,
+  type EmailSendResult,
+} from './email.provider';
+
+@Injectable()
+export class LogEmailProvider implements EmailProvider {
+  private readonly logger = new Logger(LogEmailProvider.name);
+
+  send(message: EmailMessage): Promise<EmailSendResult> {
+    const messageId = `log-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const preview = message.html.slice(0, 200).replace(/\s+/g, ' ');
+    this.logger.log(
+      {
+        to: message.to,
+        subject: message.subject,
+        htmlPreview: preview,
+        messageId,
+      },
+      'email.send.stub',
+    );
+    return Promise.resolve({ messageId });
+  }
+}

--- a/apps/api/src/modules/comm/providers/smtp-email.provider.ts
+++ b/apps/api/src/modules/comm/providers/smtp-email.provider.ts
@@ -1,0 +1,79 @@
+/**
+ * SmtpEmailProvider — production email через SMTP relay (#162).
+ *
+ * Использует nodemailer с настройками из env:
+ *   SMTP_HOST, SMTP_PORT (default 587), SMTP_USER, SMTP_PASS,
+ *   EMAIL_FROM (например 'IndiaHorizone <noreply@indiahorizone.ru>')
+ *
+ * Рекомендуемые SMTP-relays для русскоязычной аудитории:
+ * - Yandex 360 для бизнеса (smtp.yandex.ru:465 SSL) — лучшая deliverability в RU
+ * - Mailgun (smtp.mailgun.org:587 STARTTLS)
+ * - Postmark (smtp.postmarkapp.com:587)
+ *
+ * DKIM: настраивается на стороне SMTP-relay через DNS-записи (CNAME / TXT)
+ * домена indiahorizone.ru. Inline DKIM (через ключ в env) можно добавить
+ * параметром `dkim:` у createTransport если потребуется в будущем.
+ *
+ * Pool: nodemailer создаёт connection pool при `pool: true` — несколько
+ * email-ов через одно SMTP-соединение, быстрее.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { type Transporter, createTransport } from 'nodemailer';
+
+import {
+  type EmailMessage,
+  type EmailProvider,
+  type EmailSendResult,
+} from './email.provider';
+
+@Injectable()
+export class SmtpEmailProvider implements EmailProvider {
+  private readonly logger = new Logger(SmtpEmailProvider.name);
+  private readonly transporter: Transporter;
+  private readonly fromAddress: string;
+
+  constructor(private readonly config: ConfigService) {
+    const host = config.get<string>('SMTP_HOST');
+    if (!host) {
+      // Defensive: должен использоваться LogEmailProvider если SMTP_HOST не задан.
+      // comm.module.ts выбирает реализацию — сюда не должны попасть без host.
+      throw new Error('SMTP_HOST не задан — провайдер не должен инициализироваться');
+    }
+
+    const port = Number(config.get<string>('SMTP_PORT', '587'));
+    const user = config.get<string>('SMTP_USER');
+    const pass = config.get<string>('SMTP_PASS');
+
+    this.transporter = createTransport({
+      host,
+      port,
+      // 465 = implicit TLS, 587/25 = STARTTLS upgrade.
+      secure: port === 465,
+      auth: user && pass ? { user, pass } : undefined,
+      pool: true,
+      maxConnections: 5,
+      maxMessages: 100,
+    });
+
+    this.fromAddress = config.get<string>(
+      'EMAIL_FROM',
+      'IndiaHorizone <noreply@indiahorizone.ru>',
+    );
+
+    this.logger.log({ host, port, from: this.fromAddress }, 'smtp.transport.created');
+  }
+
+  async send(message: EmailMessage): Promise<EmailSendResult> {
+    const info = await this.transporter.sendMail({
+      from: this.fromAddress,
+      to: message.to,
+      subject: message.subject,
+      html: message.html,
+      // Plain-text fallback генерируется nodemailer'ом из html, если не указан.
+      // Лучше так чем без plain-text (anti-spam системы понижают рейтинг).
+    });
+
+    return { messageId: info.messageId };
+  }
+}

--- a/apps/api/src/modules/comm/template.service.ts
+++ b/apps/api/src/modules/comm/template.service.ts
@@ -1,0 +1,96 @@
+/**
+ * TemplateService — Handlebars-рендер шаблонов писем (#162).
+ *
+ * Шаблоны лежат в apps/api/src/modules/comm/templates/<id>/{subject,body}.hbs.
+ * При onModuleInit пред-компилируются (быстрый рендер на send'е).
+ *
+ * Соглашения:
+ * - subject.hbs   — одна строка, без переносов
+ * - body.hbs      — HTML email body
+ * - Имя шаблона = имя директории (например 'welcome', 'password-reset')
+ *
+ * Подстановка переменных через стандартный Handlebars `{{name}}`. HTML-escape
+ * по умолчанию для всех значений → защита от XSS-injection в email-body.
+ *
+ * Helpers (доступны во всех шаблонах):
+ * - {{tFmt date "DD.MM.YYYY"}} — будут добавлены при необходимости (пока нет).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  type OnModuleInit,
+} from '@nestjs/common';
+import Handlebars from 'handlebars';
+
+interface CompiledTemplate {
+  subject: HandlebarsTemplateDelegate;
+  body: HandlebarsTemplateDelegate;
+}
+
+export interface RenderedTemplate {
+  subject: string;
+  body: string;
+}
+
+const TEMPLATES_DIR = join(__dirname, 'templates');
+
+@Injectable()
+export class TemplateService implements OnModuleInit {
+  private readonly logger = new Logger(TemplateService.name);
+  private readonly compiled = new Map<string, CompiledTemplate>();
+
+  onModuleInit(): void {
+    try {
+      const dirs = readdirSync(TEMPLATES_DIR).filter((entry) => {
+        const path = join(TEMPLATES_DIR, entry);
+        return statSync(path).isDirectory();
+      });
+
+      for (const id of dirs) {
+        const subjectPath = join(TEMPLATES_DIR, id, 'subject.hbs');
+        const bodyPath = join(TEMPLATES_DIR, id, 'body.hbs');
+        try {
+          const subjectSrc = readFileSync(subjectPath, 'utf8').trim();
+          const bodySrc = readFileSync(bodyPath, 'utf8');
+          this.compiled.set(id, {
+            subject: Handlebars.compile(subjectSrc, { noEscape: false }),
+            body: Handlebars.compile(bodySrc, { noEscape: false }),
+          });
+          this.logger.debug({ templateId: id }, 'template.compiled');
+        } catch (err) {
+          this.logger.warn(
+            { err, templateId: id, subjectPath, bodyPath },
+            'template.compile.failed',
+          );
+        }
+      }
+
+      this.logger.log({ count: this.compiled.size }, 'templates.loaded');
+    } catch (err) {
+      this.logger.warn({ err, dir: TEMPLATES_DIR }, 'templates.dir.missing');
+    }
+  }
+
+  /**
+   * Рендерит шаблон с переданными data. Throws NotFoundException если шаблон
+   * отсутствует (caller обязан проверить templateId до вызова).
+   */
+  render(templateId: string, data: Record<string, unknown>): RenderedTemplate {
+    const tpl = this.compiled.get(templateId);
+    if (!tpl) {
+      throw new NotFoundException(`Email template не найден: ${templateId}`);
+    }
+    return {
+      subject: tpl.subject(data),
+      body: tpl.body(data),
+    };
+  }
+
+  exists(templateId: string): boolean {
+    return this.compiled.has(templateId);
+  }
+}

--- a/apps/api/src/modules/comm/templates/welcome/body.hbs
+++ b/apps/api/src/modules/comm/templates/welcome/body.hbs
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Добро пожаловать в IndiaHorizone</title>
+</head>
+<body style="margin:0; padding:0; background:#f7f4ee; font-family: 'Helvetica Neue', Arial, sans-serif; color:#222;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f7f4ee; padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="background:#ffffff; border-radius:12px; padding:40px 32px; max-width:600px;">
+          <tr>
+            <td style="font-size:24px; font-weight:600; color:#222; padding-bottom:16px;">
+              Здравствуйте{{#if firstName}}, {{firstName}}{{/if}}!
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:16px; line-height:1.5; color:#444; padding-bottom:24px;">
+              Спасибо, что зарегистрировались в IndiaHorizone — tech-enabled India concierge для русскоязычных путешественников.
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:16px; line-height:1.5; color:#444; padding-bottom:16px;">
+              Что дальше:
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:15px; line-height:1.6; color:#444; padding-bottom:8px;">
+              • Заполните профиль в личном кабинете — это ускорит подбор поездки.
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:15px; line-height:1.6; color:#444; padding-bottom:8px;">
+              • Просмотрите готовые маршруты — Керала, Раджастан, Гоа.
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:15px; line-height:1.6; color:#444; padding-bottom:24px;">
+              • Свяжитесь с нами в Telegram, если есть вопросы.
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:8px 0 24px 0;">
+              <a href="{{appUrl}}/profile"
+                 style="display:inline-block; background:#e07a3c; color:#ffffff; text-decoration:none; padding:14px 28px; border-radius:8px; font-weight:600; font-size:16px;">
+                Перейти в личный кабинет
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="font-size:13px; color:#888; padding-top:24px; border-top:1px solid #eee;">
+              Если письмо попало к вам по ошибке — просто проигнорируйте его.<br>
+              IndiaHorizone — путешествия в Индию без хаоса.
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/apps/api/src/modules/comm/templates/welcome/subject.hbs
+++ b/apps/api/src/modules/comm/templates/welcome/subject.hbs
@@ -1,0 +1,1 @@
+Добро пожаловать в IndiaHorizone, {{firstName}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,15 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.4
+      handlebars:
+        specifier: ^4.7.9
+        version: 4.7.9
       ioredis:
         specifier: ^5.4.1
         version: 5.10.1
+      nodemailer:
+        specifier: ^8.0.7
+        version: 8.0.7
       otplib:
         specifier: ^13.4.0
         version: 13.4.0
@@ -102,6 +108,9 @@ importers:
       '@types/node':
         specifier: ^20.16.13
         version: 20.19.39
+      '@types/nodemailer':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/zxcvbn':
         specifier: ^4.4.5
         version: 4.4.5
@@ -652,6 +661,9 @@ packages:
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/nodemailer@8.0.0':
+    resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1647,6 +1659,11 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2154,6 +2171,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  nodemailer@8.0.7:
+    resolution: {integrity: sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2837,6 +2858,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
@@ -2946,6 +2972,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -3455,6 +3484,10 @@ snapshots:
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/nodemailer@8.0.0':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@types/prop-types@15.7.15': {}
 
@@ -4645,6 +4678,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5146,6 +5188,8 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-releases@2.0.38: {}
+
+  nodemailer@8.0.7: {}
 
   normalize-path@3.0.0: {}
 
@@ -5897,6 +5941,9 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   uid@2.0.2:
     dependencies:
       '@lukeed/csprng': 1.1.0
@@ -6036,6 +6083,8 @@ snapshots:
       string-width: 4.2.3
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

M5.E.001 — comm-svc base + email-провайдер + welcome listener. Закрывает #162. **Разблокирует #134** (password reset) и **#136** (suspicious-session).

## Архитектура

```
auth.user.registered (event)
        │
        ▼
  WelcomeEmailListener  ──► NotifyService.send({channel,to,templateId,data})
                                    │
                                    ▼
                  ┌──────────────────────────────────┐
                  │  1. Notification.create(pending) │
                  │  2. TemplateService.render()      │
                  │  3. EmailProvider.send()          │
                  │  4. Tx { update(sent) +           │
                  │         outbox(comm.message.sent)}│
                  └──────────────────────────────────┘
                                    │
                            ┌───────┴───────┐
                            ▼               ▼
                  SmtpEmailProvider   LogEmailProvider
                  (если SMTP_HOST)    (dev fallback)
```

## Что внутри

### Schema (`20260428170000_M5_E_001_notifications`)

```prisma
enum NotificationChannel  { email | push | sms | telegram }
enum NotificationStatus   { pending | sent | failed }

model Notification {
  id, channel, recipient, templateId, payload (JSONB),
  status, sentAt, failedAt, errorMessage,
  userId (soft-ref на User), createdAt
}
```

3 индекса: `(status, created_at)`, `(recipient, created_at DESC)`, `(user_id, created_at DESC)`.

### Email Provider (switchable)

| Условие | Реализация |
|---|---|
| `SMTP_HOST` задан | `SmtpEmailProvider` (nodemailer + connection pool) |
| `SMTP_HOST` не задан | `LogEmailProvider` (логирует, не отправляет) |

```ts
// comm.module.ts factory:
useFactory: (config, smtp, log) => config.get('SMTP_HOST') ? smtp : log
```

Это позволяет dev-окружениям без credentials проходить тесты и smoke-проверки — `NotifyService.send()` работает, просто пишет в логи вместо отправки.

### TemplateService

Handlebars-рендер. Pre-compile при `onModuleInit` (быстрый рендер на send'е). Шаблоны лежат в `apps/api/src/modules/comm/templates/<id>/{subject,body}.hbs`.

Build: `nest-cli.json` + assets — `.hbs` файлы копируются в `dist/` (иначе runtime их не найдёт в Docker).

### NotifyService (facade)

```ts
async send({channel, to, templateId, data, userId?}) {
  // 1. Создаём Notification(pending) в БД
  // 2. Render через TemplateService
  // 3. Provider.send() → success/throw
  // 4. Транзакция: update status + outbox event
  //    - comm.message.sent (success)
  //    - comm.message.failed (permanent fail)
}
```

Privacy: outbox payload **НЕ содержит** recipient (email/phone могут быть ПДн). Только `notificationId`, `templateId`, `providerMessageId`.

### Welcome template (HTML email)

`templates/welcome/{subject,body}.hbs` — первый transactional шаблон. Mobile-friendly inline styles, CTA-кнопка saffron'ового цвета (наш design system), русский текст.

### WelcomeEmailListener

Подписывается на `auth.user.registered` через events-bus (consumer-group=`comm-svc-welcome`). Welcome email отправляется только для `role=client` — manager/admin/finance заводятся вручную, им onboarding не нужен.

## DKIM strategy

> **Рекомендация:** DKIM-подпись на стороне SMTP relay (DNS-записи). **Почему:** inline DKIM (приватный ключ в env) сложнее в управлении (rotation), а relay-провайдеры (Yandex 360 / Mailgun / Postmark) делают подпись автоматически после verify domain. Для русскоязычной аудитории рекомендую **Yandex 360 для бизнеса** — лучшая deliverability в RU + российская юрисдикция (152-ФЗ comfort).
>
> Inline DKIM (`dkim:` опция nodemailer) можно добавить во второй итерации если deliverability будет проблемой.

## ENV для production (для Вики)

```bash
# В /opt/indiahorizone/.env (добавить к существующим):
SMTP_HOST=smtp.yandex.ru
SMTP_PORT=465
SMTP_USER=noreply@indiahorizone.ru
SMTP_PASS=<пароль приложения из Yandex 360>
EMAIL_FROM=IndiaHorizone <noreply@indiahorizone.ru>
APP_URL=https://indiahorizone.ru   # для CTA-ссылок в email-ах; пока http://2.56.241.126:3010
```

Если не задать `SMTP_HOST` — в dev'е LogEmailProvider будет писать в логи api-контейнера. Это безопасный default.

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [x] `.hbs` файлы копируются в `apps/api/dist/modules/comm/templates/`
- [ ] **На сервере (Вика):**
  - После migrate deploy: таблица `notifications` создана
  - Без `SMTP_HOST` в env: `POST /auth/register` → запись в БД, в логах api `email.send.stub` с subject «Добро пожаловать в IndiaHorizone»
  - С `SMTP_HOST`: реальный email приходит на адрес

## Closes / Unblocks

- Closes #162
- Unblocks #134 password reset (теперь использует `NotifyService.send({templateId: 'password-reset'})`)
- Unblocks #136 suspicious-session alert email
- Foundation для #163-#165 (push / sms / telegram), #166 (preferences)

## Зависимости

- `nodemailer@8.0.7`, `handlebars@4.7.9`, `@types/nodemailer@8`
- Базируется на main (PR #340 chat schema уже merged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_