### PR TITLE
feat(comm): notification subscriptions / preferences (#166)

### DIFF
--- a/apps/api/prisma/migrations/20260428200000_M5_E_005_notification_preferences/migration.sql
+++ b/apps/api/prisma/migrations/20260428200000_M5_E_005_notification_preferences/migration.sql
@@ -1,0 +1,20 @@
+-- M5.E.005 — Notification preferences (issue #166)
+--
+-- One row per (user, category). channels is array of enabled NotificationChannel.
+-- SOS protected — service-side enforcement (нет DB-constraint, потому что
+-- preferences для SOS могут отсутствовать — defaults applied в service).
+
+CREATE TYPE "notification_category" AS ENUM ('trips', 'marketing', 'sos', 'system');
+
+CREATE TABLE "notification_preferences" (
+  "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"    UUID NOT NULL,
+  "category"   "notification_category" NOT NULL,
+  "channels"   "notification_channel"[] NOT NULL DEFAULT '{}',
+  "enabled"    BOOLEAN NOT NULL DEFAULT true,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "notification_preferences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "uq_notification_preferences_user_category" ON "notification_preferences" ("user_id", "category");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -909,6 +909,40 @@ model Notification {
   @@map("notifications")
 }
 
+/// Категория нотификации (#166) — для preferences. Каждый send имеет category;
+/// user может отписаться от каналов внутри категории (кроме SOS — always-on).
+enum NotificationCategory {
+  /// Транзакции по поездкам: подтверждения, напоминания, изменения маршрута.
+  trips
+  /// Маркетинг: новые туры, акции. По умолчанию OFF (152-ФЗ ст. 18 — opt-in для рекламы).
+  marketing
+  /// SOS — protected, не отключается. Все каналы всегда on.
+  sos
+  /// Security: пароль изменён, suspicious login, 2FA-alerts.
+  system
+
+  @@map("notification_category")
+}
+
+/// Notification preferences (#166) — каналы по категории на user'а.
+///
+/// Один row на (user, category). channels — массив включённых каналов.
+/// Если row отсутствует — используются defaults (см. NotificationPreferencesService).
+/// SOS preferences нельзя disable — service enforces.
+model NotificationPreference {
+  id        String                @id @default(uuid()) @db.Uuid
+  /// Soft-reference на User.
+  userId    String                @map("user_id") @db.Uuid
+  category  NotificationCategory
+  /// Каналы доставки. Пустой = silent для категории. SOS всегда [all 4].
+  channels  NotificationChannel[]
+  enabled   Boolean               @default(true)
+  updatedAt DateTime              @updatedAt @map("updated_at")
+
+  @@unique([userId, category], map: "uq_notification_preferences_user_category")
+  @@map("notification_preferences")
+}
+
 // === feedback модуль (#186+ [M5.G]) ===
 //
 // Источник: docs/BACKLOG/M5/G_FEEDBACK.md, docs/ARCH/MICROSERVICES.md § feedback-svc.

--- a/apps/api/src/modules/comm/comm.module.ts
+++ b/apps/api/src/modules/comm/comm.module.ts
@@ -25,6 +25,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ChatController } from './chat/chat.controller';
 import { ChatService } from './chat/chat.service';
 import { NotifyService } from './notify.service';
+import { NotificationPreferencesController } from './preferences/preferences.controller';
+import { NotificationPreferencesService } from './preferences/preferences.service';
 import { EMAIL_PROVIDER, type EmailProvider } from './providers/email.provider';
 import { LogEmailProvider } from './providers/log-email.provider';
 import { SmtpEmailProvider } from './providers/smtp-email.provider';
@@ -38,10 +40,11 @@ import { RedisModule } from '../../common/redis/redis.module';
 @Global()
 @Module({
   imports: [PrismaModule, EventsBusModule, ConfigModule, RedisModule],
-  controllers: [ChatController],
+  controllers: [ChatController, NotificationPreferencesController],
   providers: [
     ChatService,
     NotifyService,
+    NotificationPreferencesService,
     TemplateService,
     LogEmailProvider,
     SmtpEmailProvider,
@@ -63,6 +66,6 @@ import { RedisModule } from '../../common/redis/redis.module';
     WelcomeEmailListener,
     SuspiciousLoginListener,
   ],
-  exports: [NotifyService, ChatService],
+  exports: [NotifyService, ChatService, NotificationPreferencesService],
 })
 export class CommModule {}

--- a/apps/api/src/modules/comm/preferences/dto/preferences.dto.ts
+++ b/apps/api/src/modules/comm/preferences/dto/preferences.dto.ts
@@ -1,0 +1,40 @@
+import {
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+} from 'class-validator';
+
+import { NotificationCategory, NotificationChannel } from '@prisma/client';
+
+/**
+ * PATCH /comm/preferences/:category — частичное обновление предпочтений
+ * для конкретной категории.
+ */
+export class UpdatePreferenceDto {
+  /** Полная замена массива каналов. Чтобы выключить все — пустой массив. */
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsEnum(NotificationChannel, { each: true })
+  channels?: NotificationChannel[];
+
+  /** Глобальный on/off для категории. SOS — service не принимает false. */
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}
+
+export interface PreferenceItem {
+  category: NotificationCategory;
+  channels: NotificationChannel[];
+  enabled: boolean;
+  /** true если row реально есть в БД (custom user preference);
+   *  false — возвращаем default. */
+  isCustom: boolean;
+}
+
+export interface ListPreferencesResponse {
+  items: PreferenceItem[];
+}

--- a/apps/api/src/modules/comm/preferences/preferences.controller.ts
+++ b/apps/api/src/modules/comm/preferences/preferences.controller.ts
@@ -1,0 +1,53 @@
+/**
+ * NotificationPreferencesController — endpoints (#166).
+ *
+ * GET   /comm/preferences           — все 4 категории (с merging defaults)
+ * PATCH /comm/preferences/:category — частичное обновление одной категории
+ *
+ * Доступ: любая authenticated роль. User управляет ТОЛЬКО своими preferences.
+ */
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseEnumPipe,
+  Patch,
+} from '@nestjs/common';
+
+import { NotificationCategory } from '@prisma/client';
+
+import {
+  type ListPreferencesResponse,
+  type PreferenceItem,
+  UpdatePreferenceDto,
+} from './dto/preferences.dto';
+import { NotificationPreferencesService } from './preferences.service';
+import { CurrentUser } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+
+@Controller('comm/preferences')
+export class NotificationPreferencesController {
+  constructor(private readonly service: NotificationPreferencesService) {}
+
+  @Get()
+  async list(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<ListPreferencesResponse> {
+    return this.service.getAll(user.id);
+  }
+
+  @Patch(':category')
+  @HttpCode(HttpStatus.OK)
+  async update(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('category', new ParseEnumPipe(NotificationCategory))
+    category: NotificationCategory,
+    @Body() dto: UpdatePreferenceDto,
+  ): Promise<PreferenceItem> {
+    return this.service.update(user.id, category, dto);
+  }
+}

--- a/apps/api/src/modules/comm/preferences/preferences.service.ts
+++ b/apps/api/src/modules/comm/preferences/preferences.service.ts
@@ -1,0 +1,170 @@
+/**
+ * NotificationPreferencesService — управление preferences (#166).
+ *
+ * - getAll(userId) — возвращает 4 строки (по одной на category) с merging
+ *   custom preferences и defaults
+ * - update(userId, category, dto) — upsert preference
+ *   - SOS: enabled=false ИЛИ channels=[] → BadRequestException (protected)
+ * - shouldNotify(userId, category, channel) — для use из NotifyService
+ *
+ * Defaults:
+ * - trips:     [push, email]   enabled=true
+ * - marketing: [email]         enabled=FALSE  (152-ФЗ ст. 18 — opt-in)
+ * - sos:       [push, email, sms, telegram]  enabled=true (PROTECTED)
+ * - system:    [email]         enabled=true
+ */
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import type {
+  ListPreferencesResponse,
+  PreferenceItem,
+  UpdatePreferenceDto,
+} from './dto/preferences.dto';
+import type {
+  NotificationCategory,
+  NotificationChannel,
+  NotificationPreference,
+} from '@prisma/client';
+
+interface DefaultPreference {
+  channels: NotificationChannel[];
+  enabled: boolean;
+}
+
+const DEFAULTS: Record<NotificationCategory, DefaultPreference> = {
+  trips: {
+    channels: ['push', 'email'],
+    enabled: true,
+  },
+  marketing: {
+    channels: ['email'],
+    enabled: false, // 152-ФЗ ст. 18 — opt-in для коммерческих коммуникаций
+  },
+  sos: {
+    channels: ['push', 'email', 'sms', 'telegram'],
+    enabled: true, // PROTECTED — service блокирует попытки отключить
+  },
+  system: {
+    channels: ['email'],
+    enabled: true,
+  },
+};
+
+const ALL_CATEGORIES: NotificationCategory[] = ['trips', 'marketing', 'sos', 'system'];
+const ALL_CHANNELS: NotificationChannel[] = ['push', 'email', 'sms', 'telegram'];
+
+@Injectable()
+export class NotificationPreferencesService {
+  private readonly logger = new Logger(NotificationPreferencesService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getAll(userId: string): Promise<ListPreferencesResponse> {
+    const custom = await this.prisma.notificationPreference.findMany({
+      where: { userId },
+    });
+    const customByCategory = new Map<NotificationCategory, NotificationPreference>();
+    for (const c of custom) {
+      customByCategory.set(c.category, c);
+    }
+
+    const items: PreferenceItem[] = ALL_CATEGORIES.map((category) => {
+      const c = customByCategory.get(category);
+      const def = DEFAULTS[category];
+      return {
+        category,
+        channels: c?.channels ?? def.channels,
+        enabled: c?.enabled ?? def.enabled,
+        isCustom: c !== undefined,
+      };
+    });
+
+    return { items };
+  }
+
+  async update(
+    userId: string,
+    category: NotificationCategory,
+    dto: UpdatePreferenceDto,
+  ): Promise<PreferenceItem> {
+    // SOS — protected
+    if (category === 'sos') {
+      if (dto.enabled === false) {
+        throw new BadRequestException(
+          'SOS-уведомления нельзя отключить (protected). Это требование безопасности.',
+        );
+      }
+      if (dto.channels !== undefined && dto.channels.length === 0) {
+        throw new BadRequestException(
+          'SOS должен иметь хотя бы один канал. Все 4 канала включены по умолчанию.',
+        );
+      }
+    }
+
+    const def = DEFAULTS[category];
+    const upserted = await this.prisma.notificationPreference.upsert({
+      where: { userId_category: { userId, category } },
+      create: {
+        userId,
+        category,
+        channels: dto.channels ?? def.channels,
+        enabled: dto.enabled ?? def.enabled,
+      },
+      update: {
+        ...(dto.channels !== undefined ? { channels: dto.channels } : {}),
+        ...(dto.enabled !== undefined ? { enabled: dto.enabled } : {}),
+      },
+    });
+
+    this.logger.log(
+      { userId, category, enabled: upserted.enabled, channelCount: upserted.channels.length },
+      'preferences.updated',
+    );
+
+    return {
+      category,
+      channels: upserted.channels,
+      enabled: upserted.enabled,
+      isCustom: true,
+    };
+  }
+
+  /**
+   * Used by NotifyService.send() (если интегрировать) для проверки
+   * разрешения перед отправкой. SOS — всегда true (protected даже от
+   * случайной DB-инконсистентности).
+   */
+  async shouldNotify(
+    userId: string,
+    category: NotificationCategory,
+    channel: NotificationChannel,
+  ): Promise<boolean> {
+    if (category === 'sos') {
+      return true; // protected
+    }
+
+    const pref = await this.prisma.notificationPreference.findUnique({
+      where: { userId_category: { userId, category } },
+      select: { enabled: true, channels: true },
+    });
+
+    if (!pref) {
+      // No custom — use default
+      const def = DEFAULTS[category];
+      return def.enabled && def.channels.includes(channel);
+    }
+
+    return pref.enabled && pref.channels.includes(channel);
+  }
+
+  // Re-export for use в NotifyService:
+  static readonly DEFAULTS = DEFAULTS;
+  static readonly ALL_CATEGORIES = ALL_CATEGORIES;
+  static readonly ALL_CHANNELS = ALL_CHANNELS;
+}


### PR DESCRIPTION
## Summary

Schema + endpoints для управления preferences по категориям нотификаций. Закрывает #166.

## Schema

```prisma
enum NotificationCategory  { trips | marketing | sos | system }

model NotificationPreference {
  id, user_id (soft-ref), category, channels[], enabled, updated_at
  unique (user_id, category)
}
```

## Endpoints

```
GET   /comm/preferences              — все 4 категории с merging defaults
PATCH /comm/preferences/:category    — частичное обновление одной
```

`GET` возвращает `{items: PreferenceItem[]}` где каждый item имеет `isCustom: boolean` — true если у user'а есть row в БД, false если возвращены defaults.

## Defaults

| Category | Channels | Enabled | Why |
|---|---|---|---|
| `trips` | push, email | ✅ | Транзакции (подтверждения, изменения маршрута) |
| `marketing` | email | ❌ | **152-ФЗ ст. 18 opt-in** для коммерческих коммуникаций |
| `sos` | push, email, sms, telegram | ✅ **PROTECTED** | Безопасность — нельзя отключить |
| `system` | email | ✅ | Security: пароль, suspicious login, 2FA |

## SOS protection

Service-side enforcement в `update()`:
- `enabled: false` → `BadRequestException`
- `channels: []` → `BadRequestException` 

Plus `shouldNotify('sos', ...)` всегда возвращает `true` — даже если в БД оказалась некорректная row (защита от будущих багов).

## Что НЕ в этом PR

- **Интеграция в NotifyService.send** — требует расширения `SendInput` с category. Отдельный issue, чтобы не менять existing API в одном PR.
- **Frontend /profile/notifications** — отдельный UI issue
- **Маркетинг opt-in flow при register** — отдельный issue (чекбокс «получать маркетинговые письма» при регистрации, обновляет preference)

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после deploy):**
  - `GET /comm/preferences` для нового user'а → 4 row'а с defaults (isCustom=false)
  - `PATCH /comm/preferences/marketing` `{enabled: true}` → 200, isCustom=true
  - `PATCH /comm/preferences/sos` `{enabled: false}` → 400 «нельзя отключить»
  - `PATCH /comm/preferences/sos` `{channels: []}` → 400 «должен иметь хотя бы один канал»
  - `PATCH /comm/preferences/trips` `{channels: ['email']}` → 200 (push отключен)

## Closes

- Closes #166

## Зависимости

- Базируется на main (PR #346 feedback endpoints уже merged)
- Не блокирует следующие — интеграция в send будет отдельным issue

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_