### PR TITLE
feat(comm): high-urgency push для SOS / action-required (#163 follow-up)

### DIFF
--- a/apps/api/src/modules/comm/notify.service.ts
+++ b/apps/api/src/modules/comm/notify.service.ts
@@ -52,6 +52,8 @@ export interface SendInput {
  * `category` — для проверки user.preferences.channels[push]. SOS обходит
  * проверку (protected). Если не задан — preferences не проверяются (only для
  * legacy callers; новые callers ОБЯЗАНЫ указывать category).
+ *
+ * `urgency` — `'normal'` (default) | `'high'` для action-required SOS.
  */
 export interface SendPushInput {
   userId: string;
@@ -60,6 +62,7 @@ export interface SendPushInput {
   url?: string;
   tag?: string;
   category?: NotificationCategory;
+  urgency?: 'normal' | 'high';
 }
 
 @Injectable()
@@ -244,6 +247,7 @@ export class NotifyService {
       body: input.body,
       ...(input.url !== undefined ? { url: input.url } : {}),
       ...(input.tag !== undefined ? { tag: input.tag } : {}),
+      ...(input.urgency !== undefined ? { urgency: input.urgency } : {}),
     });
 
     // Status: sent если хоть один device получил, failed если все провалились

--- a/apps/api/src/modules/comm/push/push.provider.ts
+++ b/apps/api/src/modules/comm/push/push.provider.ts
@@ -21,6 +21,17 @@ export interface PushDeliverPayload {
   url?: string;
   /** Для группировки в бровзере (один tag → одна notification, не стек). */
   tag?: string;
+  /**
+   * Web Push urgency hint (RFC 8030 §5.3):
+   * - `normal` (default) — обычная нотификация (поездка стартовала, чат)
+   * - `high` — критичная (SOS ack, отмена поездки) — push-сервер пытается доставить
+   *   быстрее даже на устройстве в режиме энергосбережения
+   *
+   * Apple Web Push на iOS особенно чувствителен — `high` обходит throttling, но
+   * злоупотребление может привести к downgrade'у нашего sender-rep'а у Apple.
+   * Использовать ТОЛЬКО для action-required (SOS, finance refund failure).
+   */
+  urgency?: 'normal' | 'high';
 }
 
 export interface PushSubscriptionTarget {

--- a/apps/api/src/modules/comm/push/web-push.provider.ts
+++ b/apps/api/src/modules/comm/push/web-push.provider.ts
@@ -102,13 +102,13 @@ export class WebPushProvider implements PushProvider, OnModuleInit {
     });
 
     try {
-      // TTL 24h — push-сервис попытается доставить за это время если устройство
-      // оффлайн. Дольше нет смысла (контекст устаревает).
-      // urgency='normal' — для critical SOS будет 'high' через отдельный stream
-      // (events.comm.push.priority — TODO #163 follow-up).
+      // TTL: high-urgency = 1h (контекст SOS быстро устаревает), normal = 24h
+      const urgency = payload.urgency ?? 'normal';
+      const ttl = urgency === 'high' ? 60 * 60 : 24 * 60 * 60;
+
       await webpush.sendNotification(subscription, body, {
-        TTL: 24 * 60 * 60,
-        urgency: 'normal',
+        TTL: ttl,
+        urgency,
       });
       return { ok: true };
     } catch (err) {


### PR DESCRIPTION
## Summary

Web Push urgency hint (RFC 8030 §5.3) для SOS / action-required нотификаций. После merge SOS module (когда появится) сможет вызывать `notify.sendPush({urgency: 'high'})` — push'и обходят throttling на устройствах в режиме энергосбережения и доставляются в первую очередь.

## Что внутри

```diff
+ PushDeliverPayload.urgency: 'normal' | 'high'
+ NotifyService.SendPushInput.urgency: 'normal' | 'high'
+ WebPushProvider.deliver передаёт urgency + adjusts TTL:
  - high → TTL 1h (SOS-контекст быстро устаревает)
  - normal → TTL 24h (поездка стартовала и т.п.)
```

Использование (в будущем SOS module):

```ts
await notify.sendPush({
  userId: tripClientId,
  title: 'SOS принят',
  body: 'Concierge на связи. Не отключайте телефон.',
  url: `/sos/${sosId}`,
  category: 'sos',         // → preferences.shouldNotify protected (всегда true)
  urgency: 'high',          // → priority delivery
  tag: `sos:${sosId}`,      // → одна notification per SOS, не стек
});
```

## Recommendation

> **Critical для founders:** `urgency: 'high'` использовать ТОЛЬКО для **action-required** (SOS, finance refund failure, security incident). **Почему:** Apple Web Push на iOS особенно чувствителен к urgency. Каждое 'high' push увеличивает нашу sender-reputation у Apple. Злоупотребление (например, marketing в 'high') → downgrade reputation → push'и начинают throttle'иться даже при urgency=normal. Это сложно восстановить.

> **TTL соответствие urgency** (мой выбор):
> - **high** = 1h — если устройство офлайн >1h, контекст SOS уже не актуален. Reply на просроченный SOS опасен (клиент думает что не услышали).
> - **normal** = 24h — типичный travel-event (statuse trip changed, отель подтверждён) актуален весь день.

## Что НЕ в этом PR (намеренно)

- **Отдельный Redis Stream `events.comm.push.priority`** — не нужен в V1. `sendPush()` доставляет push синхронно (caller ждёт результат). Отдельный stream имеет смысл когда SOS-flow станет async с retry-семантикой и нужно будет priority queue в worker'ах.
- **SOS module integration** — сам SOS module ещё не создан (#192). Когда будет — там просто `notify.sendPush({urgency: 'high', category: 'sos', ...})`.
- **APNs urgency** — для native iOS будет другой механизм (apns-priority header). Когда добавим APNs adapter (фаза 4) — отдельный mapping.

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check`, `build` — green
- [ ] **После deploy + VAPID keys (#379):** smoke `notify.sendPush({urgency:'high'})` → web-push передаёт urgency=high header → DevTools Network видит pri header

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_