### PR TITLE
chore(prisma): align schema ↔ migrations zero-drift

### DIFF
--- a/.github/workflows/prisma-check.yml
+++ b/.github/workflows/prisma-check.yml
@@ -61,14 +61,22 @@ jobs:
       - name: Install api dependencies
         run: pnpm install --frozen-lockfile --filter "@indiahorizone/api..."
 
-      # Применяем все миграции к чистой БД
+      # Применяем все миграции к main БД
       - name: Apply migrations
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test?schema=public
         working-directory: apps/api
         run: pnpm exec prisma migrate deploy
 
-      # Сравниваем schema.prisma против примёненных миграций.
+      # Создаём shadow-БД для prisma migrate diff. Без неё команда падает с
+      # "You must pass the --shadow-database-url if you want to diff a migrations
+      # directory" — это причина false-positive failures после #351.
+      - name: Create shadow database
+        env:
+          PGPASSWORD: test
+        run: psql -h localhost -U test -d test -c 'CREATE DATABASE test_shadow;'
+
+      # Сравниваем schema.prisma против применённых миграций.
       # exit 0 = в синке, exit 2 = дрифт (новые таблицы/поля в schema без migration).
       # Если дрифт — выводим понятный текст и фейлим CI.
       - name: Check schema ↔ migrations drift
@@ -80,6 +88,7 @@ jobs:
           if ! pnpm exec prisma migrate diff \
             --from-migrations prisma/migrations \
             --to-schema-datamodel prisma/schema.prisma \
+            --shadow-database-url "postgresql://test:test@localhost:5432/test_shadow?schema=public" \
             --exit-code; then
             echo ""
             echo "❌ Schema drift detected!"

--- a/apps/api/prisma/migrations/20260428230000_chore_align_schema_drift/migration.sql
+++ b/apps/api/prisma/migrations/20260428230000_chore_align_schema_drift/migration.sql
@@ -1,0 +1,27 @@
+-- Align schema ↔ migrations drift (chore).
+--
+-- Контекст: ранее migrations были handwritten + некоторые auto-gen Prisma'ой.
+-- Они расходились в трактовке id-DEFAULT:
+-- - 0_init и часть migrations: id UUID NOT NULL — без DEFAULT (Prisma client
+--   передаёт uuid() из crypto.randomUUID() в INSERT)
+-- - M5_* manual migrations: id UUID NOT NULL DEFAULT gen_random_uuid()
+--
+-- В реальной БД на dev/staging таблицы имеют DEFAULT (применённые M5_* migrations).
+-- В schema.prisma — теперь все @default(dbgenerated("gen_random_uuid()")) для
+-- консистентности.
+--
+-- Эта миграция добавляет DEFAULT к тем таблицам, где его не было — чтобы
+-- база была единообразной и `prisma migrate diff` показывал zero drift.
+--
+-- Безопасно: ALTER TABLE ... SET DEFAULT не блокирует чтение/запись и не
+-- меняет существующие данные. INSERT'ы с явным id продолжают работать.
+
+ALTER TABLE "client_profiles" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "clients" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "leads" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "outbox_entries" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "push_subscriptions" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "tour_days" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "tour_media" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "tours" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "users" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -41,7 +41,7 @@ datasource db {
 /// Это гарантия, что события не потеряются при rollback'нутой транзакции, и не
 /// появятся при failed publish'е — основная гигиена event-driven систем.
 model OutboxEntry {
-  id            String    @id @default(uuid()) @db.Uuid
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Тип события: <service>.<entity>.<verb>, например "auth.user.registered"
   eventType     String    @map("event_type")
   /// Версия схемы payload (DomainEvent.schemaVersion)
@@ -157,7 +157,7 @@ enum UserStatus {
 /// (имя, паспорт, preferences) — отдельная сущность Client в модуле clients
 /// (#138), привязка через userId без FK.
 model User {
-  id           String     @id @default(uuid()) @db.Uuid
+  id           String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Email lowercased (приведение в коде на уровне приложения).
   /// Unique с case-insensitive collation в Postgres (citext или lower-index).
   email        String     @unique
@@ -191,7 +191,7 @@ model User {
 ///
 /// Cross-module FK на User ОК (тот же модуль auth, единая extraction unit).
 model RecoveryCode {
-  id        String    @id @default(uuid()) @db.Uuid
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String    @map("user_id") @db.Uuid
   /// argon2id(plaintext_code). Plaintext НИКОГДА не хранится.
   codeHash  String    @map("code_hash")
@@ -216,7 +216,7 @@ model RecoveryCode {
 ///
 /// Cross-module FK на User OK (тот же модуль auth).
 model PasswordResetToken {
-  id        String    @id @default(uuid()) @db.Uuid
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String    @map("user_id") @db.Uuid
   /// argon2id(plain_token). Plain никогда не хранится.
   tokenHash String    @map("token_hash")
@@ -244,7 +244,7 @@ model PasswordResetToken {
 /// userId — soft-reference на users.id (без FK, cross-module policy).
 /// Один User → один Client (unique constraint на userId).
 model Client {
-  id        String   @id @default(uuid()) @db.Uuid
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Soft-reference на users.id. Без FK (cross-module policy).
   userId    String   @unique @map("user_id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
@@ -291,7 +291,7 @@ enum ConsentType {
 /// шаблона текста в docs/LEGAL/CONSENTS/. Сохраняем версию для каждого consent'а
 /// чтобы в случае спора показать какой именно текст подписал клиент.
 model Consent {
-  id        String      @id @default(uuid()) @db.Uuid
+  id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   clientId  String      @map("client_id") @db.Uuid
   type      ConsentType
   scope     Json
@@ -328,7 +328,7 @@ enum EmergencyContactPriority {
 ///
 /// Cross-module FK на Client OK (один модуль clients).
 model EmergencyContact {
-  id        String                   @id @default(uuid()) @db.Uuid
+  id        String                   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   clientId  String                   @map("client_id") @db.Uuid
   /// Зашифровано (#139). plaintext: ФИО контакта.
   name      String
@@ -358,7 +358,7 @@ model EmergencyContact {
 /// потому что encrypted-payload — base64-строка, не date/etc.
 /// preferences — свободный JSONB (языки, диеты, хобби).
 model ClientProfile {
-  id             String   @id @default(uuid()) @db.Uuid
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   clientId       String   @unique @map("client_id") @db.Uuid
   /// Зашифровано (#139). plaintext: ФИО.
   firstName      String?  @map("first_name")
@@ -394,7 +394,7 @@ model ClientProfile {
 /// если revokedAt уже стоит, и снова приходит запрос → атака → invalidate
 /// все сессии user'а.
 model Session {
-  id               String    @id @default(uuid()) @db.Uuid
+  id               String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId           String    @map("user_id") @db.Uuid
   /// argon2id-хеш refresh-токена. По нему verify при /auth/refresh.
   refreshTokenHash String    @map("refresh_token_hash")
@@ -439,7 +439,7 @@ enum TourStatus {
 /// Поля costInr* в TourDay — internal (не отдаются в публичный API), для
 /// расчёта маржи и аналитики. См. CatalogService DTO mapping.
 model Tour {
-  id            String     @id @default(uuid()) @db.Uuid
+  id            String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// URL slug, например "tury-kerala-oktyabr-2026". РУ-транслит + сезон.
   slug          String     @unique
   status        TourStatus @default(DRAFT)
@@ -482,7 +482,7 @@ model Tour {
 /// costInr* — internal, для аналитики маржи; в публичный API НЕ отдаётся
 /// (исключаем в CatalogService DTO mapping). См. spec в issue #296.
 model TourDay {
-  id          String  @id @default(uuid()) @db.Uuid
+  id          String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tourId      String  @map("tour_id") @db.Uuid
   /// 1..durationDays. Уникален в рамках тура.
   dayNumber   Int     @map("day_number")
@@ -513,7 +513,7 @@ model TourDay {
 /// Медиа-ассеты тура: фото, видео, в будущем — кружки-отзывы (V2 после #142
 /// Consent). Order — для порядка отображения в галереях.
 model TourMedia {
-  id      String  @id @default(uuid()) @db.Uuid
+  id      String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tourId  String  @map("tour_id") @db.Uuid
   /// 'photo' | 'video' | 'circle-review' (последнее — после Consent #142).
   kind    String
@@ -555,7 +555,7 @@ enum LeadStatus {
 /// status workflow: NEW → CONTACTED → CONVERTED|REJECTED. Переходы делает
 /// менеджер через будущую CRM (EPIC 14). До этого — все Lead'ы NEW.
 model Lead {
-  id                 String     @id @default(uuid()) @db.Uuid
+  id                 String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Источник заявки. Свободный slug:
   /// - "tour-tury-kerala-oktyabr-2026" — кнопка с tour landing page
   /// - "general" — общая форма с главной (когда будет)
@@ -636,7 +636,7 @@ enum BookingStatus {
 /// totalAmount/currency — итог цены тура для клиента (RUB по умолчанию).
 /// Для маржи — агрегируем Booking.amount в INR (см. будущий margin-report).
 model Trip {
-  id          String     @id @default(uuid()) @db.Uuid
+  id          String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Soft-reference на clients.id (cross-module).
   clientId    String     @map("client_id") @db.Uuid
   status      TripStatus @default(draft)
@@ -672,7 +672,7 @@ model Trip {
 /// 1. Аудита (что показывали клиенту до правки)
 /// 2. Offline-cache: клиент может видеть старую version'у пока не синхронизировал
 model Itinerary {
-  id          String    @id @default(uuid()) @db.Uuid
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tripId      String    @map("trip_id") @db.Uuid
   version     Int       @default(1)
   /// NULL = draft. Set при publish'е.
@@ -700,7 +700,7 @@ model Itinerary {
 /// Активности из tour'а (catalog domain) сюда копируются как snapshot —
 /// чтобы trip dashboard не зависел от изменений в каталоге после publish.
 model DayPlan {
-  id          String   @id @default(uuid()) @db.Uuid
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   itineraryId String   @map("itinerary_id") @db.Uuid
   dayNumber   Int      @map("day_number")
   /// Конкретная дата дня (в отличие от TourDay где относительный dayNumber).
@@ -731,7 +731,7 @@ model DayPlan {
 /// pending → failed (vendor отказал, нужно переоформить)
 /// confirmed → cancelled (отменено клиентом / нами).
 model Booking {
-  id        String        @id @default(uuid()) @db.Uuid
+  id        String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tripId    String        @map("trip_id") @db.Uuid
   type      BookingType
   /// Свободный string. Внешний vendor identifier.
@@ -793,7 +793,7 @@ enum ChatThreadStatus {
 /// переписок при reopened sales-deal'е). Если важно — добавим partial unique
 /// `(kind, subject_id) WHERE status='open'` в отдельной миграции.
 model ChatThread {
-  id           String           @id @default(uuid()) @db.Uuid
+  id           String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   kind         ChatThreadKind
   /// Soft-reference на основной объект:
   /// - kind=trip  → Trip.id
@@ -801,7 +801,7 @@ model ChatThread {
   /// - kind=sales → Lead.id (модель из #297)
   subjectId    String           @map("subject_id") @db.Uuid
   /// Массив user.id (UUID) — soft-refs на User. cross-module policy.
-  participants String[]         @default([])
+  participants String[]         @default([]) @db.Uuid
   status       ChatThreadStatus @default(open)
   createdAt    DateTime         @default(now()) @map("created_at")
   updatedAt    DateTime         @updatedAt @map("updated_at")
@@ -823,14 +823,14 @@ model ChatThread {
 /// String[] — без FK, без валидации существования asset'а на schema-уровне.
 /// Service будет проверять при write (когда media-svc появится).
 model ChatMessage {
-  id          String   @id @default(uuid()) @db.Uuid
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   threadId    String   @map("thread_id") @db.Uuid
   /// Soft-reference на users.id. cross-module policy.
   fromUserId  String   @map("from_user_id") @db.Uuid
   /// Plain-text сообщение. Markdown rendering на клиенте (V2).
   body        String
   /// MediaAsset.id (UUID) массив. Поддержка после #173.
-  attachments String[] @default([])
+  attachments String[] @default([]) @db.Uuid
   createdAt   DateTime @default(now()) @map("created_at")
   /// JSONB: { "<userId>": "<ISO timestamp>" }. Кто и когда прочитал.
   /// `{}` = ещё никто (включая отправителя — отправка ≠ чтение).
@@ -884,7 +884,7 @@ enum NotificationStatus {
 /// userId опционален — для transactional notifications привязан к юзеру,
 /// для marketing/system без user'а.
 model Notification {
-  id           String              @id @default(uuid()) @db.Uuid
+  id           String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   channel      NotificationChannel
   /// email-address / E.164 phone / FCM-token / Telegram chat_id.
   recipient    String
@@ -931,12 +931,12 @@ enum NotificationCategory {
 /// Если row отсутствует — используются defaults (см. NotificationPreferencesService).
 /// SOS preferences нельзя disable — service enforces.
 model NotificationPreference {
-  id        String                @id @default(uuid()) @db.Uuid
+  id        String                @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Soft-reference на User.
   userId    String                @map("user_id") @db.Uuid
   category  NotificationCategory
   /// Каналы доставки. Пустой = silent для категории. SOS всегда [all 4].
-  channels  NotificationChannel[]
+  channels  NotificationChannel[] @default([])
   enabled   Boolean               @default(true)
   updatedAt DateTime              @updatedAt @map("updated_at")
 
@@ -985,7 +985,7 @@ enum MediaAssetStatus {
 /// Storage: bucket private, SSE-S3 server-side encryption. Доступ к содержимому
 /// — только через signed URLs (#177) с TTL.
 model MediaAsset {
-  id        String           @id @default(uuid()) @db.Uuid
+  id        String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Soft-ref на User.id — кто загрузил.
   ownerId   String           @map("owner_id") @db.Uuid
   kind      MediaAssetKind
@@ -1021,7 +1021,7 @@ model MediaAsset {
 /// Если клиент НЕ отвечает в течение expiresAt — feedback считается пропущенным
 /// (но не критично; signal используется для retention-аналитики).
 model FeedbackRequest {
-  id          String   @id @default(uuid()) @db.Uuid
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Soft-reference на Trip.id (cross-module).
   tripId      String   @map("trip_id") @db.Uuid
   /// 1..durationDays. Один request на (trip, dayNumber).
@@ -1074,7 +1074,7 @@ enum FeedbackMood {
 /// signals JSONB — обогащение через AI-аналитику в #189 (sentiment, topics,
 /// keywords). Сейчас пустой объект `{}`.
 model Feedback {
-  id        String        @id @default(uuid()) @db.Uuid
+  id        String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   /// Опционально — ссылка на FeedbackRequest. NULL = спонтанный feedback.
   requestId String?       @map("request_id") @db.Uuid
   /// Soft-reference на Trip.id (cross-module).
@@ -1131,7 +1131,7 @@ enum PushPlatform {
 /// Удаление: soft-delete через deletedAt — сохраняем для аудита (compliance).
 /// При expired endpoint (410 Gone от провайдера) — помечаем deletedAt = now.
 model PushSubscription {
-  id           String       @id @default(uuid()) @db.Uuid
+  id           String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId       String       @map("user_id") @db.Uuid
   platform     PushPlatform @default(web)
   /// W3C Web Push endpoint URL — длинный (300-500 chars типично). Для


### PR DESCRIPTION
## Summary

Закрывает pre-existing schema ↔ migrations drift, накопившийся с момента введения `prisma-check.yml` workflow (#351). Drift был во всех M5_* migration'ах из-за handwritten SQL, расходящегося с тем что Prisma генерирует из schema.

После merge: **`prisma migrate diff --exit-code` возвращает 0** — drift detection workflow становится строгим guard'ом, а не permanent-failed check'ом который все игнорируют.

## Что было

`prisma-check.yml` workflow проверяет на каждом PR'е что `schema.prisma` и `migrations/` в синке. Из-за систематического drift'а check failed на каждом schema-touching PR'е (#351, #336, #166, #173, #371...). PR'ы мерджились через admin-override.

Конкретные несоответствия:
1. **25 моделей** — schema `@default(uuid())` vs migration `DEFAULT gen_random_uuid()` (M5_* manual migrations) или migration без DEFAULT (0_init auto-gen)
2. **`chat_threads.participants`** — schema `String[]` vs migration `UUID[]` (нужно `@db.Uuid`)
3. **`chat_messages.attachments`** — то же
4. **`notification_preferences.channels`** — schema без `@default([])` vs migration `DEFAULT '{}'`

## Что сделано

### Schema (25 + 3 правок)

Bulk через `sed`:
```diff
- @default(uuid()) @db.Uuid
+ @default(dbgenerated("gen_random_uuid()")) @db.Uuid
```

Manual:
```diff
- participants String[] @default([])
+ participants String[] @default([]) @db.Uuid

- attachments String[] @default([])
+ attachments String[] @default([]) @db.Uuid

- channels NotificationChannel[]
+ channels NotificationChannel[] @default([])
```

### Migration `20260428230000_chore_align_schema_drift`

ALTER TABLE для 9 таблиц где id не имел DEFAULT (0_init auto-gen + push_subscriptions из #371):

```sql
ALTER TABLE "client_profiles"  ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "clients"          ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "leads"            ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "outbox_entries"   ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "push_subscriptions" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "tour_days"        ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "tour_media"       ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "tours"            ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
ALTER TABLE "users"            ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
```

## Verification

Локально с Postgres 16:

```bash
# Чистая БД
$ sudo -u postgres dropdb test && sudo -u postgres createdb -O test test

# Применить все миграции
$ DATABASE_URL=... pnpm exec prisma migrate deploy
> All migrations have been successfully applied.

# Проверить drift
$ DATABASE_URL=... pnpm exec prisma migrate diff \
    --from-migrations prisma/migrations \
    --to-schema-datamodel prisma/schema.prisma \
    --shadow-database-url ... --exit-code
> No difference detected.
> Exit: 0  ✅
```

## Безопасность

- `ALTER COLUMN ... SET DEFAULT` не блокирует чтение/запись (мгновенная DDL операция)
- Не меняет существующие данные
- INSERT'ы с явным id продолжают работать
- Prisma client будет генерировать uuid через `crypto.randomUUID()` (поведение не меняется) — DB DEFAULT пригодится только для raw SQL inserts (например seed через psql)

## Recommendation

> **Рекомендация для devops:vika:** после merge — обновить documents/policies про PR-merging что schema-changes теперь блокируются drift-check'ом. **Почему:** до этого PR drift-check всегда был red, потому что все пропускали. Теперь он реально работает — если кто-то добавит новое поле в schema без миграции, CI заблокирует merge. Это hotfix #335 предотвращает (missing-sessions-migration scenario).

> **Рекомендация по будущим миграциям:** не писать SQL руками. Использовать `pnpm --filter @indiahorizone/api db:migrate:dev --name <description>` — Prisma сама сгенерирует SQL точно соответствующий schema. Текущие manual M5_* migrations были источником этого drift'а.

## Test plan

- [x] `prisma migrate deploy` на чистую БД — все 21 миграции применяются
- [x] `prisma migrate diff --exit-code` → 0 (no drift)
- [x] `pnpm lint`, `format:check`, `type-check` — green
- [x] `pnpm --filter @indiahorizone/api build` — green
- [ ] **CI Schema check на этом PR** — должен пройти зелёным (это и есть proof работы)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_