### PR TITLE
ci(devops): Prisma drift detection + CI/CD deploy setup (#336 #320)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -65,9 +65,13 @@ jobs:
             git checkout "$BRANCH"
             git reset --hard "origin/$BRANCH"
 
-            echo "→ rebuilding indiahorizone-web-dev"
+            echo "→ rebuilding containers"
             cd /opt/indiahorizone
-            docker compose -f docker-compose.dev.yml up -d --build web
+            docker compose --env-file .env -f docker-compose.dev.yml up -d --build api web
+
+            echo "→ running migrations"
+            docker compose --env-file .env -f docker-compose.dev.yml run --rm api \
+              sh -c 'cd /app/apps/api && /app/apps/api/node_modules/.bin/prisma migrate deploy' || true
 
             echo "→ wait for healthy (max 60s)"
             for i in $(seq 1 12); do

--- a/.github/workflows/prisma-check.yml
+++ b/.github/workflows/prisma-check.yml
@@ -1,0 +1,106 @@
+name: Prisma Schema Check
+
+# Запускается только когда PR трогает Prisma-файлы.
+# Цель: поймать расхождение schema.prisma ↔ migrations ДО merge в main.
+# Контекст: hotfix #335 (missing sessions migration) стоил ~2 часов — этот guard
+# делает такое невозможным.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/prisma/schema.prisma'
+      - 'apps/api/prisma/migrations/**'
+
+concurrency:
+  group: prisma-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PNPM_VERSION: '9.12.0'
+  NODE_VERSION: '20'
+
+jobs:
+  prisma-drift:
+    name: Schema ↔ Migrations in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      # Ставим только зависимости api (включает Prisma CLI)
+      - name: Install api dependencies
+        run: pnpm install --frozen-lockfile --filter "@indiahorizone/api..."
+
+      # Применяем все миграции к чистой БД
+      - name: Apply migrations
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?schema=public
+        working-directory: apps/api
+        run: pnpm exec prisma migrate deploy
+
+      # Сравниваем schema.prisma против примёненных миграций.
+      # exit 0 = в синке, exit 2 = дрифт (новые таблицы/поля в schema без migration).
+      # Если дрифт — выводим понятный текст и фейлим CI.
+      - name: Check schema ↔ migrations drift
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test?schema=public
+        working-directory: apps/api
+        run: |
+          echo "Comparing schema.prisma against applied migrations..."
+          if ! pnpm exec prisma migrate diff \
+            --from-migrations prisma/migrations \
+            --to-schema-datamodel prisma/schema.prisma \
+            --exit-code; then
+            echo ""
+            echo "❌ Schema drift detected!"
+            echo ""
+            echo "schema.prisma содержит изменения, для которых нет миграции."
+            echo "Скорее всего ты добавил модель/поле в schema.prisma, но забыл"
+            echo "запустить: pnpm --filter @indiahorizone/api db:migrate:dev"
+            echo ""
+            echo "Как исправить:"
+            echo "  cd apps/api"
+            echo "  pnpm exec prisma migrate dev --name <описание_изменения>"
+            echo "  git add prisma/migrations"
+            echo "  git commit -m 'feat(db): add migration for ...'"
+            exit 2
+          fi
+          echo "✅ Schema and migrations are in sync"
+
+      # Дополнительно: валидация синтаксиса schema.prisma (1 секунда, ловит опечатки)
+      - name: Validate schema syntax
+        working-directory: apps/api
+        run: |
+          echo "Validating schema.prisma syntax..."
+          pnpm exec prisma validate
+          echo "✅ Schema syntax is valid"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -445,6 +445,24 @@ Closes #12
 
 ---
 
+## Database changes (Prisma)
+
+Если твой PR меняет `apps/api/prisma/schema.prisma` — **обязательно** создай миграцию:
+
+```bash
+cd apps/api
+pnpm exec prisma migrate dev --name <описание_изменения>
+# Пример: prisma migrate dev --name add_session_model
+```
+
+CI (`prisma-check.yml`) автоматически проверяет что schema.prisma ↔ migrations в синке.
+PR без миграции → CI fail.
+
+**Почему это важно:** однажды модель `Session` была добавлена в schema без миграции
+— баг обнаружился только на dev-деплое, потеряли ~2 часа (hotfix #335).
+
+---
+
 ## Связь с командой
 
 - **GitHub Issues:** основной канал для задач и багов

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,8 +34,8 @@ RUN pnpm install --frozen-lockfile --prefer-offline --filter "@indiahorizone/web
 # ────────────────────────── 3. builder
 FROM base AS builder
 COPY --from=deps /repo/node_modules ./node_modules
-COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules 2>/dev/null || true
-COPY --from=deps /repo/packages/shared/node_modules ./packages/shared/node_modules 2>/dev/null || true
+COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
+# shared has no separate node_modules (installed in root)
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production


### PR DESCRIPTION
## Closes #336, #320

### Что сделано

#### #336 — Prisma drift detection
- `.github/workflows/prisma-check.yml` — CI guard против schema/migration drift
- `CONTRIBUTING.md` — раздел § Database changes

#### #320 — Dev окружение + CI/CD
- `.github/workflows/deploy-dev.yml` — исправлен context path + добавлены миграции
- `apps/web/Dockerfile` — убран невалидный `2>/dev/null || true` в COPY
- GitHub Secrets добавлены: DEV_SSH_HOST, DEV_SSH_USER, DEV_SSH_KEY
- `/opt/indiahorizone/` настроен на сервере 2.56.241.126

### Smoke tests ✅
- `http://2.56.241.126:3010/` → 200
- `http://2.56.241.126:3011/health` → 200
- Все 4 контейнера healthy