### PR TITLE
feat(comm,web): push preferences + /profile/notifications + tour seed README

### DIFF
--- a/apps/api/prisma/seed/tours.ts
+++ b/apps/api/prisma/seed/tours.ts
@@ -14,7 +14,7 @@
  *
  * Issue: #295 [12.2]
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { PrismaClient, type Prisma, type TourStatus } from '@prisma/client';
@@ -53,7 +53,16 @@ interface TourJson {
   days: TourDayJson[];
 }
 
-const TOUR_FILES = ['tours/kerala-2026-10.json'];
+/**
+ * Auto-discovery всех `*.json` в директории seed/tours/.
+ * Drop new tour file → run seed → готово, без изменения кода.
+ * См. apps/api/prisma/seed/tours/README.md.
+ */
+const TOURS_DIR = join(__dirname, 'tours');
+const TOUR_FILES = readdirSync(TOURS_DIR)
+  .filter((f) => f.endsWith('.json'))
+  .map((f) => `tours/${f}`)
+  .sort();
 
 async function seedTour(file: string): Promise<void> {
   const path = join(__dirname, file);

--- a/apps/api/prisma/seed/tours/README.md
+++ b/apps/api/prisma/seed/tours/README.md
@@ -1,0 +1,214 @@
+# Tour Seed — добавление нового тура
+
+> Source-of-truth для каталога туров до появления Admin UI (#311 V2).
+> Каждый JSON в этой директории = один тур на `/tours/<slug>`.
+
+## TL;DR — как добавить новый тур
+
+1. **Скопировать** существующий шаблон: `cp kerala-2026-10.json goa-2027-01.json`
+2. **Отредактировать** все поля (см. ниже)
+3. **Применить:** `pnpm --filter @indiahorizone/api db:seed:tours`
+4. **Проверить:** `http://localhost:3010/tours/<your-slug>` рендерится
+
+Auto-discovery: seed-скрипт сам найдёт все `*.json` в этой директории — менять код не надо.
+
+## Структура файла (TourJson)
+
+```jsonc
+{
+  "slug": "tury-goa-yanvar-2027",          // URL: /tours/<slug>
+  "status": "DRAFT",                        // DRAFT (скрыто) / PUBLISHED (публично)
+  "title": "Гоа. 7 дней без хаоса",
+  "region": "Анджуна · Палолем · форт Чапора",
+  "durationDays": 7,
+  "season": "Январь 2027",
+  "priceFromRub": 180000,                   // INT, в рублях, без копеек
+  "priceToRub": 240000,                     // optional — диапазон
+  "groupSize": "до 10 человек",
+  "heroVideoUrl": null,                     // optional
+  "heroPosterUrl": "https://...",
+  "emotionalHook": "Океан, форты, прогулки на джипе через джунгли — Индия в её солнечном изводе.",
+  "trustBadges": ["24/7 на связи", "Местная команда", "Без скрытых платежей"],
+  "facts": [
+    { "iconKind": "clock", "label": "Длительность", "value": "7 дней" },
+    { "iconKind": "users", "label": "Размер группы", "value": "до 10 человек" },
+    { "iconKind": "calendar", "label": "Сезон", "value": "Январь 2027" },
+    { "iconKind": "bed", "label": "Отели", "value": "3-4★ у океана" },
+    { "iconKind": "car", "label": "Транспорт", "value": "Все трансферы" },
+    { "iconKind": "headset", "label": "Поддержка", "value": "24/7 чат" }
+  ],
+  "inclusions": {
+    "included": [
+      "Все наземные трансферы",
+      "Размещение 3-4★",
+      "Гид-сопровождение",
+      "Завтраки",
+      "Программа 7 дней"
+    ],
+    "notIncluded": [
+      "Авиабилеты",
+      "Виза в Индию",
+      "Личные расходы",
+      "Алкоголь"
+    ]
+  },
+  "faq": [
+    {
+      "q": "Какая виза нужна?",
+      "a": "Электронная e-Visa на 30 дней, оформляется онлайн за 3-7 дней. Помогаем с заявкой."
+    }
+    // ... 5-10 вопросов
+  ],
+  "days": [
+    {
+      "dayNumber": 1,
+      "location": "Анджуна",
+      "title": "Прилёт. Океан и адаптация.",
+      "description": "Встреча в аэропорту Даболим. Трансфер в отель у океана...",
+      "activities": [
+        { "kind": "culture", "label": "Welcome dinner" },
+        { "kind": "water", "label": "Закат у моря" }
+      ],
+      "imageUrl": "https://...",
+      "isOptional": false,                  // true = «на выбор» (треккинг ИЛИ СПА)
+      "costInrFrom": 8500,                  // INTERNAL — НЕ показывается клиенту
+      "costInrTo": 12000                    // INTERNAL — для аналитики маржи
+    }
+    // ... durationDays штук
+  ]
+}
+```
+
+## Поля и enum'ы
+
+### `iconKind` (для facts) — иконки Lucide
+
+| Значение | Что |
+|---|---|
+| `clock` | Часы (длительность) |
+| `users` | Люди (размер группы) |
+| `calendar` | Календарь (сезон/даты) |
+| `bed` | Кровать (отели/проживание) |
+| `car` | Машина (транспорт/трансферы) |
+| `headset` | Гарнитура (поддержка/чат) |
+
+Расширение enum'а — добавить запись в `apps/web/components/tour/Facts.tsx → ICON_MAP`.
+
+### `activities[].kind` — типы активностей дня
+
+| Значение | Иконка | Применение |
+|---|---|---|
+| `culture` | 🎵 Music | Храмы, концерты, рынки, культурные программы |
+| `nature` | 🌿 Leaf | Природа, парки, водопады, прогулки |
+| `food` | 🍴 UtensilsCrossed | Гастро-туры, кулинарные классы |
+| `water` | 🌊 Waves | Море, бэкуотеры, лодки, пляжи |
+| `adventure` | ⛰ Mountain | Треккинг, рафтинг, экстрим |
+| `wellness` | ✨ Sparkles | СПА, йога, аюрведа, ретрит |
+
+### `status`
+
+- `DRAFT` — тур виден в БД но НЕ отдаётся через `GET /tours` и `GET /tours/:slug` (404). Для подготовки контента до публикации.
+- `PUBLISHED` — публично доступен. `publishedAt` ставится автоматически в момент перехода в PUBLISHED.
+
+## Slug-конвенция
+
+> **Critical для SEO:** slug = РУ-транслит + сезон. Короткий, ключи в начале.
+
+Хорошо:
+- `tury-kerala-oktyabr-2026`
+- `tury-goa-yanvar-2027`
+- `treking-gimalai-aprel-2026`
+
+Плохо:
+- `kerala-10-days-trivandrum-varkala-jatayu` — длинный, Яндекс обрежет
+- `tour123` — нет ключей, killing CTR
+- `Гоа-январь-2027` — Cyrillic в URL не удобен в копи-пасте
+
+> **Почему важно:** Яндекс показывает первые 50 chars slug'а в snippet'е. Длинный slug → урезанный snippet → -15-20% CTR.
+
+## Privacy: `costInrFrom` / `costInrTo`
+
+Эти поля — **internal**. Хранятся для аналитики маржи (RUB price - INR cost = gross margin). **НЕ отдаются** клиенту через `GET /tours/:slug` — `CatalogService.toDayDto()` сознательно их исключает.
+
+> **Critical:** не публиковать INR-цены в `description` или другие public fields! Next.js getStaticProps встраивает весь response в HTML — если попадёт в DTO, будет видно любому клиенту в DevTools.
+
+## emotional_hook — главное про SEO
+
+Это короткое (2-3 предложения) описание тура, которое:
+- Используется как `<meta name="description">` (Yandex/Google snippet)
+- Встраивается в Open Graph для Telegram preview
+- Попадает в Schema.org TouristTrip
+
+> **Recommendation:** делайте **уникальный** hook для каждого тура. Yandex понижает ranking страниц с дублированием meta-descriptions внутри одного домена (penalty за «доорвейные страницы»). С 10-15 турами это критично.
+
+Хорошо:
+- «Керала: 10 дней без хаоса. Программа продумана за вас, контакт с местной командой 24/7. Океан, кокосы, аюрведа.»
+- «Гоа в январе: солнце 32°, океан 27°, форты португальских колоний и закатные пляжи Палолема.»
+
+Плохо:
+- «Тур в Индию на 10 дней» (generic, скопировано во все туры)
+- «Лучший тур!» (no info, спам-сигнал)
+
+## Изображения
+
+### `heroPosterUrl` (обязательно)
+
+Hero-картинка landing-страницы. **LCP-image** = Largest Contentful Paint:
+
+- **Размер:** 1920×1080 (16:9) минимум, **JPEG quality 85** (или WebP)
+- **Вес:** ≤ 200kb (Next.js auto-converts в AVIF/WebP, но base тоже важен)
+- **Содержание:** атмосферное фото места, не reception desk
+
+> **Important:** домен изображения должен быть в `apps/web/next.config.mjs → images.remotePatterns`. Сейчас разрешены: `images.unsplash.com`, `s3.ru1.storage.beget.cloud` (наш S3 #350), `cdn.indiahorizone.ru`.
+
+### `days[].imageUrl` (обязательно для каждого дня)
+
+Фото локации дня. Lazy-loaded, `aspect-[16/9]`. Можно использовать одно фото на несколько дней (например, для дней в одной локации) — главное чтобы было.
+
+## Контент-tone (recommendation)
+
+> **Recommendation для founders:** избегайте маркетингового пафоса. Русскоязычная travel-аудитория high BS-detector — «лучший тур мечты ✨» читается как реклама и снижает trust.
+>
+> **Что работает:**
+> - Честность с конкретикой («Индия — это шумно. Программа собрана так, чтобы шум был дозированно — храмы балансируем backwaters, рынки — пляжем»)
+> - Деталь которая показывает что вы реально были там («жара 32° в обед, поэтому экскурсии до 11:00 и после 16:00»)
+> - Эмоция через образ, не прилагательное («розовый закат над озером Веллаянил» лучше чем «прекрасные виды»)
+
+## После добавления тура — checklist
+
+См. также `docs/UX/TOUR_LANDING.md § Тестирование per-tour` для полного списка. Кратко:
+
+- [ ] `pnpm dev:web` → `http://localhost:3010/tours/<slug>` — рендерится без 404
+- [ ] Mobile viewport 375px — все секции читаемы
+- [ ] [Schema.org валидатор Yandex](https://yandex.ru/dev/json-ld/) — TouristTrip + FAQPage = valid
+- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) — same
+- [ ] Telegram debugger — отправить ссылку → preview корректный
+- [ ] Lighthouse mobile — Performance ≥ 80, SEO ≥ 95, A11y ≥ 95
+
+## Команды
+
+```bash
+# Запустить seed (применит все *.json в этой директории)
+pnpm --filter @indiahorizone/api db:seed:tours
+
+# Smoke API
+curl http://localhost:4000/tours
+curl http://localhost:4000/tours/<slug>
+
+# Локально посмотреть рендер (api + web должны быть запущены)
+open http://localhost:3010/tours/<slug>
+```
+
+## Идемпотентность
+
+Seed безопасно перезапускать любое количество раз:
+- Туры — upsert по `slug`
+- Дни — upsert по `(tourId, dayNumber)`
+- Удалённые из JSON дни **НЕ** удаляются автоматически из БД (защита от случайного truncate). Удалить день → через psql или admin UI (V2).
+
+## Будущее (#311 V2)
+
+Когда появится Admin Panel:
+- Туры будут редактироваться через UI, без re-deploy
+- JSON-файлы можно будет удалить (сейчас они source-of-truth)
+- Versioning туров — как в `Itinerary` (snapshot на каждый publish)

--- a/apps/api/src/modules/comm/notify.service.ts
+++ b/apps/api/src/modules/comm/notify.service.ts
@@ -22,13 +22,14 @@
  */
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 
+import { NotificationPreferencesService } from './preferences/preferences.service';
 import { EMAIL_PROVIDER, type EmailProvider } from './providers/email.provider';
 import { PushService } from './push/push.service';
 import { TemplateService } from './template.service';
 import { OutboxService } from '../../common/outbox/outbox.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 
-import type { NotificationChannel, Prisma } from '@prisma/client';
+import type { NotificationCategory, NotificationChannel, Prisma } from '@prisma/client';
 
 export interface SendInput {
   channel: NotificationChannel;
@@ -47,6 +48,10 @@ export interface SendInput {
  * `tag` — для группировки (один tag → одна notification, не стек). Удобно для
  * сценариев типа «обновился статус trip» — каждый trip имеет свой tag, новая
  * push заменяет старую вместо стека.
+ *
+ * `category` — для проверки user.preferences.channels[push]. SOS обходит
+ * проверку (protected). Если не задан — preferences не проверяются (only для
+ * legacy callers; новые callers ОБЯЗАНЫ указывать category).
  */
 export interface SendPushInput {
   userId: string;
@@ -54,6 +59,7 @@ export interface SendPushInput {
   body: string;
   url?: string;
   tag?: string;
+  category?: NotificationCategory;
 }
 
 @Injectable()
@@ -66,6 +72,7 @@ export class NotifyService {
     private readonly templates: TemplateService,
     @Inject(EMAIL_PROVIDER) private readonly emailProvider: EmailProvider,
     private readonly push: PushService,
+    private readonly preferences: NotificationPreferencesService,
   ) {}
 
   async send(input: SendInput): Promise<{ notificationId: string }> {
@@ -178,7 +185,42 @@ export class NotifyService {
     sent: number;
     failed: number;
     expired: number;
+    skipped: boolean;
   }> {
+    // Preferences check (#166): respect user.preferences.channels.push для категории.
+    // SOS — protected, всегда true. Для legacy callers без category — пропускаем
+    // проверку (skipped=false по дефолту, push идёт).
+    if (input.category) {
+      const allowed = await this.preferences.shouldNotify(input.userId, input.category, 'push');
+      if (!allowed) {
+        this.logger.log(
+          { userId: input.userId, category: input.category },
+          'comm.push.skipped.preferences',
+        );
+        // Создаём Notification для трассировки, но в статусе 'failed' с явным reason.
+        // Это даёт founder'ам аналитику «сколько отправок blocked'нуто preferences».
+        const skipped = await this.prisma.notification.create({
+          data: {
+            channel: 'push',
+            recipient: input.userId,
+            templateId: 'push:inline',
+            payload: {
+              title: input.title,
+              body: input.body,
+              ...(input.url !== undefined ? { url: input.url } : {}),
+              ...(input.tag !== undefined ? { tag: input.tag } : {}),
+            },
+            status: 'failed',
+            failedAt: new Date(),
+            errorMessage: `blocked by user preferences (category=${input.category})`,
+            userId: input.userId,
+          },
+          select: { id: true },
+        });
+        return { notificationId: skipped.id, sent: 0, failed: 0, expired: 0, skipped: true };
+      }
+    }
+
     const notification = await this.prisma.notification.create({
       data: {
         channel: 'push',
@@ -254,6 +296,6 @@ export class NotifyService {
       finalStatus === 'sent' ? 'comm.push.sent' : 'comm.push.no-devices-or-failed',
     );
 
-    return { notificationId: notification.id, ...result };
+    return { notificationId: notification.id, ...result, skipped: false };
   }
 }

--- a/apps/web/app/profile/notifications/page.tsx
+++ b/apps/web/app/profile/notifications/page.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+/**
+ * /profile/notifications — управление уведомлениями (#163 + #166).
+ *
+ * 3 секции:
+ * 1. EnableNotificationsButton — подписать текущее устройство (или показать iOS-инструкцию)
+ * 2. Preferences — checkboxes по 4 категориям × 4 каналам (SOS protected)
+ * 3. Devices — список активных push-устройств с возможностью удаления
+ *
+ * Auth required — без accessToken компонент покажет CTA на /login.
+ *
+ * Note: client component целиком — все три секции interactive (subscribe, toggle preferences, delete device).
+ */
+
+import { useEffect, useState } from 'react';
+
+import { EnableNotificationsButton } from '@/components/push/enable-notifications-button';
+import {
+  listPreferences,
+  updatePreference,
+  type NotificationCategory,
+  type NotificationChannel,
+  type PreferenceItem,
+} from '@/lib/api/preferences';
+import {
+  listPushSubscriptions,
+  unsubscribePushById,
+  type PushSubscriptionItem,
+} from '@/lib/api/push-subscriptions';
+import { useCurrentUser } from '@/lib/auth/store';
+
+const CATEGORY_LABELS: Record<NotificationCategory, { name: string; description: string }> = {
+  trips: {
+    name: 'Поездки',
+    description: 'Статусы вашей поездки, напоминания, изменения программы',
+  },
+  marketing: {
+    name: 'Маркетинг',
+    description: 'Новые туры и спецпредложения. По умолчанию выключено (152-ФЗ)',
+  },
+  sos: {
+    name: 'SOS',
+    description: 'Экстренные уведомления. Нельзя отключить (требование безопасности)',
+  },
+  system: {
+    name: 'Безопасность',
+    description: 'Подозрительный вход, смена пароля, важные системные события',
+  },
+};
+
+const CHANNEL_LABELS: Record<NotificationChannel, string> = {
+  push: 'Push',
+  email: 'Email',
+  sms: 'SMS',
+  telegram: 'Telegram',
+};
+
+export default function NotificationsProfilePage(): React.ReactElement {
+  const user = useCurrentUser();
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Уведомления</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы настроить уведомления.{' '}
+          <a href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </a>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-10 px-6 py-12 sm:py-16">
+      <header>
+        <h1 className="font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Уведомления
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Настройте, что и куда мы вам отправляем. Выключенные типы можно вернуть в любой момент.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="font-serif text-xl font-medium">Push на этом устройстве</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Подключите push, чтобы получать уведомления когда сайт закрыт.
+        </p>
+        <div className="mt-4">
+          <EnableNotificationsButton />
+        </div>
+      </section>
+
+      <PreferencesSection />
+
+      <DevicesSection />
+    </main>
+  );
+}
+
+// ─────────────────────────────────────── Preferences
+
+function PreferencesSection(): React.ReactElement {
+  const [items, setItems] = useState<PreferenceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    listPreferences()
+      .then((res) => setItems(res.items))
+      .catch((err: unknown) => {
+        console.error('[preferences] list failed', err);
+        setError('Не удалось загрузить настройки.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function toggleChannel(
+    category: NotificationCategory,
+    channel: NotificationChannel,
+    nextChannels: NotificationChannel[],
+  ): Promise<void> {
+    setSavingKey(`${category}:${channel}`);
+    setError(null);
+    try {
+      const updated = await updatePreference(category, { channels: nextChannels });
+      setItems((prev) => prev.map((i) => (i.category === category ? updated : i)));
+    } catch (err: unknown) {
+      console.error('[preferences] update failed', err);
+      setError(
+        `Не удалось обновить ${CATEGORY_LABELS[category].name} → ${CHANNEL_LABELS[channel]}`,
+      );
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  async function toggleEnabled(
+    category: NotificationCategory,
+    nextEnabled: boolean,
+  ): Promise<void> {
+    setSavingKey(`${category}:enabled`);
+    setError(null);
+    try {
+      const updated = await updatePreference(category, { enabled: nextEnabled });
+      setItems((prev) => prev.map((i) => (i.category === category ? updated : i)));
+    } catch (err: unknown) {
+      console.error('[preferences] update enabled failed', err);
+      setError(
+        `Не удалось ${nextEnabled ? 'включить' : 'отключить'} ${CATEGORY_LABELS[category].name}`,
+      );
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <section>
+        <h2 className="font-serif text-xl font-medium">Категории</h2>
+        <p className="mt-2 text-sm text-muted-foreground">Загружаем настройки…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h2 className="font-serif text-xl font-medium">Категории</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Каждую категорию можно отключить целиком или выбрать каналы доставки.
+      </p>
+
+      {error ? (
+        <p role="alert" className="mt-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="mt-6 space-y-4">
+        {items.map((item) => {
+          const labels = CATEGORY_LABELS[item.category];
+          const isProtected = item.category === 'sos';
+          return (
+            <article
+              key={item.category}
+              className="rounded-lg border border-border bg-card p-4 sm:p-5"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="font-medium">{labels.name}</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">{labels.description}</p>
+                </div>
+                <label
+                  className={`relative inline-flex cursor-pointer items-center ${
+                    isProtected ? 'pointer-events-none opacity-60' : ''
+                  }`}
+                  aria-label={`Включить ${labels.name}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={item.enabled}
+                    disabled={isProtected || savingKey === `${item.category}:enabled`}
+                    onChange={(e) => {
+                      void toggleEnabled(item.category, e.target.checked);
+                    }}
+                    className="peer sr-only"
+                  />
+                  <span className="h-6 w-11 rounded-full bg-stone-300 transition peer-checked:bg-primary" />
+                  <span className="absolute left-0.5 h-5 w-5 rounded-full bg-white transition peer-checked:left-5" />
+                </label>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {(['push', 'email', 'sms', 'telegram'] as NotificationChannel[]).map((ch) => {
+                  const isOn = item.channels.includes(ch);
+                  const key = `${item.category}:${ch}`;
+                  return (
+                    <button
+                      key={ch}
+                      type="button"
+                      disabled={
+                        savingKey === key ||
+                        !item.enabled ||
+                        (isProtected && isOn && item.channels.length === 1)
+                      }
+                      onClick={() => {
+                        const nextChannels = isOn
+                          ? item.channels.filter((c) => c !== ch)
+                          : [...item.channels, ch];
+                        void toggleChannel(item.category, ch, nextChannels);
+                      }}
+                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition ${
+                        isOn
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-border bg-background text-muted-foreground hover:border-primary/40'
+                      } disabled:cursor-not-allowed disabled:opacity-50`}
+                    >
+                      {CHANNEL_LABELS[ch]}
+                      {isOn ? <span aria-hidden>✓</span> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ─────────────────────────────────────── Devices
+
+function DevicesSection(): React.ReactElement {
+  const [items, setItems] = useState<PushSubscriptionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  useEffect(() => {
+    listPushSubscriptions()
+      .then((res) => setItems(res.items))
+      .catch((err: unknown) => {
+        console.error('[devices] list failed', err);
+        setError('Не удалось загрузить устройства.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function remove(id: string): Promise<void> {
+    setRemoving(id);
+    setError(null);
+    try {
+      await unsubscribePushById(id);
+      setItems((prev) => prev.filter((d) => d.id !== id));
+    } catch (err: unknown) {
+      console.error('[devices] remove failed', err);
+      setError('Не удалось отписать устройство.');
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <section>
+        <h2 className="font-serif text-xl font-medium">Подключённые устройства</h2>
+        <p className="mt-2 text-sm text-muted-foreground">Загружаем…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h2 className="font-serif text-xl font-medium">Подключённые устройства</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Здесь видны устройства, на которых включены push. Можно отключить любое.
+      </p>
+
+      {error ? (
+        <p role="alert" className="mt-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </p>
+      ) : null}
+
+      {items.length === 0 ? (
+        <p className="mt-4 rounded-lg border border-dashed border-border bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
+          Push не подключён ни на одном устройстве.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {items.map((d) => (
+            <li
+              key={d.id}
+              className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="text-sm font-medium">{d.deviceLabel ?? 'Устройство'}</div>
+                <div className="text-xs text-muted-foreground">
+                  Добавлено: {formatDate(d.createdAt)}
+                  {d.lastSeenAt
+                    ? ` · последний push: ${formatDate(d.lastSeenAt)}`
+                    : ' · push ещё не приходили'}
+                </div>
+              </div>
+              <button
+                type="button"
+                disabled={removing === d.id}
+                onClick={() => {
+                  void remove(d.id);
+                }}
+                className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground transition hover:border-destructive hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {removing === d.id ? 'Удаляем…' : 'Отписать'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('ru-RU', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}

--- a/apps/web/lib/api/preferences.ts
+++ b/apps/web/lib/api/preferences.ts
@@ -1,0 +1,39 @@
+/**
+ * Notification preferences API client (#166).
+ *
+ * GET    /comm/preferences          — все 4 категории с дефолтами + кастомизацией
+ * PATCH  /comm/preferences/:cat     — обновить enabled/channels для категории
+ *
+ * Категории: trips | marketing | sos | system. SOS — protected (server вернёт 400 если попытаться отключить).
+ * Каналы: push | email | sms | telegram.
+ */
+import { apiClient } from './client';
+
+export type NotificationCategory = 'trips' | 'marketing' | 'sos' | 'system';
+export type NotificationChannel = 'push' | 'email' | 'sms' | 'telegram';
+
+export interface PreferenceItem {
+  category: NotificationCategory;
+  channels: NotificationChannel[];
+  enabled: boolean;
+  /** true = пользователь явно настраивал, false = используется default */
+  isCustom: boolean;
+}
+
+export async function listPreferences(): Promise<{ items: PreferenceItem[] }> {
+  const res = await apiClient.get<{ items: PreferenceItem[] }>('/comm/preferences');
+  return res.data;
+}
+
+export interface UpdatePreferencePayload {
+  enabled?: boolean;
+  channels?: NotificationChannel[];
+}
+
+export async function updatePreference(
+  category: NotificationCategory,
+  payload: UpdatePreferencePayload,
+): Promise<PreferenceItem> {
+  const res = await apiClient.patch<PreferenceItem>(`/comm/preferences/${category}`, payload);
+  return res.data;
+}

--- a/apps/web/lib/api/push-subscriptions.ts
+++ b/apps/web/lib/api/push-subscriptions.ts
@@ -1,0 +1,28 @@
+/**
+ * Push subscriptions list/delete API client (#163 phase 2).
+ *
+ * GET    /comm/push/subscriptions   — активные устройства user'а (без endpoint/keys для privacy)
+ * DELETE /comm/push/subscribe       — отписать конкретное устройство
+ */
+import { apiClient } from './client';
+
+export type PushPlatform = 'web' | 'ios_native' | 'android_native';
+
+export interface PushSubscriptionItem {
+  id: string;
+  platform: PushPlatform;
+  deviceLabel: string | null;
+  lastSeenAt: string | null;
+  createdAt: string;
+}
+
+export async function listPushSubscriptions(): Promise<{ items: PushSubscriptionItem[] }> {
+  const res = await apiClient.get<{ items: PushSubscriptionItem[] }>('/comm/push/subscriptions');
+  return res.data;
+}
+
+export async function unsubscribePushById(subscriptionId: string): Promise<void> {
+  await apiClient.delete('/comm/push/subscribe', {
+    data: { subscriptionId },
+  });
+}


### PR DESCRIPTION
## Summary

3 связанных изменения в одном PR (3 commits):
1. **Push preferences integration** (#166 follow-up) — `NotifyService.sendPush()` уважает user preferences
2. **`/profile/notifications` page** — UI для управления preferences + devices
3. **Tour seed README + auto-discovery** — упростить добавление 10-15 туров founder'ом

## Что внутри

### Commit 1: NotifyService.sendPush respects preferences

```ts
await notify.sendPush({
  userId, title, body, url,
  category: 'trips',  // ← новый optional параметр
});
// Внутри: preferences.shouldNotify(userId, 'trips', 'push') → true/false
// false → создаётся Notification со status='failed', errorMessage='blocked by user preferences'
//        возвращается { sent: 0, ..., skipped: true }
```

- 152-ФЗ ст. 18 compliance — marketing push'и не идут без opt-in
- SOS обходит проверку (protected)
- Legacy callers без `category` — preferences не проверяются (push идёт)
- Notification record создаётся даже для skipped — для аналитики

### Commit 2: `/profile/notifications` page

Полнофункциональная страница:

1. **Section 1: Push на этом устройстве** — `EnableNotificationsButton` с iOS-инструкцией
2. **Section 2: Категории** — 4 категории × 4 канала с auto-save:
   - Поездки / Маркетинг / SOS / Безопасность
   - Push / Email / SMS / Telegram
   - SOS protected (нельзя отключить)
   - Toggle категории (master switch) + toggle каждого канала
3. **Section 3: Подключённые устройства** — список с device label, датой подключения, last push + кнопкой «Отписать»

- Auth required — без токена → CTA на `/login`
- Inline error feedback при API failure
- Bundle: 5.72 kB / 115 kB First Load
- `robots.ts` уже disallow `/profile/`

API clients добавлены:
- `lib/api/preferences.ts` — listPreferences + updatePreference
- `lib/api/push-subscriptions.ts` — listPushSubscriptions + unsubscribePushById

### Commit 3: Tour seed README + auto-discovery

С учётом 10-15 туров на старте — упрощаем процесс добавления:

- **Auto-discovery:** `seed/tours.ts` теперь читает все `*.json` в директории — нет нужды модифицировать `TOUR_FILES` при добавлении
- **README** с инструкцией для founder'а:
  - Структура TourJson + полный пример
  - Enum'ы (iconKind, activities[].kind, status)
  - Slug-конвенция для SEO (РУ-транслит + сезон, короткий)
  - Privacy: `costInrFrom`/`costInrTo` — internal, never в публичном DTO
  - **emotional_hook** unique per tour (Yandex penalty за дублирование)
  - Image guidelines (LCP, allowed domains)
  - Content tone recommendations (избегать маркетингового пафоса для RU travel)
  - Per-tour QA checklist + smoke commands

## Recommendation для founders

> **Использование `category` параметра:** при отправке любого push из бизнес-кода (`trip.status.changed listener`, etc) **обязательно** указывайте `category: 'trips' | 'marketing' | 'system' | 'sos'`. Без category preferences не проверяются → user не сможет opt-out из marketing'а через UI. **Почему критично:** GDPR/152-ФЗ требуют технической возможности opt-out, не просто текста в правилах.

> **Tour content tone (важное напоминание из README):** избегайте «лучший тур мечты ✨». Русскоязычный travel-клиент high BS-detector. Лучше работает: честность + конкретика + образ через деталь («жара 32° в обед — экскурсии до 11:00 и после 16:00»).

> **emotional_hook ОБЯЗАТЕЛЬНО уникален для каждого тура.** Yandex понижает ranking страниц с дублированием meta-descriptions внутри домена. С 10-15 турами это критично — все попадут под penalty при копи-пасте.

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check` — green
- [x] `pnpm --filter @indiahorizone/api build` + `pnpm --filter @indiahorizone/web build` — green
- [x] /profile/notifications добавился в Next routes (5.72 kB)
- [ ] **После deploy:** smoke - login → /profile/notifications → toggle preference → проверить что в БД сохранилось
- [ ] **После deploy:** smoke push с category=marketing для user'а с marketing.enabled=false → notification.status='failed', errorMessage='blocked by user preferences'

## Что НЕ в этом PR

- **Email preferences integration** — `NotifyService.send()` пока не проверяет preferences для email. Сейчас email канал protected (welcome/password-reset/suspicious-login — все system/sos). Для email-marketing — отдельный issue когда появится marketing email-flow.
- **Generic ProfileLayout** — пока только одна страница `/profile/notifications`. Когда будут другие (`/profile/settings`, `/profile/devices` отдельно) — сделаем shared layout в `(profile)/` route group.
- **2-3 примера tour JSON для других регионов** — без актуального контента от Шивама/Roman'а это будет fake-данные. README достаточно как guide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_