### PR TITLE
fix(deploy): build Docker image in GHA → push to GHCR (fix timeout)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,5 +1,9 @@
 # Deploy apps/web to dev-сервер 2.56.241.126
 #
+# ВАЖНО: Docker образ строится здесь, в GHA, и пушится в GHCR.
+#        На сервере — только docker pull + restart (без --build).
+#        Это решает проблему таймаута при build на сервере (issue: build >15 мин).
+#
 # Issue: #320 [devops:vika]
 # Триггеры:
 #   - push в main → авто-deploy
@@ -12,7 +16,8 @@
 #      - DEV_SSH_KEY  = приватный SSH-ключ (один раз сгенерировать пару,
 #                       публичный — на сервер в ~/.ssh/authorized_keys,
 #                       приватный — сюда)
-#   2. На сервере: git clone, см. issue #320 шаг 2
+#   2. GITHUB_TOKEN автоматически имеет packages:write (permissions ниже)
+#   3. На сервере: git clone, см. issue #320 шаг 2
 #
 # Структура на сервере:
 #   /opt/indiahorizone/
@@ -35,17 +40,64 @@ concurrency:
   group: deploy-dev
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  deploy:
-    name: SSH deploy
+  build-and-push:
+    name: Build & push Docker image to GHCR
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/rivega42/indiahorizone-web
+          tags: |
+            type=raw,value=dev
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: SSH deploy (pull & restart)
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Echo deploy params
         run: |
           echo "Branch: ${{ github.event.inputs.branch || github.ref_name }}"
           echo "Triggered by: ${{ github.actor }}"
           echo "SHA: ${{ github.sha }}"
+          echo "Image: ghcr.io/rivega42/indiahorizone-web:dev"
 
       - name: SSH deploy
         uses: appleboy/ssh-action@v1.0.3
@@ -65,9 +117,12 @@ jobs:
             git checkout "$BRANCH"
             git reset --hard "origin/$BRANCH"
 
-            echo "→ rebuilding containers"
+            echo "→ pulling fresh image from GHCR"
+            docker pull ghcr.io/rivega42/indiahorizone-web:dev
+
+            echo "→ restarting containers (no build)"
             cd /opt/indiahorizone
-            docker compose --env-file .env -f docker-compose.dev.yml up -d --build api web
+            docker compose --env-file .env -f docker-compose.dev.yml up -d --no-build api web
 
             echo "→ running migrations"
             docker compose --env-file .env -f docker-compose.dev.yml run --rm api \

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,9 +1,12 @@
 # Compose для dev на 2.56.241.126:3010
 # Issue: #320 [devops:vika]
 #
+# ВАЖНО: образ строится в GitHub Actions и пушится в GHCR.
+#        Локальный build отключён. pull_policy: always гарантирует свежий образ.
+#
 # Запуск (на сервере):
 #   cd /opt/indiahorizone
-#   docker compose -f docker-compose.dev.yml up -d --build
+#   docker compose -f docker-compose.dev.yml up -d --no-build
 #
 # Что НЕ входит в этот compose (специально):
 #   - apps/api (NestJS) — добавим когда [12.4] Lead закроется и Vika
@@ -13,10 +16,8 @@
 
 services:
   web:
-    build:
-      context: ./deploy
-      dockerfile: apps/web/Dockerfile
-    image: indiahorizone-web:dev
+    image: ghcr.io/rivega42/indiahorizone-web:dev
+    pull_policy: always
     container_name: indiahorizone-web-dev
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Проблема

`deploy-dev.yml` делал `docker compose up --build` **на сервере** через SSH. Build занимал >15 мин, GHA job timeout (15 мин) срабатывал до завершения. Последние 5 запусков — все failure.

## Решение

Перенесли Docker build в **GitHub Actions**, образ пушится в GHCR. На сервере — только `docker pull` + restart.

## Что изменилось

### `.github/workflows/deploy-dev.yml`
- Добавлен job `build-and-push`: собирает образ с BuildKit cache, пушит в `ghcr.io/rivega42/indiahorizone-web:dev`
- SSH-шаг теперь только: `docker pull` + `docker compose ... up -d --no-build`
- Добавлены `permissions: packages: write` для GITHUB_TOKEN
- Timeout увеличен с 15 до 30 мин (build в GHA быстрее, но запас на сеть)

### `deploy/docker-compose.dev.yml`
- Убрана секция `build:` из сервиса `web`
- `image` заменён на `ghcr.io/rivega42/indiahorizone-web:dev`
- Добавлен `pull_policy: always` — всегда тянет свежий образ

## Ожидаемый результат

| До | После |
|----|-------|
| Build на сервере: ~20 мин → timeout | Build в GHA: ~5-8 мин (с cache) |
| SSH job падает | SSH job: pull + restart ~30 сек |
| 5 failed runs | ✅ |

Связано с issue #320 [devops:vika]