### PR TITLE
feat(comm): chat REST endpoints с Idempotency-Key (#169)

### DIFF
--- a/apps/api/src/modules/comm/chat/chat.controller.ts
+++ b/apps/api/src/modules/comm/chat/chat.controller.ts
@@ -1,0 +1,89 @@
+/**
+ * ChatController — REST endpoints для чатов (#169).
+ *
+ * GET    /chat/threads
+ * GET    /chat/threads/:id/messages?limit=&cursor=
+ * POST   /chat/threads/:id/messages   (Idempotency-Key: required)
+ * POST   /chat/threads/:id/read
+ *
+ * Доступ: любая authenticated роль (RBAC проверяется на уровне thread'а
+ * через participants). Без @Roles — глобальный JwtAuthGuard требует только
+ * валидный JWT.
+ *
+ * Idempotency-Key (POST /messages): obligatory header. Защита от double-send
+ * на flaky mobile network. Storage в Redis 24h.
+ */
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+
+import { ChatService } from './chat.service';
+import {
+  ListMessagesQueryDto,
+  type ListMessagesResponse,
+  type ListThreadsResponse,
+  SendMessageDto,
+} from './dto/chat.dto';
+import { CurrentUser } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+import type { ChatMessage } from '@prisma/client';
+
+@Controller('chat')
+export class ChatController {
+  constructor(private readonly chat: ChatService) {}
+
+  @Get('threads')
+  async listThreads(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ListThreadsResponse> {
+    return this.chat.listThreads(user.id);
+  }
+
+  @Get('threads/:id/messages')
+  async listMessages(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Query() query: ListMessagesQueryDto,
+  ): Promise<ListMessagesResponse> {
+    return this.chat.listMessages(user.id, id, query);
+  }
+
+  @Post('threads/:id/messages')
+  @HttpCode(HttpStatus.CREATED)
+  async sendMessage(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Body() dto: SendMessageDto,
+    @Headers('idempotency-key') idempotencyKey?: string,
+  ): Promise<ChatMessage> {
+    if (!idempotencyKey) {
+      throw new BadRequestException(
+        'Header Idempotency-Key обязателен для POST chat/threads/:id/messages',
+      );
+    }
+    if (idempotencyKey.length < 8 || idempotencyKey.length > 128) {
+      throw new BadRequestException('Idempotency-Key должен быть 8-128 символов');
+    }
+    return this.chat.sendMessage(user.id, id, dto, idempotencyKey);
+  }
+
+  @Post('threads/:id/read')
+  @HttpCode(HttpStatus.OK)
+  async markRead(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<{ updated: number }> {
+    return this.chat.markRead(user.id, id);
+  }
+}

--- a/apps/api/src/modules/comm/chat/chat.service.ts
+++ b/apps/api/src/modules/comm/chat/chat.service.ts
@@ -1,0 +1,249 @@
+/**
+ * ChatService — REST-сервис для чатов (#169).
+ *
+ * Endpoint'ы (см. controller):
+ * - GET  /chat/threads
+ * - GET  /chat/threads/:id/messages?cursor
+ * - POST /chat/threads/:id/messages (Idempotency-Key required)
+ * - POST /chat/threads/:id/read
+ *
+ * Access control: user должен быть в participants thread'а. Иначе 403/404.
+ *
+ * Idempotency-Key (HTTP header) на POST messages: Redis-backed, TTL 24h.
+ * Повторный POST с тем же ключом возвращает тот же response — защита от
+ * double-send при flaky network на mobile.
+ */
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+import { RedisService } from '../../../common/redis/redis.service';
+
+import type {
+  ListMessagesQueryDto,
+  ListMessagesResponse,
+  ListThreadsResponse,
+  SendMessageDto,
+} from './dto/chat.dto';
+import type { ChatMessage } from '@prisma/client';
+
+const IDEMPOTENCY_TTL_SEC = 24 * 60 * 60; // 24h
+
+interface MessageCursor {
+  createdAt: string;
+  id: string;
+}
+
+@Injectable()
+export class ChatService {
+  private readonly logger = new Logger(ChatService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async listThreads(userId: string): Promise<ListThreadsResponse> {
+    // PostgreSQL UUID[] @> ARRAY[userId] — содержит ли participants нашего user'а
+    const items = await this.prisma.chatThread.findMany({
+      where: {
+        participants: { has: userId },
+      },
+      orderBy: { updatedAt: 'desc' },
+      take: 100,
+    });
+    return { items };
+  }
+
+  async listMessages(
+    userId: string,
+    threadId: string,
+    query: ListMessagesQueryDto,
+  ): Promise<ListMessagesResponse> {
+    await this.assertThreadAccess(userId, threadId);
+
+    const limit = query.limit ?? 50;
+    const cursor = query.cursor ? this.decodeCursor(query.cursor) : null;
+
+    const items = await this.prisma.chatMessage.findMany({
+      where: {
+        threadId,
+        ...(cursor
+          ? {
+              OR: [
+                { createdAt: { lt: new Date(cursor.createdAt) } },
+                {
+                  AND: [
+                    { createdAt: new Date(cursor.createdAt) },
+                    { id: { lt: cursor.id } },
+                  ],
+                },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+    });
+
+    const hasMore = items.length > limit;
+    const page = hasMore ? items.slice(0, limit) : items;
+
+    let nextCursor: string | null = null;
+    if (hasMore) {
+      const last = page[page.length - 1] as ChatMessage;
+      nextCursor = this.encodeCursor({
+        createdAt: last.createdAt.toISOString(),
+        id: last.id,
+      });
+    }
+
+    return { items: page, nextCursor };
+  }
+
+  /**
+   * Send message с Idempotency-Key защитой от double-send.
+   * Если ключ уже использован — возвращаем ранее созданное сообщение
+   * (по сохранённому id в Redis).
+   */
+  async sendMessage(
+    userId: string,
+    threadId: string,
+    dto: SendMessageDto,
+    idempotencyKey: string,
+  ): Promise<ChatMessage> {
+    await this.assertThreadAccess(userId, threadId);
+
+    const idempKey = this.idempotencyKey(userId, threadId, idempotencyKey);
+
+    const cached = await this.redis.getClient().get(idempKey);
+    if (cached) {
+      const messageId = cached;
+      const existing = await this.prisma.chatMessage.findUnique({
+        where: { id: messageId },
+      });
+      if (existing) {
+        this.logger.debug({ idempotencyKey, messageId }, 'chat.message.idempotent-replay');
+        return existing;
+      }
+      // Cache pointer есть, но message исчез — стейл cache. Пишем новое.
+    }
+
+    const message = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.chatMessage.create({
+        data: {
+          threadId,
+          fromUserId: userId,
+          body: dto.body,
+          attachments: dto.attachments ?? [],
+          // readBy default '{}' (никто не прочитал, включая отправителя — он сам
+          // ставит read mark когда возвращается в чат)
+        },
+      });
+
+      // Тач thread.updatedAt чтобы он всплыл в /chat/threads.
+      await tx.chatThread.update({
+        where: { id: threadId },
+        data: { updatedAt: new Date() },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'comm.chat.message_sent',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          threadId,
+          messageId: created.id,
+          fromUserId: userId,
+          // body НЕ публикуем в outbox — может содержать ПДн
+          hasAttachments: (dto.attachments?.length ?? 0) > 0,
+        },
+      });
+
+      return created;
+    });
+
+    // Сохраняем idempotency mapping → message.id
+    await this.redis
+      .getClient()
+      .set(idempKey, message.id, 'EX', IDEMPOTENCY_TTL_SEC);
+
+    return message;
+  }
+
+  /**
+   * Mark all unread messages in thread as read by user. Атомарный update
+   * через jsonb_set по каждому message — но проще просто обновить через update
+   * с merge object (Prisma).
+   *
+   * V1: bulk-update — на всех messages thread'а where readBy ?| array[userId] is false
+   * проставить readBy[userId] = now. PostgreSQL JSONB || merge.
+   */
+  async markRead(userId: string, threadId: string): Promise<{ updated: number }> {
+    await this.assertThreadAccess(userId, threadId);
+
+    const now = new Date().toISOString();
+
+    // Raw SQL для атомарного JSONB merge: read_by = read_by || jsonb_build_object($userId, $now)
+    // на всех сообщениях thread'а где user'а ещё нет в read_by.
+    const result = await this.prisma.$executeRaw`
+      UPDATE "chat_messages"
+      SET "read_by" = "read_by" || jsonb_build_object(${userId}::text, ${now}::text)
+      WHERE "thread_id" = ${threadId}::uuid
+        AND NOT ("read_by" ? ${userId}::text)
+        AND "from_user_id" <> ${userId}::uuid
+    `;
+
+    return { updated: Number(result) };
+  }
+
+  // ─── helpers ───
+
+  private async assertThreadAccess(userId: string, threadId: string): Promise<void> {
+    const thread = await this.prisma.chatThread.findUnique({
+      where: { id: threadId },
+      select: { participants: true },
+    });
+    if (!thread) {
+      throw new NotFoundException('Thread не найден');
+    }
+    if (!thread.participants.includes(userId)) {
+      // 403 (а не 404) — user знает что thread существует, но он не участник.
+      // С 404 атакующий не различал бы существующие threads, но для UX чата
+      // 403 корректнее (UI может показать «вас удалили из чата»).
+      throw new ForbiddenException('Нет доступа к этому чату');
+    }
+  }
+
+  private idempotencyKey(userId: string, threadId: string, key: string): string {
+    return `chat-idem:${userId}:${threadId}:${key}`;
+  }
+
+  private encodeCursor(cursor: MessageCursor): string {
+    return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+  }
+
+  private decodeCursor(raw: string): MessageCursor {
+    try {
+      const json = Buffer.from(raw, 'base64url').toString('utf8');
+      const parsed = JSON.parse(json) as Partial<MessageCursor>;
+      if (
+        typeof parsed.createdAt !== 'string' ||
+        typeof parsed.id !== 'string' ||
+        Number.isNaN(Date.parse(parsed.createdAt))
+      ) {
+        throw new Error('invalid cursor');
+      }
+      return { createdAt: parsed.createdAt, id: parsed.id };
+    } catch {
+      throw new BadRequestException('Невалидный cursor');
+    }
+  }
+}

--- a/apps/api/src/modules/comm/chat/dto/chat.dto.ts
+++ b/apps/api/src/modules/comm/chat/dto/chat.dto.ts
@@ -1,0 +1,65 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+import type { ChatMessage, ChatThread } from '@prisma/client';
+
+/**
+ * POST /chat/threads/:id/messages
+ *
+ * Idempotency-Key обязателен на этом endpoint'е (см. controller). Содержание тела:
+ */
+export class SendMessageDto {
+  @IsString()
+  @MinLength(1, { message: 'Сообщение не может быть пустым' })
+  @MaxLength(4000, { message: 'Сообщение слишком длинное (max 4000)' })
+  body!: string;
+
+  /** Опциональные media-attachments (UUID MediaAsset; модели появятся в #173) */
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10, { message: 'Максимум 10 attachments на сообщение' })
+  @IsUUID(4, { each: true })
+  attachments?: string[];
+}
+
+/**
+ * GET /chat/threads/:id/messages query params
+ */
+export class ListMessagesQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+
+  /**
+   * Opaque base64 cursor от предыдущей страницы (`{createdAt, id}`).
+   * Для первой загрузки — не передаём; service вернёт самые свежие.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  cursor?: string;
+}
+
+export interface ListThreadsResponse {
+  items: ChatThread[];
+}
+
+export interface ListMessagesResponse {
+  items: ChatMessage[];
+  /** null если страница последняя */
+  nextCursor: string | null;
+}

--- a/apps/api/src/modules/comm/comm.module.ts
+++ b/apps/api/src/modules/comm/comm.module.ts
@@ -22,6 +22,8 @@
 import { Global, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
+import { ChatController } from './chat/chat.controller';
+import { ChatService } from './chat/chat.service';
 import { NotifyService } from './notify.service';
 import { EMAIL_PROVIDER, type EmailProvider } from './providers/email.provider';
 import { LogEmailProvider } from './providers/log-email.provider';
@@ -31,11 +33,14 @@ import { SuspiciousLoginListener } from './listeners/suspicious-login.listener';
 import { WelcomeEmailListener } from './listeners/welcome.listener';
 import { EventsBusModule } from '../../common/events-bus/events-bus.module';
 import { PrismaModule } from '../../common/prisma/prisma.module';
+import { RedisModule } from '../../common/redis/redis.module';
 
 @Global()
 @Module({
-  imports: [PrismaModule, EventsBusModule, ConfigModule],
+  imports: [PrismaModule, EventsBusModule, ConfigModule, RedisModule],
+  controllers: [ChatController],
   providers: [
+    ChatService,
     NotifyService,
     TemplateService,
     LogEmailProvider,
@@ -58,6 +63,6 @@ import { PrismaModule } from '../../common/prisma/prisma.module';
     WelcomeEmailListener,
     SuspiciousLoginListener,
   ],
-  exports: [NotifyService],
+  exports: [NotifyService, ChatService],
 })
 export class CommModule {}


### PR DESCRIPTION
## Summary

Полный CRUD чата поверх schema #167. Закрывает #169.

## Endpoints

```
GET    /chat/threads                                      — список thread'ов user'а
GET    /chat/threads/:id/messages?limit=&cursor=          — cursor-paginated
POST   /chat/threads/:id/messages   Idempotency-Key: ...  — send (header required)
POST   /chat/threads/:id/read                              — mark all as read
```

## Access control

`assertThreadAccess(userId, threadId)`: user должен быть в `thread.participants[]`. Иначе 403. Прямой запрос несуществующего thread'а → 404.

> **Рекомендация:** 403 (а не 404) для unauthorized — UI может показать «вас удалили из чата». **Почему:** pure-anti-enumeration UX-паттерн неудобен для активных чатов где user видит «invitation revoked». 4XX тут soft-leak'ает существование thread'а — но threadId UUID, и user уже знал о нём.

## Idempotency-Key

Обязательный header на POST messages (8-128 chars). Storage в Redis:
```
key:  chat-idem:<userId>:<threadId>:<key>
val:  <messageId>
TTL:  24h
```

Replay с тем же key → возвращаем существующий message. Защита от double-send на flaky mobile network (типичный Indian travel-сценарий).

## Cursor pagination

`(createdAt DESC, id DESC)` — стабильно при concurrent writes (новые сообщения не сдвигают страницы). Opaque base64 JSON `{createdAt, id}`. Аналогично #219 audit.

## Mark read (атомарный)

Raw SQL JSONB merge:
```sql
UPDATE chat_messages
SET read_by = read_by || jsonb_build_object($userId, $now)
WHERE thread_id = $threadId
  AND NOT (read_by ? $userId)
  AND from_user_id <> $userId
```

Отправитель не отмечается как прочитавший своё сообщение. Только то что не было прочитано — обновляется (atomicity не теряется при concurrent reads).

## Outbox event

`comm.chat.message_sent` в той же транзакции что message.create:
- `payload`: threadId, messageId, fromUserId, **hasAttachments** (boolean — без id'ов)
- **body НЕ публикуется** — может содержать ПДн (имена, паспорта, номера броней)

## Что НЕ в этом PR

- **WebSocket gateway #168** — realtime push для подключённых клиентов
- **Чат UI #170** (frontend)
- **POST /chat/threads** для создания thread'а — отдельный issue (создание привязано к Trip/SosEvent/Lead — нужен domain-specific flow)
- **DELETE /messages/:id** для удаления — отдельный issue (legal: retention?)
- **PATCH /messages/:id** для редактирования — отдельный issue

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после deploy):**
  - Manager создаёт Trip → backend создаёт thread — пока вручную через Prisma
  - `GET /chat/threads` как client (член participants) → видит thread
  - `GET /chat/threads` как другой user → пустой список
  - `POST /messages` без `Idempotency-Key` → 400
  - `POST /messages` с тем же ключом дважды → один message в БД, второй call возвращает существующий
  - Cursor pagination на 200+ сообщениях

## Closes

- Closes #169

## Зависимости

- Базируется на main (PR #343 suspicious-login уже merged)
- Не блокирует следующие — #168 (WebSocket) можно делать поверх

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_