### PR TITLE
feat(trips): trip status state-machine + PATCH /status + payment listener (#160)

### DIFF
--- a/apps/api/src/modules/trips/status/dto/transition.dto.ts
+++ b/apps/api/src/modules/trips/status/dto/transition.dto.ts
@@ -1,0 +1,28 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { TripStatus } from '@prisma/client';
+
+/**
+ * PATCH /trips/:id/status — manual переход (#160).
+ *
+ * `to` обязателен. `reason` опционален — если не задан, в payload event'а
+ * пишется 'manual'. Для cancelled — рекомендуется указать осознанный reason.
+ */
+export class TransitionStatusDto {
+  @IsEnum(TripStatus, {
+    message: 'to — draft|paid|in_progress|completed|cancelled',
+  })
+  to!: TripStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}
+
+export interface TransitionResponse {
+  tripId: string;
+  from: TripStatus;
+  to: TripStatus;
+  transitionedAt: Date;
+}

--- a/apps/api/src/modules/trips/status/payment-listener.ts
+++ b/apps/api/src/modules/trips/status/payment-listener.ts
@@ -1,0 +1,103 @@
+/**
+ * PaymentReceivedListener — auto-transition draft → paid при finance.payment.received (#160).
+ *
+ * Когда finance модуль (#202+) опубликует `finance.payment.received` для trip'а
+ * со status='draft' → автоматически переходим в 'paid'.
+ *
+ * Если trip уже в другом status'е (paid/cancelled/etc.) — silent skip.
+ *
+ * Note: finance модуль ещё не реализован. Этот listener будет no-op до тех пор,
+ * пока не появится publisher. После появления — заработает автоматически.
+ *
+ * Идемпотентность: гарантирована через events-bus consumer-group + processed_events.
+ */
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+
+import { EventsBusService } from '../../../common/events-bus/events-bus.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+import { TripStatusService } from './trip-status.service';
+
+import type { DomainEvent } from '../../../common/events-bus/types';
+
+interface PaymentReceivedPayload {
+  paymentId: string;
+  invoiceId: string;
+  // Один из этих полей должен ссылаться на Trip (формат TBD когда finance готов):
+  tripId?: string;
+  amount: number;
+  method: string;
+}
+
+const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+@Injectable()
+export class PaymentReceivedListener implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PaymentReceivedListener.name);
+  private subscription: { stop: () => void } | null = null;
+
+  constructor(
+    private readonly bus: EventsBusService,
+    private readonly status: TripStatusService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscription = this.bus.subscribe<PaymentReceivedPayload>(
+      'finance.payment.received',
+      this.handleEvent.bind(this),
+      {
+        consumerGroup: 'trips-status-payment',
+        consumerName: 'payment-listener-1',
+      },
+    );
+    this.logger.log('payment-listener.started');
+  }
+
+  onModuleDestroy(): void {
+    this.subscription?.stop();
+    this.subscription = null;
+  }
+
+  private async handleEvent(event: DomainEvent<PaymentReceivedPayload>): Promise<void> {
+    const { tripId } = event.payload;
+    if (!tripId) {
+      this.logger.debug({ eventId: event.id }, 'payment.no-tripId.skip');
+      return;
+    }
+
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { id: true, status: true },
+    });
+    if (!trip) {
+      this.logger.warn({ tripId, eventId: event.id }, 'payment.trip-not-found');
+      return;
+    }
+    if (trip.status !== 'draft') {
+      this.logger.debug(
+        { tripId, currentStatus: trip.status },
+        'payment.trip-not-draft.skip',
+      );
+      return; // already paid / cancelled / etc.
+    }
+
+    try {
+      await this.status.transition(
+        tripId,
+        'paid',
+        'payment-received',
+        SYSTEM_USER_ID,
+        `paymentId=${event.payload.paymentId}`,
+      );
+    } catch (err) {
+      this.logger.error({ err, tripId }, 'payment.auto-transition.failed');
+      // Не throw — события не критичны для перепроцессинга. Manual fix через
+      // PATCH /trips/:id/status если автомат не сработал.
+    }
+  }
+}

--- a/apps/api/src/modules/trips/status/status-machine.ts
+++ b/apps/api/src/modules/trips/status/status-machine.ts
@@ -1,0 +1,54 @@
+/**
+ * TripStatus state-machine (#160).
+ *
+ * Allowed transitions:
+ *
+ *   draft ──┬──► paid ──► in_progress ──► completed
+ *           │      │              │
+ *           └──────┴──────────────┴────► cancelled (anywhere)
+ *
+ * Любая попытка перехода вне этой матрицы → BadRequestException.
+ *
+ * Triggers:
+ * - draft → paid: PATCH /trips/:id/status (admin/manager) ИЛИ
+ *   listener на finance.payment.received (когда finance модуль будет готов)
+ * - paid → in_progress: scheduled cron при startsAt <= now (V2, отдельный issue)
+ *   или manual PATCH (для testing)
+ * - in_progress → completed: cron при endsAt < now (V2)
+ *   или manual PATCH
+ * - * → cancelled: manual PATCH (admin/manager) с reason
+ *
+ * Critical: state machine с explicit transitions защищает от того что год
+ * спустя кто-то напишет `status = 'completed'` из произвольного места и
+ * сломает аналитику NPS, refund'ов, закрытых-трип-метрик.
+ */
+import { TripStatus } from '@prisma/client';
+
+const ALLOWED_TRANSITIONS: Readonly<Record<TripStatus, ReadonlyArray<TripStatus>>> = {
+  draft: ['paid', 'cancelled'],
+  paid: ['in_progress', 'cancelled'],
+  in_progress: ['completed', 'cancelled'],
+  completed: [], // финальный
+  cancelled: [], // финальный
+};
+
+export function isAllowedTransition(from: TripStatus, to: TripStatus): boolean {
+  if (from === to) return false; // no-op = invalid
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+export function getAllowedTransitions(from: TripStatus): ReadonlyArray<TripStatus> {
+  return ALLOWED_TRANSITIONS[from];
+}
+
+/**
+ * Reasoning string для outbox event payload — почему произошёл переход
+ * (manual / payment-received / time-based).
+ */
+export type TransitionReason =
+  | 'manual'
+  | 'payment-received'
+  | 'time-started'
+  | 'time-ended'
+  | 'cancelled-by-client'
+  | 'cancelled-by-manager';

--- a/apps/api/src/modules/trips/status/trip-status.service.ts
+++ b/apps/api/src/modules/trips/status/trip-status.service.ts
@@ -1,0 +1,105 @@
+/**
+ * TripStatusService — управление переходами статусов trip'а (#160).
+ *
+ * - transition(tripId, to, reason, actor) — атомарный переход с валидацией
+ * - Outbox event `trips.status.changed` в той же транзакции
+ *
+ * Валидации:
+ * - Переход разрешён state-machine'ом (см. status-machine.ts)
+ * - Trip существует
+ * - Caller имеет права (RBAC проверяется в controller'е через @Roles)
+ *
+ * Race-safety: используем optimistic transition через UPDATE WHERE status = $from.
+ * Параллельный transition двумя caller'ами — один из них сработает (count=1),
+ * второй вернётся с count=0 и BadRequestException.
+ */
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+import {
+  type TransitionReason,
+  isAllowedTransition,
+} from './status-machine';
+
+import type { TransitionResponse } from './dto/transition.dto';
+import type { TripStatus } from '@prisma/client';
+
+@Injectable()
+export class TripStatusService {
+  private readonly logger = new Logger(TripStatusService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  async transition(
+    tripId: string,
+    to: TripStatus,
+    reason: TransitionReason,
+    actorId: string,
+    additionalReason?: string,
+  ): Promise<TransitionResponse> {
+    const trip = await this.prisma.trip.findUnique({
+      where: { id: tripId },
+      select: { id: true, status: true },
+    });
+    if (!trip) {
+      throw new NotFoundException('Trip не найден');
+    }
+
+    if (!isAllowedTransition(trip.status, to)) {
+      throw new BadRequestException(
+        `Переход ${trip.status} → ${to} не разрешён state-machine'ом`,
+      );
+    }
+
+    const transitionedAt = new Date();
+
+    await this.prisma.$transaction(async (tx) => {
+      // Optimistic transition с проверкой текущего status (race-safety).
+      const updated = await tx.trip.updateMany({
+        where: { id: tripId, status: trip.status },
+        data: { status: to },
+      });
+      if (updated.count === 0) {
+        // Параллельный transition уже изменил status — отказываем.
+        throw new BadRequestException(
+          'Trip status изменился во время transition (concurrent update)',
+        );
+      }
+
+      await this.outbox.add(tx, {
+        type: 'trips.status.changed',
+        schemaVersion: 1,
+        actor: { type: 'user', id: actorId },
+        payload: {
+          tripId,
+          from: trip.status,
+          to,
+          reason,
+          ...(additionalReason ? { additionalReason } : {}),
+          transitionedAt: transitionedAt.toISOString(),
+        },
+      });
+    });
+
+    this.logger.log(
+      { tripId, from: trip.status, to, reason, actorId },
+      'trips.status.changed',
+    );
+
+    return {
+      tripId,
+      from: trip.status,
+      to,
+      transitionedAt,
+    };
+  }
+}

--- a/apps/api/src/modules/trips/trips.controller.ts
+++ b/apps/api/src/modules/trips/trips.controller.ts
@@ -15,10 +15,16 @@ import {
   HttpStatus,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
 } from '@nestjs/common';
 
 import { CreateTripDto, type CreateTripResponse } from './dto/create-trip.dto';
+import {
+  TransitionStatusDto,
+  type TransitionResponse,
+} from './status/dto/transition.dto';
+import { TripStatusService } from './status/trip-status.service';
 import { TripsService } from './trips.service';
 import { CurrentUser, Roles } from '../../common/auth/decorators';
 
@@ -27,7 +33,10 @@ import type { Trip } from '@prisma/client';
 
 @Controller('trips')
 export class TripsController {
-  constructor(private readonly trips: TripsService) {}
+  constructor(
+    private readonly trips: TripsService,
+    private readonly status: TripStatusService,
+  ) {}
 
   /**
    * POST /trips — создание trip'а. Только manager / admin.
@@ -79,5 +88,20 @@ export class TripsController {
     hasPublishedItinerary: boolean;
   }> {
     return this.trips.findById(user.id, user.role, tripId);
+  }
+
+  /**
+   * PATCH /trips/:id/status — manual transition (#160).
+   * Только manager / admin. Reason для cancelled — рекомендуется явный.
+   */
+  @Patch(':id/status')
+  @HttpCode(HttpStatus.OK)
+  @Roles('manager', 'admin')
+  async transitionStatus(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) tripId: string,
+    @Body() dto: TransitionStatusDto,
+  ): Promise<TransitionResponse> {
+    return this.status.transition(tripId, dto.to, 'manual', user.id, dto.reason);
   }
 }

--- a/apps/api/src/modules/trips/trips.module.ts
+++ b/apps/api/src/modules/trips/trips.module.ts
@@ -3,20 +3,25 @@
  *
  * #149 — Prisma модели (Trip, Itinerary, DayPlan, Booking)
  * #150 — POST /trips (manager/admin only)
- * #151+ — editor versioning, status transitions, bookings nesting
+ * #151 — itinerary versioning + publish + GET (manager/admin → draft, all roles → read latest published)
+ * #160 — TripStatus state machine + PATCH /trips/:id/status + listener finance.payment.received
+ * #361 — GET /trips/me + GET /trips/:id (client/manager/admin)
  */
 import { Module } from '@nestjs/common';
 
 import { ItineraryController } from './itinerary/itinerary.controller';
 import { ItineraryService } from './itinerary/itinerary.service';
+import { PaymentReceivedListener } from './status/payment-listener';
+import { TripStatusService } from './status/trip-status.service';
 import { TripsController } from './trips.controller';
 import { TripsService } from './trips.service';
+import { EventsBusModule } from '../../common/events-bus/events-bus.module';
 import { PrismaModule } from '../../common/prisma/prisma.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, EventsBusModule],
   controllers: [TripsController, ItineraryController],
-  providers: [TripsService, ItineraryService],
-  exports: [TripsService, ItineraryService],
+  providers: [TripsService, ItineraryService, TripStatusService, PaymentReceivedListener],
+  exports: [TripsService, ItineraryService, TripStatusService],
 })
 export class TripsModule {}


### PR DESCRIPTION
## Summary

Trip status state-machine с allowed transitions + PATCH endpoint + listener для будущего finance модуля. Закрывает основную часть #160 (cron auto-transitions — отдельным issue).

## State machine

```
draft ──┬──► paid ──► in_progress ──► completed
        │      │              │
        └──────┴──────────────┴──► cancelled (anywhere)
```

`completed` и `cancelled` — финальные. Любой переход вне матрицы → `BadRequestException`.

## Components

### `status-machine.ts`
- `ALLOWED_TRANSITIONS` const map — single source of truth
- `isAllowedTransition(from, to)` helper
- `TransitionReason` union type для outbox payload

### `TripStatusService.transition()`
- **Optimistic concurrency**: `UPDATE WHERE id=X AND status=$from` → count=0 при race
- Outbox event `trips.status.changed` в той же транзакции
- Payload: `{tripId, from, to, reason, additionalReason?, transitionedAt}`

### `PATCH /trips/:id/status` (manual)
- @Roles('manager', 'admin')
- Body: `{to: TripStatus, reason?: string}`
- Reason='manual' в outbox payload + опциональный free-text reason

### `PaymentReceivedListener`
- Subscribes `finance.payment.received` (consumer-group=`trips-status-payment`)
- При `payload.tripId` + `trip.status='draft'` → auto-transition в 'paid' с reason='payment-received'
- Silent skip если status уже не-draft (idempotent для at-least-once)
- Не throw'ает при ошибке — auto не должен блокировать (manual fix через PATCH)

## Что НЕ в этом PR (отдельный issue для cron)

```
paid → in_progress при startsAt <= now
in_progress → completed при endsAt < now
```

Требуют `@nestjs/schedule` + setup cron tab. Manual PATCH работает на 90% случаев пока cron не нужен. Открою issue после merge'а если в scope MVP-1.

## Race-safety

```ts
UPDATE WHERE id = $tripId AND status = $expected_from
```

Параллельный transition двумя caller'ами:
- Один UPDATE atomic — count=1, success
- Второй — count=0, BadRequestException 'concurrent update'

## Test plan

- [x] `pnpm --filter @indiahorizone/api build` — зелёный
- [ ] **На сервере (после re-deploy):**
  - `PATCH /trips/:id/status {to: 'paid'}` (manager) → 200, status='paid'
  - `PATCH /trips/:id/status {to: 'completed'}` from status='draft' → 400 'не разрешён'
  - `PATCH /trips/:id/status {to: 'cancelled', reason: 'клиент отказался'}` → 200
  - В audit_events видим `trips.status.changed` с правильным diff'ом

## Closes / Partial close

- Closes #160 (state-machine + manual + listener готовы; auto-cron — отдельный issue)
- Завершает M5.D Slice (только cron остался, не блокер для MVP)

## Зависимости

- Базируется на main (PR #362 GET /trips/me уже merged)
- finance модуль ещё не существует — listener будет no-op до тех пор

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_