### PR TITLE
chore(observability): Prometheus metrics baseline (#125)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,6 +54,7 @@
     "otplib": "^13.4.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,12 @@
-import { Module } from '@nestjs/common';
+import { type MiddlewareConsumer, Module, type NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { CommonAuthModule } from './common/auth/auth.module';
 import { CryptoModule } from './common/crypto/crypto.module';
 import { EventsBusModule } from './common/events-bus/events-bus.module';
 import { LoggerModule } from './common/logger/logger.module';
+import { MetricsMiddleware } from './common/metrics/metrics.middleware';
+import { MetricsModule } from './common/metrics/metrics.module';
 import { OutboxModule } from './common/outbox/outbox.module';
 import { PrismaModule } from './common/prisma/prisma.module';
 import { RedisModule } from './common/redis/redis.module';
@@ -27,6 +29,7 @@ import { TripsModule } from './modules/trips/trips.module';
       cache: true,
     }),
     LoggerModule, // pino + correlation-id (#124) — должен быть выше остальных
+    MetricsModule, // Prometheus metrics + /metrics endpoint (#125)
     CryptoModule, // global, нужен PrismaService в фазе 4 + ClientsService уже сейчас (#139)
     PrismaModule,
     RedisModule,
@@ -46,4 +49,9 @@ import { TripsModule } from './modules/trips/trips.module';
     HealthModule,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    // HTTP request duration metric — на все routes (#125)
+    consumer.apply(MetricsMiddleware).forRoutes('*');
+  }
+}

--- a/apps/api/src/common/metrics/metrics.controller.ts
+++ b/apps/api/src/common/metrics/metrics.controller.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /metrics — Prometheus scrape endpoint (#125).
+ *
+ * Защита: header `X-Internal-Token` должен совпадать с env METRICS_TOKEN.
+ * Если METRICS_TOKEN не задан — endpoint полностью отключён (403 для всех).
+ *
+ * Это **не endpoint для пользователей** — Prometheus / VictoriaMetrics scrape'ит
+ * отсюда метрики. Доступен ТОЛЬКО Viка через docker network (или внешний
+ * Prometheus с правильным токеном).
+ *
+ * Не rate-limited (исключим в throttle.config skipIf), не audited.
+ */
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Headers,
+  Res,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SkipThrottle } from '@nestjs/throttler';
+
+import { MetricsService } from './metrics.service';
+import { Public } from '../auth/decorators';
+
+import type { Response } from 'express';
+
+@Controller()
+@SkipThrottle()
+export class MetricsController {
+  constructor(
+    private readonly metrics: MetricsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Prometheus default content-type: `text/plain; version=0.0.4; charset=utf-8`
+   * (важно — Prometheus отказывается парсить если другой).
+   */
+  @Public()
+  @Get('metrics')
+  async scrape(
+    @Headers('x-internal-token') token: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    const expected = this.config.get<string>('METRICS_TOKEN');
+    if (!expected) {
+      // Endpoint полностью disabled — METRICS_TOKEN обязателен в prod.
+      // В dev'е без переменной получим 403; Викa добавит при первом scrape.
+      throw new ForbiddenException('Metrics endpoint disabled (METRICS_TOKEN not set)');
+    }
+    if (token !== expected) {
+      throw new ForbiddenException('Invalid X-Internal-Token');
+    }
+
+    const body = await this.metrics.registry.metrics();
+    res.setHeader('Content-Type', this.metrics.registry.contentType);
+    res.send(body);
+  }
+}

--- a/apps/api/src/common/metrics/metrics.middleware.ts
+++ b/apps/api/src/common/metrics/metrics.middleware.ts
@@ -1,0 +1,51 @@
+/**
+ * HTTP request duration middleware (#125).
+ *
+ * При каждом HTTP-запросе:
+ * 1. Запускает таймер
+ * 2. По завершении ответа фиксирует latency в histogram'е с лейблами:
+ *    - method: GET/POST/PATCH/DELETE
+ *    - route: matched Express route (например /clients/me, /trips/:id/itinerary)
+ *      → cardinality controlled, не взрывается от ID'ов
+ *    - status: 2xx/4xx/5xx
+ *
+ * Регистрируется в AppModule через apply(MetricsMiddleware).forRoutes('*').
+ */
+import { Injectable, type NestMiddleware } from '@nestjs/common';
+
+import { MetricsService } from './metrics.service';
+
+import type { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class MetricsMiddleware implements NestMiddleware {
+  constructor(private readonly metrics: MetricsService) {}
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const startNs = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const endNs = process.hrtime.bigint();
+      const durationSec = Number(endNs - startNs) / 1e9;
+
+      // Express заполняет req.route после matching'а — берём path шаблон.
+      // Если route нет (404, /metrics direct hit) — используем 'unknown'.
+      const route =
+        (req as unknown as { route?: { path?: string } }).route?.path ??
+        // fallback на baseUrl + path для unmatched
+        (req.originalUrl ?? req.url ?? '').split('?')[0] ??
+        'unknown';
+
+      this.metrics.httpRequestDuration.observe(
+        {
+          method: req.method,
+          route: typeof route === 'string' ? route : 'unknown',
+          status: String(res.statusCode),
+        },
+        durationSec,
+      );
+    });
+
+    next();
+  }
+}

--- a/apps/api/src/common/metrics/metrics.module.ts
+++ b/apps/api/src/common/metrics/metrics.module.ts
@@ -1,0 +1,23 @@
+/**
+ * MetricsModule — Prometheus metrics + middleware + scrape endpoint (#125).
+ *
+ * Global — MetricsService доступен везде (для регистрации custom метрик
+ * каждым модулем).
+ *
+ * Middleware регистрируется в AppModule через configure(consumer).
+ */
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { MetricsController } from './metrics.controller';
+import { MetricsMiddleware } from './metrics.middleware';
+import { MetricsService } from './metrics.service';
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  controllers: [MetricsController],
+  providers: [MetricsService, MetricsMiddleware],
+  exports: [MetricsService, MetricsMiddleware],
+})
+export class MetricsModule {}

--- a/apps/api/src/common/metrics/metrics.service.ts
+++ b/apps/api/src/common/metrics/metrics.service.ts
@@ -1,0 +1,84 @@
+/**
+ * MetricsService — Prometheus metrics baseline (#125).
+ *
+ * Использует prom-client default registry. При initial start:
+ * - collectDefaultMetrics() — Node.js process metrics (eventloop lag,
+ *   heap_used, gc_duration_seconds, active_handles, etc.)
+ * - http_request_duration_seconds — histogram с лейблами method/route/status
+ *
+ * Custom metrics добавляются через .registerHistogram/Counter/Gauge —
+ * caller'ы (например outbox-relay для outbox_pending_count) импортируют
+ * сервис и регистрируют свою метрику.
+ *
+ * Endpoint /metrics реализуется в MetricsController (защита internal-token).
+ */
+import { Injectable, type OnModuleInit } from '@nestjs/common';
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+  collectDefaultMetrics,
+} from 'prom-client';
+
+@Injectable()
+export class MetricsService implements OnModuleInit {
+  readonly registry: Registry;
+  readonly httpRequestDuration: Histogram<'method' | 'route' | 'status'>;
+
+  constructor() {
+    this.registry = new Registry();
+
+    this.httpRequestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request latency in seconds',
+      labelNames: ['method', 'route', 'status'] as const,
+      // Buckets подобраны под typical web API: 5ms, 10ms, ..., 5s, 10s.
+      // 99% латентности должны попадать в bucket'ы для percentile-аккуратности.
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      registers: [this.registry],
+    });
+  }
+
+  onModuleInit(): void {
+    // Default metrics: process_*, nodejs_*, gc_*, etc. — стандарт Prom community.
+    collectDefaultMetrics({ register: this.registry });
+  }
+
+  /**
+   * Helper для модулей, которые хотят зарегистрировать свою counter/gauge/histogram.
+   * Используется например в outbox-relay для счётчика pending entries.
+   */
+  registerCounter(opts: { name: string; help: string; labelNames?: string[] }): Counter {
+    return new Counter({
+      name: opts.name,
+      help: opts.help,
+      labelNames: opts.labelNames ?? [],
+      registers: [this.registry],
+    });
+  }
+
+  registerGauge(opts: { name: string; help: string; labelNames?: string[] }): Gauge {
+    return new Gauge({
+      name: opts.name,
+      help: opts.help,
+      labelNames: opts.labelNames ?? [],
+      registers: [this.registry],
+    });
+  }
+
+  registerHistogram(opts: {
+    name: string;
+    help: string;
+    labelNames?: string[];
+    buckets?: number[];
+  }): Histogram {
+    return new Histogram({
+      name: opts.name,
+      help: opts.help,
+      labelNames: opts.labelNames ?? [],
+      ...(opts.buckets ? { buckets: opts.buckets } : {}),
+      registers: [this.registry],
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       pino-http:
         specifier: ^11.0.0
         version: 11.0.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1980,6 +1983,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -3581,6 +3587,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
@@ -3966,6 +3976,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.5.0:
     resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
@@ -6777,6 +6790,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bintrees@1.0.2: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -8503,6 +8518,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -8988,6 +9008,10 @@ snapshots:
       - yaml
 
   tapable@2.3.3: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terser-webpack-plugin@5.5.0(webpack@5.97.1):
     dependencies:


### PR DESCRIPTION
## Summary

Prometheus metrics + middleware + scrape endpoint. Закрывает #125. **M5.A bootstrap slice ПОЛНОСТЬЮ done** после этого PR'а.

## Что внутри

### MetricsService

```ts
- registry: prom-client Registry (default)
- httpRequestDuration: Histogram(method, route, status), buckets 5ms..10s
- collectDefaultMetrics() при init — process_*, nodejs_*, gc_*
- registerCounter/Gauge/Histogram — для custom метрик других модулей
```

### MetricsMiddleware

```ts
hrtime-based timing на каждый HTTP request:
  start: process.hrtime.bigint()
  res.on('finish'): histogram.observe({method, route, status}, durationSec)
```

`route` берём из Express'а после matching'а (`req.route.path` = `/clients/me`, `/trips/:id/itinerary`) — controlled cardinality, не взрывается от UUID'ов.

### MetricsController

```
GET /metrics
  Header: X-Internal-Token: ${METRICS_TOKEN}
  Content-Type: text/plain; version=0.0.4; charset=utf-8
  @Public + @SkipThrottle
```

Если `METRICS_TOKEN` не задан — endpoint полностью disabled (403). Безопасный default. Vика добавит токен в `.env`:

```bash
METRICS_TOKEN=$(openssl rand -hex 32)
```

### AppModule.configure

```ts
configure(consumer: MiddlewareConsumer) {
  consumer.apply(MetricsMiddleware).forRoutes('*');
}
```

## Default metrics (бесплатно из collectDefaultMetrics)

- `process_resident_memory_bytes`
- `nodejs_eventloop_lag_seconds` (важно для diagnostics)
- `nodejs_heap_size_used_bytes`
- `nodejs_gc_duration_seconds`
- `nodejs_active_handles_total`
- `process_cpu_seconds_total`

## Custom метрики (для модулей)

Любой модуль может регистрировать через DI:

```ts
constructor(private readonly metrics: MetricsService) {}

private outboxPending = this.metrics.registerGauge({
  name: 'outbox_pending_count',
  help: 'Unpublished outbox entries',
});

// Затем в коде:
this.outboxPending.set(count);
```

## Prometheus scrape config (для Вики когда подключит)

```yaml
scrape_configs:
  - job_name: indiahorizone-api
    static_configs:
      - targets: ['api:4000']
    metrics_path: /metrics
    scrape_interval: 15s
    bearer_token: ${METRICS_TOKEN}   # или authorization header через relabeling
```

## Что НЕ в этом PR

- **Custom метрики per-module** (outbox_pending, redis_cache_hit_rate, login_attempts, etc.) — отдельные small commits
- **Grafana dashboards** — #224, devops:vika
- **Prometheus в docker-compose** — devops:vika когда дойдём до monitoring stack
- **Alerting rules** — после Grafana (отдельный issue)

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после re-deploy):**
  - `curl http://2.56.241.126:3011/metrics` → 403 (нет header)
  - `curl -H 'X-Internal-Token: <token>' http://2.56.241.126:3011/metrics` → 200, Prometheus formatted output
  - В output: `http_request_duration_seconds_bucket{le="0.005"}...`, `process_resident_memory_bytes`, etc.
  - После `curl /auth/login` (несколько раз) — `http_request_duration_seconds_count{method="POST",route="/auth/login",status="200"}` инкрементируется

## Closes

- Closes #125 — последний P1 в M5.A
- **M5.A Bootstrap slice ПОЛНОСТЬЮ done**: Prisma + Redis + outbox + idempotency + pino + OTel + metrics

## Зависимости

- `prom-client@^15`
- Базируется на main (PR #357 OpenTelemetry уже merged — оба observability работают рядом без конфликтов)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_