### PR TITLE
chore(web): share CONSENT_VERSION + PRIVACY_VERSION via lib/legal/versions.ts

### DIFF
--- a/apps/web/app/(legal)/consent/page.tsx
+++ b/apps/web/app/(legal)/consent/page.tsx
@@ -11,15 +11,14 @@
  */
 import type { Metadata } from 'next';
 
+import { CONSENT_VERSION, LEGAL_LAST_UPDATED } from '@/lib/legal/versions';
+
 export const metadata: Metadata = {
   title: 'Согласие на обработку персональных данных',
   description:
     'Текст согласия на обработку персональных данных, который вы даёте при заполнении формы заявки на сайте IndiaHorizone.',
   robots: { index: true, follow: true },
 };
-
-export const CONSENT_VERSION = '0.1.0';
-const LAST_UPDATED = '28 апреля 2026 г.';
 
 export default function ConsentPage(): React.ReactElement {
   return (
@@ -29,7 +28,7 @@ export default function ConsentPage(): React.ReactElement {
           Согласие на обработку персональных данных
         </h1>
         <p className="mt-3 text-sm text-muted-foreground">
-          Версия {CONSENT_VERSION} (черновик) · обновлено {LAST_UPDATED}
+          Версия {CONSENT_VERSION} (черновик) · обновлено {LEGAL_LAST_UPDATED}
         </p>
       </header>
 

--- a/apps/web/app/(legal)/privacy/page.tsx
+++ b/apps/web/app/(legal)/privacy/page.tsx
@@ -10,14 +10,13 @@
  */
 import type { Metadata } from 'next';
 
+import { LEGAL_LAST_UPDATED, PRIVACY_VERSION } from '@/lib/legal/versions';
+
 export const metadata: Metadata = {
   title: 'Политика конфиденциальности',
   description: 'Как IndiaHorizone собирает, использует и защищает ваши персональные данные.',
   robots: { index: true, follow: true },
 };
-
-const PRIVACY_VERSION = '0.1.0';
-const LAST_UPDATED = '28 апреля 2026 г.';
 
 export default function PrivacyPage(): React.ReactElement {
   return (
@@ -27,7 +26,7 @@ export default function PrivacyPage(): React.ReactElement {
           Политика конфиденциальности
         </h1>
         <p className="mt-3 text-sm text-muted-foreground">
-          Версия {PRIVACY_VERSION} (черновик) · обновлено {LAST_UPDATED}
+          Версия {PRIVACY_VERSION} (черновик) · обновлено {LEGAL_LAST_UPDATED}
         </p>
       </header>
 

--- a/apps/web/app/tours/[slug]/lead-form.tsx
+++ b/apps/web/app/tours/[slug]/lead-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { LeadApiError, submitLead } from '@/lib/api/leads';
+import { CONSENT_VERSION } from '@/lib/legal/versions';
 
 type ContactType = 'phone' | 'telegram' | 'email';
 
@@ -11,8 +12,6 @@ type FormState =
   | { kind: 'submitting' }
   | { kind: 'success' }
   | { kind: 'error'; message: string };
-
-const CONSENT_TEXT_VERSION = '2026-04-27-v1';
 
 export function LeadForm({ tourSlug }: { tourSlug: string }): React.ReactElement {
   const [name, setName] = useState('');
@@ -37,7 +36,7 @@ export function LeadForm({ tourSlug }: { tourSlug: string }): React.ReactElement
       contact: contact.trim(),
       ...(comment.trim().length > 0 ? { comment: comment.trim() } : {}),
       consent,
-      consentTextVersion: CONSENT_TEXT_VERSION,
+      consentTextVersion: CONSENT_VERSION,
     };
 
     try {
@@ -154,11 +153,15 @@ export function LeadForm({ tourSlug }: { tourSlug: string }): React.ReactElement
           required
         />
         <span className="text-background/80">
-          Согласен(на) с обработкой персональных данных в соответствии с{' '}
+          Даю{' '}
+          <a href="/consent" className="underline hover:text-primary">
+            согласие на обработку персональных данных
+          </a>{' '}
+          в соответствии с{' '}
           <a href="/privacy" className="underline hover:text-primary">
             Политикой конфиденциальности
           </a>
-          . Передача данных партнёру в Индии — для организации поездки.
+          , включая трансграничную передачу партнёру в Индии для организации поездки.
         </span>
       </label>
 

--- a/apps/web/lib/legal/versions.ts
+++ b/apps/web/lib/legal/versions.ts
@@ -1,0 +1,22 @@
+/**
+ * Версии юридических документов (#307).
+ *
+ * Source-of-truth для:
+ * - apps/web/app/(legal)/consent/page.tsx (отображает версию пользователю)
+ * - apps/web/app/(legal)/privacy/page.tsx (отображает версию)
+ * - apps/web/app/tours/[slug]/lead-form.tsx (отправляет на API в Lead.consentTextVersion)
+ *
+ * При каждом редактировании текста /consent или /privacy — bump версии здесь.
+ * Backend сохраняет именно эту строку — она и есть юр. доказательство какая
+ * редакция была активна на момент согласия.
+ *
+ * Формат: SemVer-like (`major.minor.patch`):
+ * - patch — типографские правки, не меняющие смысл
+ * - minor — изменение содержания одного блока
+ * - major — структурная переработка (сменился operator, добавилась/убрана категория данных)
+ */
+
+export const CONSENT_VERSION = '0.1.0';
+export const PRIVACY_VERSION = '0.1.0';
+
+export const LEGAL_LAST_UPDATED = '28 апреля 2026 г.';


### PR DESCRIPTION
## Summary

Wires together the legal pages (#368) and the lead form (#304-existing). Single source-of-truth for legal document versions.

## Что сделано

- **`apps/web/lib/legal/versions.ts`** — exports `CONSENT_VERSION`, `PRIVACY_VERSION`, `LEGAL_LAST_UPDATED`
- **`(legal)/consent/page.tsx`** — импортирует CONSENT_VERSION + LEGAL_LAST_UPDATED из shared
- **`(legal)/privacy/page.tsx`** — то же
- **`tours/[slug]/lead-form.tsx`** — импортирует CONSENT_VERSION (раньше был hardcoded `'2026-04-27-v1'`), добавлена ссылка на `/consent` рядом со ссылкой на `/privacy`, явно упомянута трансграничная передача в Индию

## Recommendation

> **Рекомендация:** при каждом редактировании текста /privacy или /consent — bump соответствующей версии в `lib/legal/versions.ts`. **Почему:** backend сохраняет именно `consentTextVersion` в `Lead` записи — это и есть юр. доказательство того, какая редакция была активна на момент согласия. Если текст изменили без bump'а версии, невозможно будет точно ответить на вопрос «под чем подписался клиент».

## Test plan

- [x] Lint, format, type-check, build — все green

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_