### PR TITLE
feat(trips): itinerary versioning + publish + GET (#151)

### DIFF
--- a/apps/api/src/modules/trips/itinerary/dto/itinerary.dto.ts
+++ b/apps/api/src/modules/trips/itinerary/dto/itinerary.dto.ts
@@ -1,0 +1,75 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsObject,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+import type { DayPlan, Itinerary } from '@prisma/client';
+
+/**
+ * Один день в маршруте при PATCH /trips/:id/itinerary (#151).
+ *
+ * items — JSONB-массив плана дня. Структуру не валидируем в DTO (свободный
+ * JSON, разные дни — разные структуры). Validation глубокая — на уровне
+ * UI и шаблонов в админке (EPIC 13).
+ */
+export class DayPlanInputDto {
+  @IsInt()
+  @Min(1)
+  dayNumber!: number;
+
+  /** ISO date 'YYYY-MM-DD' либо ISO datetime — Prisma приведёт к Date. */
+  @IsDateString()
+  date!: string;
+
+  @IsString()
+  @MaxLength(500)
+  summary!: string;
+
+  /** Свободный массив плана дня. */
+  @IsArray()
+  items!: unknown[];
+}
+
+/**
+ * PATCH /trips/:id/itinerary — создаёт новую draft-version.
+ * Полная замена days (не diff — caller присылает финальный массив, сервер
+ * сравнивает и компонует diff на publish step).
+ */
+export class UpsertItineraryDto {
+  @IsArray()
+  @ArrayMinSize(1, { message: 'Itinerary должен иметь хотя бы один день' })
+  @ValidateNested({ each: true })
+  @Type(() => DayPlanInputDto)
+  days!: DayPlanInputDto[];
+}
+
+export interface ItineraryWithDays extends Itinerary {
+  days: DayPlan[];
+}
+
+export interface CreateVersionResponse {
+  itineraryId: string;
+  version: number;
+  daysCount: number;
+}
+
+export interface PublishResponse {
+  itineraryId: string;
+  version: number;
+  publishedAt: Date;
+  diff: {
+    addedDays: number[];
+    removedDays: number[];
+    changedDays: number[];
+    /** Был ли previously published itinerary. false = первая публикация. */
+    hadPrevious: boolean;
+  };
+}

--- a/apps/api/src/modules/trips/itinerary/itinerary.controller.ts
+++ b/apps/api/src/modules/trips/itinerary/itinerary.controller.ts
@@ -1,0 +1,66 @@
+/**
+ * ItineraryController — версионированный маршрут поездки (#151).
+ *
+ * PATCH  /trips/:id/itinerary          — manager/admin: создать/обновить draft
+ * POST   /trips/:id/itinerary/publish  — manager/admin: опубликовать draft
+ * GET    /trips/:id/itinerary          — client (own) + manager+ : last published
+ *
+ * RBAC routing — частично через @Roles, частично service.assertReadAccess
+ * (для GET где разные роли видят разное).
+ */
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+
+import { CurrentUser, Roles } from '../../../common/auth/decorators';
+import {
+  type CreateVersionResponse,
+  type ItineraryWithDays,
+  type PublishResponse,
+  UpsertItineraryDto,
+} from './dto/itinerary.dto';
+import { ItineraryService } from './itinerary.service';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+
+@Controller('trips')
+export class ItineraryController {
+  constructor(private readonly itinerary: ItineraryService) {}
+
+  @Patch(':id/itinerary')
+  @HttpCode(HttpStatus.OK)
+  @Roles('manager', 'admin')
+  async upsertDraft(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+    @Body() dto: UpsertItineraryDto,
+  ): Promise<CreateVersionResponse> {
+    return this.itinerary.upsertDraft(tripId, user.id, dto.days);
+  }
+
+  @Post(':id/itinerary/publish')
+  @HttpCode(HttpStatus.OK)
+  @Roles('manager', 'admin')
+  async publish(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+  ): Promise<PublishResponse> {
+    return this.itinerary.publishLatest(tripId, user.id);
+  }
+
+  @Get(':id/itinerary')
+  async get(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+  ): Promise<ItineraryWithDays> {
+    return this.itinerary.getLatestPublished(tripId, user.id, user.role);
+  }
+}

--- a/apps/api/src/modules/trips/itinerary/itinerary.service.ts
+++ b/apps/api/src/modules/trips/itinerary/itinerary.service.ts
@@ -1,0 +1,316 @@
+/**
+ * ItineraryService — версионирование маршрутов (#151).
+ *
+ * Поток:
+ * 1. PATCH /trips/:id/itinerary → upsertVersion(tripId, days) — создаёт ДРАФТ
+ *    (новая Itinerary с version=N+1, publishedAt=null) или дополняет последний
+ *    неопубликованный draft.
+ * 2. POST /trips/:id/itinerary/publish → publishLatest(tripId) — старая
+ *    "published" остаётся (история), новая получает publishedAt=now.
+ * 3. GET /trips/:id/itinerary — return last where publishedAt is not null.
+ *
+ * Уникальный (trip_id, version) гарантируется БД — параллельный publish одного
+ * draft двумя manager'ами один из них получит P2002 → caller ретраит на
+ * актуальной версии.
+ *
+ * Diff на publish:
+ * - Сравниваем НОВЫЕ days (только что published) с ПРЕДЫДУЩИМИ published.
+ * - addedDays / removedDays — по dayNumber
+ * - changedDays — где summary, date или items[] отличаются (deep equal)
+ * - Diff сохраняется в outbox event `trips.itinerary.updated` для audit (#218)
+ */
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+import type {
+  CreateVersionResponse,
+  DayPlanInputDto,
+  ItineraryWithDays,
+  PublishResponse,
+} from './dto/itinerary.dto';
+import type { DayPlan, Prisma, UserRole } from '@prisma/client';
+
+@Injectable()
+export class ItineraryService {
+  private readonly logger = new Logger(ItineraryService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  /**
+   * PATCH /trips/:id/itinerary — создать новый draft Itinerary с днями.
+   *
+   * Идемпотентность: если последняя Itinerary draft (publishedAt=null) —
+   * перезаписываем её days (full replace). Если последняя published —
+   * создаём новую version=N+1 с publishedAt=null.
+   */
+  async upsertDraft(
+    tripId: string,
+    creatorUserId: string,
+    days: DayPlanInputDto[],
+  ): Promise<CreateVersionResponse> {
+    await this.assertTripExists(tripId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const lastVersion = await tx.itinerary.findFirst({
+        where: { tripId },
+        orderBy: { version: 'desc' },
+        select: { id: true, version: true, publishedAt: true },
+      });
+
+      let itineraryId: string;
+      let version: number;
+
+      if (lastVersion && lastVersion.publishedAt === null) {
+        // Reuse существующий draft — full-replace days.
+        await tx.dayPlan.deleteMany({ where: { itineraryId: lastVersion.id } });
+        itineraryId = lastVersion.id;
+        version = lastVersion.version;
+      } else {
+        // Создаём новую version (предыдущая published, или вообще первая).
+        const nextVersion = (lastVersion?.version ?? 0) + 1;
+        const created = await tx.itinerary.create({
+          data: { tripId, version: nextVersion },
+          select: { id: true, version: true },
+        });
+        itineraryId = created.id;
+        version = created.version;
+      }
+
+      // Bulk insert days.
+      await tx.dayPlan.createMany({
+        data: days.map((d) => ({
+          itineraryId,
+          dayNumber: d.dayNumber,
+          date: new Date(d.date),
+          summary: d.summary,
+          items: d.items as Prisma.InputJsonValue,
+        })),
+      });
+
+      this.logger.log(
+        { tripId, itineraryId, version, daysCount: days.length, creatorUserId },
+        'itinerary.draft.upserted',
+      );
+
+      return { itineraryId, version, daysCount: days.length };
+    });
+  }
+
+  /**
+   * Опубликовать последний draft. Diff между новой и предыдущей published
+   * → outbox event trips.itinerary.updated.
+   *
+   * При невалидной last (нет draft'а или уже published) — 409 Conflict
+   * (через NotFound для simplicity сейчас).
+   */
+  async publishLatest(tripId: string, publisherUserId: string): Promise<PublishResponse> {
+    await this.assertTripExists(tripId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const draft = await tx.itinerary.findFirst({
+        where: { tripId, publishedAt: null },
+        orderBy: { version: 'desc' },
+        select: { id: true, version: true },
+      });
+
+      if (!draft) {
+        throw new NotFoundException(
+          'Нет draft itinerary для публикации. Сначала PATCH /itinerary.',
+        );
+      }
+
+      const previouslyPublished = await tx.itinerary.findFirst({
+        where: { tripId, publishedAt: { not: null } },
+        orderBy: { version: 'desc' },
+        select: { id: true, version: true },
+      });
+
+      // Получаем days обоих versions для diff.
+      const [newDays, oldDays] = await Promise.all([
+        tx.dayPlan.findMany({ where: { itineraryId: draft.id } }),
+        previouslyPublished
+          ? tx.dayPlan.findMany({ where: { itineraryId: previouslyPublished.id } })
+          : Promise.resolve([] as DayPlan[]),
+      ]);
+
+      const diff = computeDiff(oldDays, newDays);
+
+      const now = new Date();
+      await tx.itinerary.update({
+        where: { id: draft.id },
+        data: { publishedAt: now },
+      });
+
+      await this.outbox.add(tx, {
+        type: 'trips.itinerary.updated',
+        schemaVersion: 1,
+        actor: { type: 'user', id: publisherUserId },
+        payload: {
+          tripId,
+          itineraryId: draft.id,
+          version: draft.version,
+          publishedAt: now.toISOString(),
+          previousVersion: previouslyPublished?.version ?? null,
+          dayPlanIds: newDays.map((d) => d.id),
+          diff,
+        },
+      });
+
+      this.logger.log(
+        {
+          tripId,
+          itineraryId: draft.id,
+          version: draft.version,
+          addedDays: diff.addedDays.length,
+          removedDays: diff.removedDays.length,
+          changedDays: diff.changedDays.length,
+        },
+        'itinerary.published',
+      );
+
+      return {
+        itineraryId: draft.id,
+        version: draft.version,
+        publishedAt: now,
+        diff: {
+          addedDays: diff.addedDays,
+          removedDays: diff.removedDays,
+          changedDays: diff.changedDays,
+          hadPrevious: previouslyPublished !== null,
+        },
+      };
+    });
+  }
+
+  /**
+   * GET /trips/:id/itinerary — последняя published version (для клиента).
+   * Если нет published — 404 (даже если есть draft — клиент его не видит).
+   */
+  async getLatestPublished(
+    tripId: string,
+    userId: string,
+    role: UserRole,
+  ): Promise<ItineraryWithDays> {
+    await this.assertReadAccess(userId, role, tripId);
+
+    const itinerary = await this.prisma.itinerary.findFirst({
+      where: { tripId, publishedAt: { not: null } },
+      orderBy: { version: 'desc' },
+      include: { days: { orderBy: { dayNumber: 'asc' } } },
+    });
+    if (!itinerary) {
+      throw new NotFoundException('Маршрут ещё не опубликован');
+    }
+    return itinerary;
+  }
+
+  // ─── access helpers ───
+
+  private async assertTripExists(tripId: string): Promise<void> {
+    const exists = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { id: true },
+    });
+    if (!exists) {
+      throw new NotFoundException(`Trip не найден: ${tripId}`);
+    }
+  }
+
+  /**
+   * GET доступ:
+   * - admin / manager / concierge / finance → все trips
+   * - client → только own trip (через Trip.clientId → Client.userId)
+   */
+  private async assertReadAccess(
+    userId: string,
+    role: UserRole,
+    tripId: string,
+  ): Promise<void> {
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { clientId: true },
+    });
+    if (!trip) {
+      throw new NotFoundException('Trip не найден');
+    }
+
+    if (
+      role === 'admin' ||
+      role === 'manager' ||
+      role === 'concierge' ||
+      role === 'finance'
+    ) {
+      return;
+    }
+
+    if (role === 'client') {
+      const client = await this.prisma.client.findUnique({
+        where: { id: trip.clientId },
+        select: { userId: true },
+      });
+      if (client && client.userId === userId) return;
+    }
+
+    throw new ForbiddenException('Нет доступа к маршруту этого trip');
+  }
+}
+
+/**
+ * Diff между two наборами days по dayNumber.
+ *
+ * - added: dayNumber есть в new, нет в old
+ * - removed: dayNumber есть в old, нет в new
+ * - changed: dayNumber в обоих, но summary/date/items отличаются
+ */
+function computeDiff(
+  oldDays: DayPlan[],
+  newDays: DayPlan[],
+): {
+  addedDays: number[];
+  removedDays: number[];
+  changedDays: number[];
+} {
+  const oldByNumber = new Map<number, DayPlan>();
+  for (const d of oldDays) oldByNumber.set(d.dayNumber, d);
+  const newByNumber = new Map<number, DayPlan>();
+  for (const d of newDays) newByNumber.set(d.dayNumber, d);
+
+  const addedDays: number[] = [];
+  const removedDays: number[] = [];
+  const changedDays: number[] = [];
+
+  for (const [n, newD] of newByNumber) {
+    const oldD = oldByNumber.get(n);
+    if (!oldD) {
+      addedDays.push(n);
+      continue;
+    }
+    if (
+      newD.summary !== oldD.summary ||
+      newD.date.getTime() !== oldD.date.getTime() ||
+      JSON.stringify(newD.items) !== JSON.stringify(oldD.items)
+    ) {
+      changedDays.push(n);
+    }
+  }
+
+  for (const n of oldByNumber.keys()) {
+    if (!newByNumber.has(n)) removedDays.push(n);
+  }
+
+  addedDays.sort((a, b) => a - b);
+  removedDays.sort((a, b) => a - b);
+  changedDays.sort((a, b) => a - b);
+
+  return { addedDays, removedDays, changedDays };
+}

--- a/apps/api/src/modules/trips/trips.module.ts
+++ b/apps/api/src/modules/trips/trips.module.ts
@@ -7,14 +7,16 @@
  */
 import { Module } from '@nestjs/common';
 
+import { ItineraryController } from './itinerary/itinerary.controller';
+import { ItineraryService } from './itinerary/itinerary.service';
 import { TripsController } from './trips.controller';
 import { TripsService } from './trips.service';
 import { PrismaModule } from '../../common/prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [TripsController],
-  providers: [TripsService],
-  exports: [TripsService],
+  controllers: [TripsController, ItineraryController],
+  providers: [TripsService, ItineraryService],
+  exports: [TripsService, ItineraryService],
 })
 export class TripsModule {}


### PR DESCRIPTION
## Summary

Версионирование маршрута поездки. Закрывает #151. Завершает M5.D Trips backend (вместе с #149/#150) — остался только #160 (status transitions, blocked finance).

## Endpoints

```
PATCH  /trips/:id/itinerary          — manager/admin: создать/обновить draft
POST   /trips/:id/itinerary/publish  — manager/admin: опубликовать draft
GET    /trips/:id/itinerary          — client (own) / manager+ : latest published
```

## Workflow

```
1. PATCH /itinerary {days: [...]}  → draft создан/обновлён, publishedAt=null
2. (повторный PATCH с другими days)  → reuse draft, full-replace days
3. POST /itinerary/publish          → publishedAt=now, diff vs previous, outbox event
4. PATCH /itinerary {days: [...]}  → новая Itinerary version=N+1 (предыдущая опубликована)
5. POST /publish ещё раз            → новая publishedAt
```

История всех versions сохраняется в БД (для аудита). Клиент через GET видит только последнюю published.

## Diff на publish

Сравниваем new days с previously published days по `dayNumber`:

```ts
{
  addedDays:   [3, 5],     // dayNumber есть в new, нет в old
  removedDays: [4],         // наоборот
  changedDays: [1, 2, 7],   // оба, но summary/date/items различаются
  hadPrevious: true
}
```

`items[]` сравнивается через `JSON.stringify` deep-equal — простой и достаточный для V1 (для глубокой структурной аналитики — V2 через jsondiffpatch).

## Outbox event

```ts
{
  type: 'trips.itinerary.updated',
  payload: {
    tripId, itineraryId, version, publishedAt,
    previousVersion: number | null,
    dayPlanIds: string[],   // все UUID dayPlans новой version
    diff: {addedDays, removedDays, changedDays}
  }
}
```

Subscriber'ы:
- **Audit (#218)** — пишет полный diff в audit_events
- **Будущий push-handler** — нотификация клиенту «маршрут обновлён» (когда #163 готов)
- **Будущий cache-invalidation** для PWA offline copy на мобильном

## Race-safety

- **Параллельный publish одного draft** двумя manager'ами: `unique (trip_id, version)` constraint в БД (#149) — один из publish'ей атомарно поставит publishedAt, второй получит P2002. Caller ретраит на актуальной версии.
- **Concurrent upsertDraft на reused draft**: last-write-wins (bulk replace через deleteMany + createMany в транзакции).

## RBAC

| Endpoint | Роли |
|---|---|
| PATCH | manager, admin |
| POST publish | manager, admin |
| GET | client (own trip), manager, admin, concierge, finance |

## Что НЕ в этом PR

- **DELETE /itinerary/:version** — soft-delete старых versions (отдельный issue, для админов когда захотят зачистить историю)
- **PATCH одиночного дня без full-replace** — drag-drop UX в админке (#13.10) можно реализовать через текущий endpoint полным replacement; если будет нужен incremental — отдельный issue
- **Frontend editor** (`apps/admin` или `apps/web/admin`) — отдельный UX issue в EPIC 13

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после re-deploy):**
  - Manager: `PATCH /trips/:id/itinerary {days: [{...10 дней}]}` → draft id, version=1
  - Manager: `POST /trips/:id/itinerary/publish` → publishedAt + diff `{addedDays:[1..10], hadPrevious: false}`
  - Client (owner): `GET /trips/:id/itinerary` → массив 10 days
  - Client (другой): `GET ...` → 403
  - Manager: `PATCH /itinerary {days: [...11 дней]}` → version=2, draft
  - Manager: `POST /publish` → version=2 published, `diff: {addedDays:[11], changedDays:[если что-то поменял]}`
  - Client: `GET` теперь возвращает version=2

## Closes

- Closes #151
- M5.D Trips backend slice ≈ done (только #160 transitions blocked)

## Зависимости

- Базируется на main (PR #352 WebSocket уже merged)
- Не блокирует следующие — это завершение D-slice

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_