### PR TITLE
feat(feedback): POST /feedback + GET /trips/:id/feedbacks (#188)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { CatalogModule } from './modules/catalog/catalog.module';
 import { ClientsModule } from './modules/clients/clients.module';
 import { CommModule } from './modules/comm/comm.module';
+import { FeedbackModule } from './modules/feedback/feedback.module';
 import { HealthModule } from './modules/health/health.module';
 import { LeadsModule } from './modules/leads/leads.module';
 import { TripsModule } from './modules/trips/trips.module';
@@ -35,6 +36,7 @@ import { TripsModule } from './modules/trips/trips.module';
     LeadsModule,
     TripsModule,
     CommModule,
+    FeedbackModule,
     AuditModule,
     CommonAuthModule, // глобальный JwtAuthGuard, требует AuthModule (JwtTokenService)
     HealthModule,

--- a/apps/api/src/modules/feedback/dto/feedback.dto.ts
+++ b/apps/api/src/modules/feedback/dto/feedback.dto.ts
@@ -1,0 +1,55 @@
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+import { FeedbackMood, FeedbackType } from '@prisma/client';
+
+import type { Feedback } from '@prisma/client';
+
+/**
+ * POST /feedback (#188).
+ *
+ * Idempotency-Key header обязателен (см. controller). Body:
+ */
+export class CreateFeedbackDto {
+  @IsUUID(4, { message: 'tripId должен быть UUIDv4' })
+  tripId!: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(365, { message: 'dayNumber 1-365 (длинные poездки exotic)' })
+  dayNumber!: number;
+
+  @IsEnum(FeedbackType, { message: 'type — text или circle' })
+  type!: FeedbackType;
+
+  @IsString()
+  @MinLength(1, { message: 'body не может быть пустым' })
+  @MaxLength(4000)
+  body!: string;
+
+  @IsEnum(FeedbackMood, {
+    message: 'mood — bad | neutral | ok | good | excellent',
+  })
+  mood!: FeedbackMood;
+
+  /**
+   * Для type=circle — UUID MediaAsset (#173 будущий).
+   * Сейчас валидируется только формат, существование asset'а не проверяется.
+   */
+  @IsOptional()
+  @IsUUID(4, { message: 'mediaId должен быть UUIDv4' })
+  mediaId?: string;
+}
+
+export interface ListFeedbacksResponse {
+  items: Feedback[];
+}

--- a/apps/api/src/modules/feedback/feedback.controller.ts
+++ b/apps/api/src/modules/feedback/feedback.controller.ts
@@ -1,0 +1,65 @@
+/**
+ * FeedbackController — endpoints daily feedback (#188).
+ *
+ * POST /feedback                — клиент пишет (Idempotency-Key required)
+ * GET  /trips/:id/feedbacks     — feedback'и поездки (RBAC по ролям)
+ *
+ * RBAC granularity:
+ * - POST: только client (owner trip'а)
+ * - GET: client (own) + concierge + manager + admin + finance
+ *
+ * Глобальный JwtAuthGuard уже требует валидный JWT. Доступ per-trip
+ * проверяется на уровне service'а через assertClientOwnsTrip / assertReadAccess.
+ *
+ * @Roles НЕ ставим — service сам routes доступ через UserRole. Это позволяет
+ * client'у писать только свои feedback'и, но другим ролям — читать чужие.
+ */
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+
+import { CreateFeedbackDto, type ListFeedbacksResponse } from './dto/feedback.dto';
+import { FeedbackService } from './feedback.service';
+import { CurrentUser } from '../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../common/auth/types';
+import type { Feedback } from '@prisma/client';
+
+@Controller()
+export class FeedbackController {
+  constructor(private readonly feedback: FeedbackService) {}
+
+  @Post('feedback')
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateFeedbackDto,
+    @Headers('idempotency-key') idempotencyKey?: string,
+  ): Promise<Feedback> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Header Idempotency-Key обязателен для POST /feedback');
+    }
+    if (idempotencyKey.length < 8 || idempotencyKey.length > 128) {
+      throw new BadRequestException('Idempotency-Key должен быть 8-128 символов');
+    }
+    return this.feedback.create(user.id, dto, idempotencyKey);
+  }
+
+  @Get('trips/:id/feedbacks')
+  async listByTrip(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+  ): Promise<ListFeedbacksResponse> {
+    const items = await this.feedback.listByTrip(user.id, user.role, tripId);
+    return { items };
+  }
+}

--- a/apps/api/src/modules/feedback/feedback.module.ts
+++ b/apps/api/src/modules/feedback/feedback.module.ts
@@ -1,0 +1,22 @@
+/**
+ * FeedbackModule — daily feedback клиента в активной поездке.
+ *
+ * #186 — Prisma модели (FeedbackRequest, Feedback)
+ * #188 — endpoints POST/GET (этот PR)
+ * #189+ — AI-enrichment (sentiment, topics) post-write
+ * #190 — frontend экран feedback
+ */
+import { Module } from '@nestjs/common';
+
+import { FeedbackController } from './feedback.controller';
+import { FeedbackService } from './feedback.service';
+import { PrismaModule } from '../../common/prisma/prisma.module';
+import { RedisModule } from '../../common/redis/redis.module';
+
+@Module({
+  imports: [PrismaModule, RedisModule],
+  controllers: [FeedbackController],
+  providers: [FeedbackService],
+  exports: [FeedbackService],
+})
+export class FeedbackModule {}

--- a/apps/api/src/modules/feedback/feedback.service.ts
+++ b/apps/api/src/modules/feedback/feedback.service.ts
@@ -1,0 +1,216 @@
+/**
+ * FeedbackService — daily feedback клиента (#188).
+ *
+ * POST /feedback   — клиент пишет (text + mood [+ circle media])
+ * GET  /trips/:id/feedbacks — клиент / concierge / manager / admin читают
+ *
+ * Access control:
+ * - POST: только клиент trip'а (Trip.clientId соответствует user'а Client)
+ * - GET: client (own trips) + concierge + manager + admin (все)
+ *
+ * Idempotency-Key (header) на POST: Redis-cached, TTL 24h (как в chat).
+ *
+ * Уникальность (trip_id, day_number) гарантируется БД. При попытке повторного
+ * POST на тот же день — 409 Conflict (отдельный issue для PATCH-обновления).
+ *
+ * Outbox event `feedback.received` — для AI-enrichment (#189) и аналитики.
+ */
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { OutboxService } from '../../common/outbox/outbox.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { RedisService } from '../../common/redis/redis.service';
+
+import type { CreateFeedbackDto } from './dto/feedback.dto';
+import type { Feedback, UserRole, Prisma } from '@prisma/client';
+
+const IDEMPOTENCY_TTL_SEC = 24 * 60 * 60;
+const PRISMA_UNIQUE_VIOLATION = 'P2002';
+
+@Injectable()
+export class FeedbackService {
+  private readonly logger = new Logger(FeedbackService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async create(
+    userId: string,
+    dto: CreateFeedbackDto,
+    idempotencyKey: string,
+  ): Promise<Feedback> {
+    // Access: только клиент собственной trip'ы
+    await this.assertClientOwnsTrip(userId, dto.tripId);
+
+    // Replay protection через Idempotency-Key
+    const idemKey = this.idempotencyKey(userId, dto.tripId, idempotencyKey);
+    const cached = await this.redis.getClient().get(idemKey);
+    if (cached) {
+      const existing = await this.prisma.feedback.findUnique({
+        where: { id: cached },
+      });
+      if (existing) {
+        return existing;
+      }
+    }
+
+    let feedback: Feedback;
+    try {
+      feedback = await this.prisma.$transaction(async (tx) => {
+        // Если был FeedbackRequest на этот день — линкуем.
+        const request = await tx.feedbackRequest.findUnique({
+          where: { tripId_dayNumber: { tripId: dto.tripId, dayNumber: dto.dayNumber } },
+          select: { id: true },
+        });
+
+        const created = await tx.feedback.create({
+          data: {
+            tripId: dto.tripId,
+            dayNumber: dto.dayNumber,
+            type: dto.type,
+            body: dto.body,
+            mood: dto.mood,
+            ...(dto.mediaId !== undefined ? { mediaId: dto.mediaId } : {}),
+            ...(request ? { requestId: request.id } : {}),
+          },
+        });
+
+        await this.outbox.add(tx, {
+          type: 'feedback.received',
+          schemaVersion: 1,
+          actor: { type: 'user', id: userId },
+          payload: {
+            feedbackId: created.id,
+            tripId: dto.tripId,
+            dayNumber: dto.dayNumber,
+            mood: dto.mood,
+            // body/mediaId НЕ публикуем — потенциально ПДн или sensitive content
+            hasMedia: dto.mediaId !== undefined,
+            type: dto.type,
+          },
+        });
+
+        return created;
+      });
+    } catch (err) {
+      // Unique violation на (trip_id, day_number) — уже есть feedback на этот день.
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code?: string }).code === PRISMA_UNIQUE_VIOLATION
+      ) {
+        throw new ConflictException(
+          `Feedback на день ${dto.dayNumber} уже существует. Для обновления — PATCH /feedback/:id`,
+        );
+      }
+      throw err;
+    }
+
+    await this.redis
+      .getClient()
+      .set(idemKey, feedback.id, 'EX', IDEMPOTENCY_TTL_SEC);
+
+    this.logger.log(
+      { feedbackId: feedback.id, tripId: dto.tripId, mood: dto.mood },
+      'feedback.received',
+    );
+
+    return feedback;
+  }
+
+  async listByTrip(
+    userId: string,
+    role: UserRole,
+    tripId: string,
+  ): Promise<Feedback[]> {
+    await this.assertReadAccess(userId, role, tripId);
+
+    return this.prisma.feedback.findMany({
+      where: { tripId },
+      orderBy: { dayNumber: 'asc' },
+    });
+  }
+
+  // ─── access helpers ───
+
+  /**
+   * Только клиент-владелец trip'а может писать feedback.
+   * Trip.clientId = Client.id, Client.userId = User.id.
+   */
+  private async assertClientOwnsTrip(userId: string, tripId: string): Promise<void> {
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: {
+        clientId: true,
+      },
+    });
+    if (!trip) {
+      throw new NotFoundException('Trip не найден');
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { id: trip.clientId },
+      select: { userId: true },
+    });
+    if (!client || client.userId !== userId) {
+      throw new ForbiddenException('Только клиент-владелец может оставлять feedback');
+    }
+  }
+
+  /**
+   * Чтение feedback'ов trip'а:
+   * - client → только own trip
+   * - concierge / manager / admin / finance → любой trip
+   * - guide → только trips где он guide (нет такого FK сейчас; TODO когда добавим)
+   */
+  private async assertReadAccess(
+    userId: string,
+    role: UserRole,
+    tripId: string,
+  ): Promise<void> {
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { clientId: true },
+    });
+    if (!trip) {
+      throw new NotFoundException('Trip не найден');
+    }
+
+    if (
+      role === 'admin' ||
+      role === 'concierge' ||
+      role === 'manager' ||
+      role === 'finance'
+    ) {
+      return; // Полный read-доступ к feedback'ам всех trip'ов.
+    }
+
+    if (role === 'client') {
+      const client = await this.prisma.client.findUnique({
+        where: { id: trip.clientId },
+        select: { userId: true },
+      });
+      if (!client || client.userId !== userId) {
+        throw new ForbiddenException('Нет доступа к feedback');
+      }
+      return;
+    }
+
+    // guide — пока без attribution к trip'у (отдельный issue, когда будет
+    // Trip.guideId или TripGuide-связь).
+    throw new ForbiddenException('Нет доступа к feedback');
+  }
+
+  private idempotencyKey(userId: string, tripId: string, key: string): string {
+    return `feedback-idem:${userId}:${tripId}:${key}`;
+  }
+}


### PR DESCRIPTION
## Summary

Endpoints для daily feedback поверх schema #186. Закрывает #188.

## Endpoints

```
POST /feedback                  Idempotency-Key: required
                                Body: { tripId, dayNumber, type, body, mood, mediaId? }
GET  /trips/:id/feedbacks       (RBAC по ролям, см. ниже)
```

## RBAC

| Role | POST /feedback | GET /trips/:id/feedbacks |
|---|---|---|
| `client` | own trip только | own trip только |
| `manager` | ❌ | ✅ all trips |
| `concierge` | ❌ | ✅ all trips |
| `finance` | ❌ | ✅ all trips |
| `admin` | ❌ | ✅ all trips |
| `guide` | ❌ | TODO (нет Trip.guideId attribution) |

> **Архитектурный выбор:** не ставим `@Roles` на класс — Service routes доступ через `user.role`. Это позволяет client писать только свои, но manager/concierge/admin читать чужие.

## Idempotency

Header `Idempotency-Key` (8-128 chars) обязателен на POST. Storage в Redis (TTL 24h):
```
key:  feedback-idem:<userId>:<tripId>:<key>
val:  feedback.id
```

Replay → возвращаем существующий feedback. Защита от mobile flaky network (типичный кейс — клиент в Индии с нестабильным интернетом).

## Уникальность

DB constraint `unique (trip_id, day_number)`. При повторном POST на тот же день → 409 Conflict с подсказкой использовать PATCH (отдельный issue для UPDATE-flow).

## FeedbackRequest auto-linking

Если был `FeedbackRequest` на (trip, day) — автоматически линкуется через `requestId`. Позволяет аналитике различать «по запросу» vs «спонтанно».

## Outbox event

`feedback.received` в той же транзакции:
```ts
{
  payload: {
    feedbackId, tripId, dayNumber, mood,
    type, hasMedia: boolean,
    // body/mediaId НЕ публикуем — может содержать ПДн / sensitive
  }
}
```

Подписчик AI-enrichment (#189) обогатит `signals` (sentiment, topics, keywords).

## Что НЕ в этом PR

- **PATCH /feedback/:id** — обновление существующего feedback'а
- **AI signals enrichment #189** — sentiment / topics post-write
- **Frontend #190** — экран feedback в trip dashboard
- **Scheduled FeedbackRequest creation** — cron вечером каждого дня поездки
- **Notification (push) при FeedbackRequest** — использует #162

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после deploy):**
  - Client с активным trip → POST /feedback с валидными данными → 201
  - Тот же POST с тем же Idempotency-Key → возвращает existing
  - Тот же POST с другим Idempotency-Key, тот же day → 409
  - Manager → POST /feedback → 403 (только client может писать)
  - Manager → GET /trips/:id/feedbacks → 200
  - Client → GET чужого trip'а → 403

## Closes

- Closes #188

## Зависимости

- Базируется на main (PR #345 feedback schema уже merged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_