### PR TITLE
feat(trips): GET /trips/me + GET /trips/:id с RBAC (#361)

### DIFF
--- a/apps/api/src/modules/trips/trips.controller.ts
+++ b/apps/api/src/modules/trips/trips.controller.ts
@@ -1,25 +1,40 @@
 /**
  * TripsController — endpoints управления поездками.
  *
- * - POST /trips — создание Trip менеджером/админом (#150)
+ * - POST /trips      — создание Trip менеджером/админом (#150)
+ * - GET  /trips/me   — список trip'ов с RBAC (#361)
+ * - GET  /trips/:id  — детали trip (#361)
  *
- * Будущее: PATCH/DELETE/list, bookings nested — отдельные issues.
+ * Note: PATCH /trips/:id/itinerary и связанные — в ItineraryController (#151).
  */
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 
 import { CreateTripDto, type CreateTripResponse } from './dto/create-trip.dto';
 import { TripsService } from './trips.service';
 import { CurrentUser, Roles } from '../../common/auth/decorators';
 
 import type { AuthenticatedUser } from '../../common/auth/types';
+import type { Trip } from '@prisma/client';
 
 @Controller('trips')
-@Roles('manager', 'admin')
 export class TripsController {
   constructor(private readonly trips: TripsService) {}
 
+  /**
+   * POST /trips — создание trip'а. Только manager / admin.
+   */
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @Roles('manager', 'admin')
   async create(
     @CurrentUser() user: AuthenticatedUser,
     @Body() dto: CreateTripDto,
@@ -34,5 +49,35 @@ export class TripsController {
       ...(dto.currency !== undefined ? { currency: dto.currency } : {}),
       createdBy: user.id,
     });
+  }
+
+  /**
+   * GET /trips/me — список trip'ов с фильтром по role:
+   * - client → only own
+   * - manager → only created-by-self
+   * - admin/concierge/finance → все (top 100)
+   */
+  @Get('me')
+  async listMine(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<{ items: Trip[] }> {
+    const items = await this.trips.listForUser(user.id, user.role);
+    return { items };
+  }
+
+  /**
+   * GET /trips/:id — детали одной trip с RBAC.
+   * Возвращает Trip + bookingsCount + hasPublishedItinerary.
+   */
+  @Get(':id')
+  async findById(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+  ): Promise<{
+    trip: Trip;
+    bookingsCount: number;
+    hasPublishedItinerary: boolean;
+  }> {
+    return this.trips.findById(user.id, user.role, tripId);
   }
 }

--- a/apps/api/src/modules/trips/trips.service.ts
+++ b/apps/api/src/modules/trips/trips.service.ts
@@ -3,13 +3,23 @@
  *
  * Currently:
  * - createTrip (#150) — создание Trip + outbox `trips.created`
+ * - listForUser (#361) — RBAC-aware list (client/manager/admin)
+ * - findById (#361) — single trip с details
  *
- * Будущее (#151+): editor versioning, status transitions, bookings nesting.
+ * Будущее (#160): status transitions.
  */
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { OutboxService } from '../../common/outbox/outbox.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
+
+import type { Trip, UserRole } from '@prisma/client';
 
 export interface CreateTripInput {
   clientId: string;
@@ -91,5 +101,105 @@ export class TripsService {
       'trips.created',
     );
     return { tripId };
+  }
+
+  /**
+   * GET /trips/me — список trip'ов с фильтром по роли (#361):
+   * - client → only Trip.clientId == own client_id
+   * - manager → only Trip.createdBy == self user_id
+   * - admin / concierge / finance → все
+   * - guide → пока ничего (нет Trip.guideId attribution)
+   *
+   * Сортировка: startsAt DESC (свежие сверху).
+   */
+  async listForUser(userId: string, role: UserRole): Promise<Trip[]> {
+    if (role === 'admin' || role === 'concierge' || role === 'finance') {
+      return this.prisma.trip.findMany({
+        orderBy: { startsAt: 'desc' },
+        take: 100,
+      });
+    }
+
+    if (role === 'manager') {
+      return this.prisma.trip.findMany({
+        where: { createdBy: userId },
+        orderBy: { startsAt: 'desc' },
+        take: 100,
+      });
+    }
+
+    if (role === 'client') {
+      const client = await this.prisma.client.findUnique({
+        where: { userId },
+        select: { id: true },
+      });
+      if (!client) return [];
+      return this.prisma.trip.findMany({
+        where: { clientId: client.id },
+        orderBy: { startsAt: 'desc' },
+        take: 100,
+      });
+    }
+
+    // guide — не имеет trip-attribution в текущей schema
+    return [];
+  }
+
+  /**
+   * GET /trips/:id — детали одной trip с RBAC.
+   * Возвращает Trip + bookings count + флаг hasPublishedItinerary.
+   */
+  async findById(
+    userId: string,
+    role: UserRole,
+    tripId: string,
+  ): Promise<{
+    trip: Trip;
+    bookingsCount: number;
+    hasPublishedItinerary: boolean;
+  }> {
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      include: {
+        _count: { select: { bookings: true } },
+      },
+    });
+    if (!trip) {
+      throw new NotFoundException('Trip не найден');
+    }
+
+    // RBAC
+    if (role === 'admin' || role === 'concierge' || role === 'finance') {
+      // Полный доступ
+    } else if (role === 'manager') {
+      if (trip.createdBy !== userId) {
+        throw new ForbiddenException('Нет доступа: trip создан другим manager');
+      }
+    } else if (role === 'client') {
+      const client = await this.prisma.client.findUnique({
+        where: { userId },
+        select: { id: true },
+      });
+      // findUnique({where:{userId}}) гарантирует client.userId === userId,
+      // проверяем только что trip принадлежит этому Client.
+      if (!client || client.id !== trip.clientId) {
+        throw new ForbiddenException('Нет доступа к чужому trip');
+      }
+    } else {
+      // guide и прочее
+      throw new ForbiddenException('Нет доступа');
+    }
+
+    const publishedItinerary = await this.prisma.itinerary.findFirst({
+      where: { tripId, publishedAt: { not: null } },
+      select: { id: true },
+    });
+
+    const { _count, ...tripData } = trip;
+    return {
+      trip: tripData as Trip,
+      bookingsCount: _count.bookings,
+      hasPublishedItinerary: publishedItinerary !== null,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Read endpoints для trip'ов. Закрывает #361 (gap-issue, найденный сегодня — frontend Trip Dashboard их не сможет построить без них).

## Endpoints

```
GET /trips/me          — список с RBAC по роли
GET /trips/:id         — детали + bookingsCount + hasPublishedItinerary
```

## RBAC

| Role | GET /trips/me | GET /trips/:id |
|---|---|---|
| `client` | own (через Client.userId lookup) | own only — иначе 403 |
| `manager` | created-by-self only | created-by-self only — иначе 403 |
| `admin` | все (top 100) | все |
| `concierge` | все | все |
| `finance` | все | все |
| `guide` | empty (пока нет attribution) | 403 |

## Response shapes

```ts
GET /trips/me → { items: Trip[] }   // sorted startsAt DESC
GET /trips/:id → {
  trip: Trip,
  bookingsCount: number,            // через Prisma _count
  hasPublishedItinerary: boolean    // показать ли клиенту "View itinerary"
}
```

## Что НЕ в этом PR

- **Pagination cursor-based** на /trips/me — фаза 4 когда у одного manager'а будет > 100 trip'ов одновременно
- **Filtering** (по status, region, date range) — отдельный issue если потребуется в Trip Dashboard UI
- **Включённый latest itinerary** в GET /trips/:id — пока возвращаем boolean (фронт делает дополнительный GET /trips/:id/itinerary при необходимости). Если перфоманс станет проблемой — embed'нем в одном response.
- **GET /trips/:id/bookings** — отдельный endpoint для booking details (когда будут endpoints для Booking)

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после re-deploy):**
  - Manager создаёт Trip → `GET /trips/me` как manager → видит созданный
  - Client (Owner trip'а) → `GET /trips/me` → видит свой
  - Client (другой) → `GET /trips/me` → пустой массив
  - Client → `GET /trips/<own-id>` → 200 + meta
  - Client → `GET /trips/<other-client-trip-id>` → 403

## Closes

- Closes #361
- M5.D Trips backend: создание ✅, чтение ✅, итинерарий ✅, статус-машина ⏳ (#160 ждёт finance event)

## Зависимости

- Базируется на main (PR #360 PWA уже merged)
- Foundation для frontend #154 (Trip Dashboard главный экран) и #156 (экран маршрута)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_