### PR TITLE
feat(web): SEO — Schema.org + Open Graph + robots/sitemap для tour landing (#308)

### DIFF
--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,34 @@
+/**
+ * robots.txt (#308) — Next.js metadata API.
+ *
+ * Сейчас: разрешаем всех ботов на все public-route'ы. /api/*, /login, /register
+ * не индексируем (нет SEO-value).
+ *
+ * Будущее: при появлении staging-домена — disallow для не-prod env'ов через
+ * NEXT_PUBLIC_DISABLE_INDEXING=true (отдельный issue для devops).
+ */
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://indiahorizone.ru';
+
+export default function robots(): MetadataRoute.Robots {
+  // Глобальный kill-switch для preview/staging deploy'ев.
+  if (process.env['NEXT_PUBLIC_DISABLE_INDEXING'] === 'true') {
+    return {
+      rules: [{ userAgent: '*', disallow: '/' }],
+      sitemap: `${SITE_URL}/sitemap.xml`,
+    };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/login', '/register', '/profile/'],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,43 @@
+/**
+ * sitemap.xml (#308) — Next.js metadata API.
+ *
+ * Перечисляет все индексируемые URL'ы для Яндекс/Google ботов.
+ * Туры подтягиваются из catalog API через listTourSlugs() (тот же канал,
+ * что и generateStaticParams в /tours/[slug]/page.tsx).
+ *
+ * lastModified: используем `new Date()` — Яндекс/Google понимают это как
+ * «обновлено в момент последнего ре-генерации». ISR обновляет sitemap
+ * раз в час (revalidate=3600 наследуется от parent).
+ *
+ * priority — относительный сигнал: главная 1.0, туры 0.8, юр.документы 0.3.
+ * changeFrequency — подсказка ботам, как часто чекать.
+ */
+import type { MetadataRoute } from 'next';
+
+import { listTourSlugs } from '@/lib/api/tours';
+
+const SITE_URL = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://indiahorizone.ru';
+
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const slugs = await listTourSlugs();
+  const now = new Date();
+
+  const tourEntries: MetadataRoute.Sitemap = slugs.map((slug) => ({
+    url: `${SITE_URL}/tours/${slug}`,
+    lastModified: now,
+    changeFrequency: 'weekly',
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    ...tourEntries,
+  ];
+}

--- a/apps/web/app/tours/[slug]/page.tsx
+++ b/apps/web/app/tours/[slug]/page.tsx
@@ -20,14 +20,85 @@ import { notFound } from 'next/navigation';
 import { LeadForm } from './lead-form';
 
 import type { ActivityKind, Tour } from '@/lib/mock/tours';
+import type { Metadata } from 'next';
 
 import { getTourBySlug, listTourSlugs } from '@/lib/api/tours';
+import { buildFaqPageJsonLd, buildTouristTripJsonLd } from '@/lib/seo/tour-jsonld';
 
 export const revalidate = 3600;
+
+const SITE_URL = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://indiahorizone.ru';
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   const slugs = await listTourSlugs();
   return slugs.map((slug) => ({ slug }));
+}
+
+/**
+ * SEO + Open Graph + Twitter Card (#308).
+ *
+ * Title: «<тур> — <регион> · IndiaHorizone». Russian-first для Яндекса.
+ * Description: emotional_hook (3-4 строки) — у Яндекса лимит ~250 символов
+ * на snippet, обрежется автоматически.
+ * Canonical: абсолютный URL — Яндекс игнорирует относительные.
+ *
+ * Open Graph: type='website' (не 'article') — Telegram preview корректнее
+ * рендерится для website, чем для article (для last нужны author/date).
+ *
+ * robots: index/follow — туры PUBLIC по определению. NOINDEX-логика для
+ * DRAFT/SOLD-OUT — отдельный issue.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const tour = await getTourBySlug(params.slug);
+  if (!tour) {
+    return {
+      title: 'Тур не найден',
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const tourUrl = `${SITE_URL}/tours/${tour.slug}`;
+  const fullTitle = `${tour.title} — ${tour.region}`;
+  const heroImage = tour.heroPosterUrl.startsWith('http')
+    ? tour.heroPosterUrl
+    : `${SITE_URL}${tour.heroPosterUrl}`;
+
+  return {
+    title: fullTitle,
+    description: tour.emotionalHook,
+    alternates: { canonical: tourUrl },
+    openGraph: {
+      title: fullTitle,
+      description: tour.emotionalHook,
+      url: tourUrl,
+      siteName: 'IndiaHorizone',
+      locale: 'ru_RU',
+      type: 'website',
+      images: [{ url: heroImage, width: 1920, height: 1080, alt: tour.title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: fullTitle,
+      description: tour.emotionalHook,
+      images: [heroImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true, 'max-image-preview': 'large' },
+    },
+    other: {
+      // Яндекс.Вебмастер verification — задаётся через env при деплое.
+      // Без значения тег не рендерится (Next.js skip'ает falsy other-keys).
+      ...(process.env['NEXT_PUBLIC_YANDEX_VERIFICATION']
+        ? { 'yandex-verification': process.env['NEXT_PUBLIC_YANDEX_VERIFICATION'] }
+        : {}),
+    },
+  };
 }
 
 export default async function TourPage({
@@ -38,8 +109,24 @@ export default async function TourPage({
   const tour = await getTourBySlug(params.slug);
   if (!tour) notFound();
 
+  const tripJsonLd = buildTouristTripJsonLd(tour);
+  const faqJsonLd = buildFaqPageJsonLd(tour);
+
   return (
     <main className="min-h-svh bg-background text-foreground">
+      {/*
+        JSON-LD рендерим как inline `<script>` — Next.js Metadata API не поддерживает.
+        dangerouslySetInnerHTML безопасен здесь: входные данные — typed Tour из нашего же
+        API/mock'а (никакого user-input не попадает в JSON.stringify).
+      */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(tripJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
       <Hero tour={tour} />
       <Facts tour={tour} />
       <DayTimeline tour={tour} />

--- a/apps/web/lib/seo/tour-jsonld.ts
+++ b/apps/web/lib/seo/tour-jsonld.ts
@@ -1,0 +1,145 @@
+/**
+ * Schema.org JSON-LD генераторы для tour landing (#308).
+ *
+ * Зачем:
+ * - Яндекс читает Schema.org для rich snippets (звёздочки, цена, FAQ-аккордеон)
+ * - Google Travel понимает TouristTrip / TouristAttraction для travel search
+ * - FAQPage даёт expandable вопросы прямо в выдаче
+ *
+ * Почему не через `<script type="application/ld+json">` в metadata API:
+ * Next.js Metadata API не поддерживает JSON-LD. Эти строки рендерятся inline
+ * в page.tsx через `<script type="application/ld+json" dangerouslySetInnerHTML />`.
+ *
+ * Спецификация:
+ * - https://schema.org/TouristTrip — для тура целиком
+ * - https://schema.org/TouristAttraction — для каждого дня (внутри itinerary)
+ * - https://schema.org/FAQPage — для блока вопросов
+ *
+ * Принципы:
+ * - Все поля — JSON-safe (никаких function/Date/undefined)
+ * - Цены — number, не string ('250000', не '250 000 ₽')
+ * - URL — абсолютные (https://indiahorizone.ru/...) — Яндекс игнорирует относительные
+ */
+
+import type { Tour } from '../mock/tours';
+
+const SITE_URL = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://indiahorizone.ru';
+
+interface JsonLdOffer {
+  '@type': 'Offer';
+  price: number;
+  priceCurrency: string;
+  availability: string;
+  url: string;
+  priceValidUntil?: string;
+}
+
+interface JsonLdAttraction {
+  '@type': 'TouristAttraction';
+  name: string;
+  description: string;
+  image: string;
+}
+
+interface JsonLdTouristTrip {
+  '@context': 'https://schema.org';
+  '@type': 'TouristTrip';
+  name: string;
+  description: string;
+  image: string[];
+  url: string;
+  touristType: string[];
+  offers: JsonLdOffer;
+  itinerary: JsonLdAttraction[];
+  provider: {
+    '@type': 'Organization';
+    name: string;
+    url: string;
+  };
+}
+
+interface JsonLdFAQ {
+  '@context': 'https://schema.org';
+  '@type': 'FAQPage';
+  mainEntity: {
+    '@type': 'Question';
+    name: string;
+    acceptedAnswer: {
+      '@type': 'Answer';
+      text: string;
+    };
+  }[];
+}
+
+function absoluteUrl(maybeRelative: string): string {
+  if (maybeRelative.startsWith('http://') || maybeRelative.startsWith('https://')) {
+    return maybeRelative;
+  }
+  if (maybeRelative.startsWith('/')) {
+    return `${SITE_URL}${maybeRelative}`;
+  }
+  return `${SITE_URL}/${maybeRelative}`;
+}
+
+/**
+ * TouristTrip JSON-LD для тура целиком.
+ *
+ * Цена: используем priceFromRub. Если есть priceToRub — указываем priceFromRub
+ * как точку входа (минимум). Schema.org не имеет clean-way для price-range,
+ * поэтому Offer.price = priceFromRub. Range уже видно в hero-блоке landing'а.
+ *
+ * touristType: подсказывает Google Travel какой тип путешественника.
+ * "Cultural traveler" + "Adventure traveler" — типичный mix Кералы.
+ */
+export function buildTouristTripJsonLd(tour: Tour): JsonLdTouristTrip {
+  const tourUrl = `${SITE_URL}/tours/${tour.slug}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TouristTrip',
+    name: tour.title,
+    description: tour.emotionalHook,
+    image: [absoluteUrl(tour.heroPosterUrl)],
+    url: tourUrl,
+    touristType: ['Cultural traveler', 'Adventure traveler', 'Wellness traveler'],
+    offers: {
+      '@type': 'Offer',
+      price: tour.priceFromRub,
+      priceCurrency: 'RUB',
+      availability: 'https://schema.org/InStock',
+      url: tourUrl,
+    },
+    itinerary: tour.days.map((day) => ({
+      '@type': 'TouristAttraction',
+      name: `День ${day.dayNumber}: ${day.title}`,
+      description: day.description,
+      image: absoluteUrl(day.imageUrl),
+    })),
+    provider: {
+      '@type': 'Organization',
+      name: 'IndiaHorizone',
+      url: SITE_URL,
+    },
+  };
+}
+
+/**
+ * FAQPage JSON-LD — отдельным блоком (Яндекс/Google требует именно так).
+ *
+ * Ответ может быть в HTML — `<a>`, `<strong>` и т.д. Яндекс рендерит safe-subset.
+ * Но source-of-truth у нас plain text → keep simple.
+ */
+export function buildFaqPageJsonLd(tour: Tour): JsonLdFAQ {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: tour.faq.map((item) => ({
+      '@type': 'Question',
+      name: item.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.a,
+      },
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

SEO-оптимизация landing'ов туров для **Яндекса** (приоритет — RU аудитория) + Google + соцсети. Без этого слоя страницы туров показываются в выдаче без rich snippets — ниже CTR на 25-40% по индустрии.

Closes #308.

## Что добавлено

### 1. `generateMetadata` для `/tours/[slug]`

- **Title:** `«<тур> — <регион>»` (Russian-first для Яндекса)
- **Description:** `emotional_hook` (250 chars limit Яндекса автоматически)
- **Canonical:** абсолютный URL — Яндекс игнорирует относительные
- **Open Graph:** `type='website'` (Telegram preview корректнее, чем 'article'), `locale='ru_RU'`, hero-картинка 1920x1080
- **Twitter Card:** `summary_large_image` для twitter/X шаринга
- **robots:** `index/follow` (туры публичные) + `googleBot.max-image-preview='large'`
- **Yandex-verification:** из `NEXT_PUBLIC_YANDEX_VERIFICATION` env (тег скрывается если не задан)

### 2. Schema.org JSON-LD — `apps/web/lib/seo/tour-jsonld.ts`

Inline `<script type="application/ld+json">` в `page.tsx` (Next.js Metadata API не поддерживает ld+json):

- **TouristTrip** — тур целиком: name, description, image, url, touristType, **Offer** (price/currency/availability), **itinerary** (TouristAttraction для каждого дня), **Organization** provider
- **FAQPage** — отдельным блоком (Яндекс/Google требует), все вопросы из `tour.faq`

> **Рекомендация (реализована):** Offer.price = priceFromRub (точка входа). Schema.org нет clean-way для price-range, поэтому используем минимум. Range уже видно в hero визуально.

### 3. `robots.txt` — `apps/web/app/robots.ts`

- `allow: /`, `disallow: /api/`, `/login`, `/register`, `/profile/`
- Yandex: `host` директива (Яндекс это любит)
- **Kill-switch** через `NEXT_PUBLIC_DISABLE_INDEXING=true` — staging deploy'ы не индексируются (рекомендация: использовать на dev-сервере 2.56.241.126)
- Ссылка на sitemap

### 4. `sitemap.xml` — `apps/web/app/sitemap.ts`

- Главная (priority 1.0, daily) + все туры из `listTourSlugs()` (priority 0.8, weekly)
- Тот же канал что `generateStaticParams` — никакой расхождения между prerendered URL'ами и sitemap
- ISR `revalidate=3600` — sitemap обновляется при добавлении новых туров

## Верификация — что попало в HTML

```bash
$ grep -o "og:[a-z]*\|twitter:[a-z]*\|TouristTrip\|FAQPage\|application/ld+json" \
  .next/server/app/tours/tury-kerala-oktyabr-2026.html | sort -u

FAQPage
TouristTrip
application/ld+json
og:description
og:image
og:locale
og:site_name
og:title
og:type
og:url
twitter:card
twitter:description
twitter:image
twitter:title
```

## Recommendation для founders

> **Рекомендация:** после merge — добавить в Яндекс.Вебмастер и Google Search Console:
> 1. Подтвердить домен через `NEXT_PUBLIC_YANDEX_VERIFICATION` env (Вика установит)
> 2. Submitt'ить `https://indiahorizone.ru/sitemap.xml`
> 3. В Search Console включить Schema validator → проверить TouristTrip + FAQPage отображаются как валидные
>
> **Почему:** sitemap нужен Яндексу для быстрой индексации новых туров (без него обнаружение URL'ов через crawling может занять 2-4 недели). FAQPage даёт expandable вопросы прямо в SERP — заметный лифт CTR в туристических запросах.

> **Дополнительная рекомендация (для Шивама/Roman'а):** при добавлении 2-3 туров через Tour Catalog — проверить уникальность `emotional_hook` для каждого. Если все 3 hook'а похожи (типа «10 дней без хаоса»), Яндекс понизит ranking — он наказывает за повторяющиеся meta-descriptions внутри одного домена.

## Out of scope

- **Schema.org Review/AggregateRating** — добавим когда соберём ≥10 настоящих отзывов (сейчас reviews пустые в mock'е, fake-отзывы — нарушение Schema.org TOS)
- **Open Graph video tag** — для hero видео когда WebM/AV1 будет готов (#309)
- **Yandex.Metrika + Google Analytics** — отдельный issue (privacy considerations + consent banner #307)
- **Hreflang** — пока только ru_RU, en_US появится в фазе 4 при выходе на en-аудиторию

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check` — green
- [x] `pnpm --filter @indiahorizone/web build` — green, sitemap.xml + robots.txt в output
- [x] grep на HTML build → все OG/Twitter/JSON-LD теги присутствуют
- [ ] **Manual после deploy:** Яндекс.Валидатор Schema.org `https://yandex.ru/dev/json-ld/` → проверить TouristTrip
- [ ] **Manual после deploy:** Google Rich Results Test `https://search.google.com/test/rich-results` → проверить FAQPage detected
- [ ] **Manual после deploy:** OpenGraph debugger Telegram (отправить ссылку в чат) → preview корректный

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_