### PR TITLE
feat(comm): push API completion — DELETE/GET + NotifyService.sendPush() (#163 phase 2)

### DIFF
--- a/apps/api/src/modules/comm/notify.service.ts
+++ b/apps/api/src/modules/comm/notify.service.ts
@@ -23,6 +23,7 @@
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { EMAIL_PROVIDER, type EmailProvider } from './providers/email.provider';
+import { PushService } from './push/push.service';
 import { TemplateService } from './template.service';
 import { OutboxService } from '../../common/outbox/outbox.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
@@ -38,6 +39,23 @@ export interface SendInput {
   userId?: string;
 }
 
+/**
+ * Push payload — короткое уведомление в браузер/устройство.
+ *
+ * `title` + `body` — отображается в нотификации.
+ * `url` — куда вести при клике (default '/').
+ * `tag` — для группировки (один tag → одна notification, не стек). Удобно для
+ * сценариев типа «обновился статус trip» — каждый trip имеет свой tag, новая
+ * push заменяет старую вместо стека.
+ */
+export interface SendPushInput {
+  userId: string;
+  title: string;
+  body: string;
+  url?: string;
+  tag?: string;
+}
+
 @Injectable()
 export class NotifyService {
   private readonly logger = new Logger(NotifyService.name);
@@ -47,11 +65,14 @@ export class NotifyService {
     private readonly outbox: OutboxService,
     private readonly templates: TemplateService,
     @Inject(EMAIL_PROVIDER) private readonly emailProvider: EmailProvider,
+    private readonly push: PushService,
   ) {}
 
   async send(input: SendInput): Promise<{ notificationId: string }> {
     if (input.channel !== 'email') {
-      throw new NotFoundException(`Channel "${input.channel}" пока не реализован (#163/#164/#165)`);
+      throw new NotFoundException(
+        `Channel "${input.channel}" в .send() не поддерживается. Для push используйте .sendPush(); для sms/telegram — отдельные методы (#164/#165)`,
+      );
     }
     if (!this.templates.exists(input.templateId)) {
       throw new NotFoundException(`Template "${input.templateId}" не найден`);
@@ -136,5 +157,103 @@ export class NotifyService {
       // основного business flow.
       throw err;
     }
+  }
+
+  /**
+   * Отправить push на ВСЕ активные устройства user'а.
+   *
+   * Создаёт ОДНУ Notification запись (агрегат "интент уведомить"), независимо
+   * от того сколько device-subscription'ов было затронуто. Детализация
+   * delivery/expired счётчиков — в логах PushService.sendToUser + outbox-event
+   * comm.message.sent.
+   *
+   * Returns sent/failed/expired counters — caller может решить что делать
+   * (например, если sent=0 → ескалировать через email).
+   *
+   * Best-effort: не throw'ит на отдельных device failures. Throw только при
+   * полном сбое DB (не должен возникать).
+   */
+  async sendPush(input: SendPushInput): Promise<{
+    notificationId: string;
+    sent: number;
+    failed: number;
+    expired: number;
+  }> {
+    const notification = await this.prisma.notification.create({
+      data: {
+        channel: 'push',
+        // recipient у push — это userId (не email/phone). Для аналитики достаточно.
+        recipient: input.userId,
+        templateId: 'push:inline', // нет template-системы для push в V1 — title/body передаются inline
+        payload: {
+          title: input.title,
+          body: input.body,
+          ...(input.url !== undefined ? { url: input.url } : {}),
+          ...(input.tag !== undefined ? { tag: input.tag } : {}),
+        },
+        status: 'pending',
+        userId: input.userId,
+      },
+      select: { id: true },
+    });
+
+    const result = await this.push.sendToUser(input.userId, {
+      title: input.title,
+      body: input.body,
+      ...(input.url !== undefined ? { url: input.url } : {}),
+      ...(input.tag !== undefined ? { tag: input.tag } : {}),
+    });
+
+    // Status: sent если хоть один device получил, failed если все провалились
+    // (вкл. expired). pending → для случая sent=0+failed=0+expired=0 (нет subs).
+    const finalStatus =
+      result.sent > 0 ? 'sent' : result.failed + result.expired > 0 ? 'failed' : 'pending';
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.notification.update({
+        where: { id: notification.id },
+        data: {
+          status: finalStatus,
+          ...(finalStatus === 'sent' ? { sentAt: new Date() } : {}),
+          ...(finalStatus === 'failed' ? { failedAt: new Date() } : {}),
+        },
+      });
+
+      if (finalStatus === 'sent') {
+        await this.outbox.add(tx, {
+          type: 'comm.message.sent',
+          schemaVersion: 1,
+          actor: { type: 'system' },
+          payload: {
+            notificationId: notification.id,
+            channel: 'push',
+            templateId: 'push:inline',
+            // recipient НЕ публикуем (privacy)
+            providerMessageId: `push:${result.sent}/${result.sent + result.failed + result.expired}`,
+            userId: input.userId,
+          },
+        });
+      } else if (finalStatus === 'failed') {
+        await this.outbox.add(tx, {
+          type: 'comm.message.failed',
+          schemaVersion: 1,
+          actor: { type: 'system' },
+          payload: {
+            notificationId: notification.id,
+            channel: 'push',
+            templateId: 'push:inline',
+            errorMessage: `failed=${result.failed}, expired=${result.expired}`,
+            userId: input.userId,
+          },
+        });
+      }
+    });
+
+    this.logger.log(
+      { notificationId: notification.id, userId: input.userId, ...result, status: finalStatus },
+      finalStatus === 'sent' ? 'comm.push.sent' : 'comm.push.no-devices-or-failed',
+    );
+
+    return { notificationId: notification.id, ...result };
   }
 }

--- a/apps/api/src/modules/comm/push/dto/list-subscriptions.dto.ts
+++ b/apps/api/src/modules/comm/push/dto/list-subscriptions.dto.ts
@@ -1,0 +1,18 @@
+import type { PushPlatform } from '@prisma/client';
+
+/**
+ * Public DTO для GET /comm/push/subscriptions.
+ *
+ * Privacy: НЕ возвращаем endpoint и keys (p256dh / auth) — endpoint per-device
+ * potentially PII (раскрывает FCM/APNs ID), а keys пользователю не нужны для UI
+ * "ваши устройства". Только id + platform + deviceLabel + timestamps.
+ */
+export interface PushSubscriptionListItemDto {
+  id: string;
+  platform: PushPlatform;
+  /** Human-readable метка ("iOS Safari", "Chrome Desktop"). NULL если не задана. */
+  deviceLabel: string | null;
+  /** Когда последний раз успешно доставился push (NULL = ни разу). */
+  lastSeenAt: string | null; // ISO
+  createdAt: string; // ISO
+}

--- a/apps/api/src/modules/comm/push/dto/unsubscribe.dto.ts
+++ b/apps/api/src/modules/comm/push/dto/unsubscribe.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * DTO для DELETE /comm/push/subscribe.
+ *
+ * Один из двух способов идентифицировать subscription:
+ * - `subscriptionId` — id из БД (предпочтительно, frontend знает после subscribe)
+ * - `endpoint` — W3C endpoint URL (fallback если frontend сохранил только subscription, а id потерял)
+ *
+ * Если оба заданы — приоритет subscriptionId.
+ * Если ничего не задано — 400 Bad Request.
+ */
+export class UnsubscribePushDto {
+  @IsOptional()
+  @IsUUID('4')
+  subscriptionId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(20)
+  @MaxLength(2048)
+  endpoint?: string;
+}

--- a/apps/api/src/modules/comm/push/push.controller.ts
+++ b/apps/api/src/modules/comm/push/push.controller.ts
@@ -1,19 +1,29 @@
 /**
  * PushController — endpoints для управления push-subscription'ами (#163).
  *
- * - POST /comm/push/subscribe — подписать текущее устройство user'а.
- *   Frontend (#356) вызывает после browser.pushManager.subscribe().
+ * - POST   /comm/push/subscribe        — подписать устройство (см. #356 frontend flow)
+ * - DELETE /comm/push/subscribe        — отписать с устройства (по id или endpoint)
+ * - GET    /comm/push/subscriptions    — список активных устройств user'а (для UI «ваши устройства»)
  *
- * Будущее (V2):
- * - DELETE /comm/push/subscribe — отписать с этого устройства
- * - GET /comm/push/subscriptions — список устройств user'а (для UI)
+ * Все три endpoint'а требуют auth — push-подписка привязана к user'у через JWT.
  */
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from '@nestjs/common';
 
 import { SubscribePushDto } from './dto/subscribe.dto';
+import { UnsubscribePushDto } from './dto/unsubscribe.dto';
 import { PushService } from './push.service';
 import { CurrentUser } from '../../../common/auth/decorators';
 
+import type { PushSubscriptionListItemDto } from './dto/list-subscriptions.dto';
 import type { AuthenticatedUser } from '../../../common/auth/types';
 
 @Controller('comm/push')
@@ -34,5 +44,49 @@ export class PushController {
       ...(dto.keys?.auth !== undefined ? { auth: dto.keys.auth } : {}),
       ...(dto.deviceLabel !== undefined ? { deviceLabel: dto.deviceLabel } : {}),
     });
+  }
+
+  /**
+   * DELETE /comm/push/subscribe — отписать subscription текущего user'а.
+   * Body: либо `{subscriptionId}` либо `{endpoint}`. Если оба — приоритет id.
+   *
+   * Idempotent: если уже soft-deleted или не существует у этого user'а — 204 (no-op).
+   */
+  @Delete('subscribe')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async unsubscribe(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UnsubscribePushDto,
+  ): Promise<void> {
+    if (!dto.subscriptionId && !dto.endpoint) {
+      throw new BadRequestException('Нужен subscriptionId или endpoint');
+    }
+    if (dto.subscriptionId) {
+      await this.push.unsubscribeById(user.id, dto.subscriptionId);
+      return;
+    }
+    if (dto.endpoint) {
+      await this.push.unsubscribeByEndpoint(user.id, dto.endpoint);
+    }
+  }
+
+  /**
+   * GET /comm/push/subscriptions — список активных subscription'ов user'а.
+   * Privacy: НЕ возвращаем endpoint / keys — только id, platform, deviceLabel, timestamps.
+   */
+  @Get('subscriptions')
+  async list(
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<{ items: PushSubscriptionListItemDto[] }> {
+    const subs = await this.push.listForUser(user.id);
+    return {
+      items: subs.map((s) => ({
+        id: s.id,
+        platform: s.platform,
+        deviceLabel: s.deviceLabel,
+        lastSeenAt: s.lastSeenAt?.toISOString() ?? null,
+        createdAt: s.createdAt.toISOString(),
+      })),
+    };
   }
 }

--- a/apps/api/src/modules/comm/push/push.service.ts
+++ b/apps/api/src/modules/comm/push/push.service.ts
@@ -119,6 +119,18 @@ export class PushService {
   }
 
   /**
+   * Soft-delete subscription по id. RBAC: только владелец может отписаться.
+   * Чужой id → 404 (не раскрываем существование чужих subscription'ов).
+   */
+  async unsubscribeById(userId: string, subscriptionId: string): Promise<{ removed: boolean }> {
+    const result = await this.prisma.pushSubscription.updateMany({
+      where: { id: subscriptionId, userId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+    return { removed: result.count > 0 };
+  }
+
+  /**
    * Активные subscription'ы user'а (для UI «ваши устройства»).
    */
   async listForUser(userId: string): Promise<PushSubscription[]> {


### PR DESCRIPTION
## Summary

Завершает push API после foundation в #371. После merge: full lifecycle subscription management (subscribe → list → unsubscribe) + высокоуровневая доставка через `NotifyService.sendPush()`.

Closes #163 phase 2. Real WebPushProvider остаётся заблокирован на VAPID keys (#353).

## Что внутри

### 1. DELETE /comm/push/subscribe

Отписать subscription. Body — discriminated:

```json
{ "subscriptionId": "uuid" }    // предпочтительно, frontend знает после subscribe
// OR
{ "endpoint": "https://fcm.../" }  // fallback
```

→ `204 No Content` (idempotent — если уже soft-deleted/не существует, всё равно 204)

**RBAC:** `PushService.unsubscribeById` фильтрует `WHERE userId=...` — чужой id просто не найдётся (не раскрываем существование чужих subscription'ов).

### 2. GET /comm/push/subscriptions

Список активных устройств. **Privacy:** НЕ возвращаем endpoint/keys.

```json
→ 200 {
  items: [
    {
      id: "uuid",
      platform: "web",
      deviceLabel: "iOS Safari",
      lastSeenAt: "2026-04-28T10:30:00Z",  // null если ни разу не доставили
      createdAt: "2026-04-28T09:15:00Z"
    },
    ...
  ]
}
```

Используется для UI «ваши устройства» в личном кабинете (V2).

### 3. NotifyService.sendPush(input)

Высокоуровневый API доставки push:

```ts
await notify.sendPush({
  userId: "uuid",
  title: "Ваш тур начался!",
  body: "Сегодня первый день программы. Хорошей поездки 🌴",
  url: "/trips/abc/today",
  tag: "trip:abc:status"  // опционально — группировка
});
// → { notificationId, sent: 2, failed: 0, expired: 0 }
```

**Что делает:**
1. Создаёт `Notification` (channel=push, status=pending) — агрегатная запись «интент уведомить»
2. Вызывает `PushService.sendToUser(userId, payload)` — best-effort на ВСЕ active subscriptions
3. Финальный `Notification.status`:
   - `sent` — хоть один device получил
   - `failed` — все провалились (вкл. expired)
   - `pending` — нет subscription'ов вообще
4. Outbox event `comm.message.sent` (если sent>0) или `comm.message.failed` (если все failed)

**Privacy:** в outbox payload нет endpoint/keys, providerMessageId = `push:<sent>/<total>` для аналитики без раскрытия per-device IDs.

**Behavior change:** `NotifyService.send()` при `channel='push'` теперь бросает `NotFoundException` с подсказкой: «используйте `sendPush()`». Это явный API-разделитель — push требует userId+title+body, email требует to+templateId+data, шаблоны разные.

## Recommendation для founders

> **Рекомендация по использованию push для бизнес-сценариев:** push наиболее ценен для **time-critical** уведомлений: «гид опоздал», «погода поменялась», «приехала машина». **Не использовать** для marketing — это убивает opt-in rate. Каждый push должен иметь action-link (`url`) — чтобы клик вёл к конкретному экрану, а не на главную. **Почему:** в travel push без action перестаёт читаться через 2-3 раза, opt-out растёт.

> **Рекомендация-предупреждение:** push CAN'T заменить SMS/email для **юридически значимых** уведомлений (изменение договора, отзыв согласия, принципы PassportController при #141). **Почему:** push доставка не гарантируется (offline device, browser cache, expired subscription) — суд не примет «я отправил push» как доказательство уведомления. Для важного — multi-channel: push + email + sms.

> **Рекомендация по deduplication через `tag`:** для каждого scenario использовать стабильный `tag` (например, `trip:<id>:status`). Это означает что новая push с тем же tag заменит предыдущую, не складываясь в стек. **Когда не использовать tag:** для discrete events типа «новое сообщение от concierge» — каждое сообщение должно быть видно отдельно.

## Out of scope

- **Push templates** — для V1 title/body передаются inline. Если push'ей будет 5+ типов — добавить `apps/api/src/modules/comm/templates/push/<id>/{title,body}.hbs` с TemplateService.renderPush()
- **Real WebPushProvider** — blocked на VAPID (#353)
- **Throttle profile для push endpoints** — default api-profile (вероятно достаточно — DELETE/GET редкие действия)
- **Notification preferences integration** — sendPush() сейчас не проверяет user.preferences.channels.push. Добавить wiring через `NotificationPreferencesService.canDeliver(userId, category, channel)` — отдельный issue (#166 follow-up)

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check` — green
- [x] `pnpm --filter @indiahorizone/api build` — green
- [ ] **После deploy:** smoke POST /subscribe → GET /subscriptions показывает запись
- [ ] **После deploy:** DELETE /subscribe (по id) → GET /subscriptions без записи
- [ ] **После deploy:** sendPush({userId без subs}) → status=pending, sent=0
- [ ] **После deploy:** sendPush({userId c subs}) — в LogPushProvider логи показывают payload

## Recommendation для devops:vika

> При получении VAPID keys (#353):
> 1. Добавить `web-push` npm в apps/api: `pnpm --filter @indiahorizone/api add web-push @types/web-push`
> 2. Создать `apps/api/src/modules/comm/push/web-push.provider.ts` (extends `PushProvider`) — реализация через `webPush.sendNotification(subscription, payload)` + handle 410 как `expired`
> 3. Switch в `comm.module.ts`: `provide: PUSH_PROVIDER, useFactory: cfg => cfg.get('VAPID_PRIVATE_KEY') ? webPushProvider : logPushProvider`
> 4. `NEXT_PUBLIC_VAPID_PUBLIC_KEY` env для frontend
>
> **Проверка:** subscribe из Chrome → sendPush через `curl -X POST /admin/test-push` → ожидаем notification в браузере.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_