### PR TITLE
feat(comm): NotifyService.send() respects email preferences (#166 parity)

### DIFF
--- a/apps/api/src/modules/auth/password-reset/password-reset.service.ts
+++ b/apps/api/src/modules/auth/password-reset/password-reset.service.ts
@@ -79,6 +79,8 @@ export class PasswordResetService {
         templateId: 'password-reset',
         data: { resetUrl },
         userId: user.id,
+        // Password reset = system-critical, нельзя отключить через preferences.
+        category: 'system',
       });
     } catch (err) {
       // Email-fail НЕ должен ломать UX (всё равно 204).

--- a/apps/api/src/modules/comm/listeners/suspicious-login.listener.ts
+++ b/apps/api/src/modules/comm/listeners/suspicious-login.listener.ts
@@ -87,6 +87,8 @@ export class SuspiciousLoginListener implements OnModuleInit, OnModuleDestroy {
           resetPasswordUrl,
         },
         userId,
+        // Suspicious-login = security-critical, system category (не блокируется preferences).
+        category: 'system',
       });
     } catch (err) {
       // Re-throw — events-bus retry-цикл подхватит. Если SMTP временно недоступен,

--- a/apps/api/src/modules/comm/listeners/welcome.listener.ts
+++ b/apps/api/src/modules/comm/listeners/welcome.listener.ts
@@ -81,6 +81,9 @@ export class WelcomeEmailListener implements OnModuleInit, OnModuleDestroy {
           appUrl,
         },
         userId,
+        // Welcome email — обязательный onboarding (system category),
+        // не маркетинг. Не блокируется preferences.
+        category: 'system',
       });
     } catch (err) {
       // Re-throw — events-bus retry-цикл подхватит. После MAX_ATTEMPTS попыток

--- a/apps/api/src/modules/comm/notify.service.ts
+++ b/apps/api/src/modules/comm/notify.service.ts
@@ -38,6 +38,14 @@ export interface SendInput {
   data: Record<string, unknown>;
   /** Опционально: связать notification с user'ом (transactional context) */
   userId?: string;
+  /**
+   * Категория для проверки user.preferences.channels[email]. SOS обходит
+   * проверку (protected). Если не задан — preferences не проверяются (legacy).
+   *
+   * Welcome / password-reset / suspicious-login — это `system` (нельзя отключить).
+   * Marketing email — `marketing` (152-ФЗ ст. 18: opt-in, по умолчанию выключен).
+   */
+  category?: NotificationCategory;
 }
 
 /**
@@ -78,7 +86,7 @@ export class NotifyService {
     private readonly preferences: NotificationPreferencesService,
   ) {}
 
-  async send(input: SendInput): Promise<{ notificationId: string }> {
+  async send(input: SendInput): Promise<{ notificationId: string; skipped?: boolean }> {
     if (input.channel !== 'email') {
       throw new NotFoundException(
         `Channel "${input.channel}" в .send() не поддерживается. Для push используйте .sendPush(); для sms/telegram — отдельные методы (#164/#165)`,
@@ -86,6 +94,34 @@ export class NotifyService {
     }
     if (!this.templates.exists(input.templateId)) {
       throw new NotFoundException(`Template "${input.templateId}" не найден`);
+    }
+
+    // Preferences check (#166): respect user.preferences.channels[email] для category.
+    // SOS — protected. Если category не задан или userId не задан — preferences
+    // не проверяются (legacy callers / sender to non-user email).
+    if (input.userId !== undefined && input.category !== undefined) {
+      const allowed = await this.preferences.shouldNotify(input.userId, input.category, 'email');
+      if (!allowed) {
+        this.logger.log(
+          { userId: input.userId, category: input.category, templateId: input.templateId },
+          'comm.email.skipped.preferences',
+        );
+        // Создаём Notification record для трассировки.
+        const skipped = await this.prisma.notification.create({
+          data: {
+            channel: input.channel,
+            recipient: input.to,
+            templateId: input.templateId,
+            payload: input.data as Prisma.InputJsonValue,
+            status: 'failed',
+            failedAt: new Date(),
+            errorMessage: `blocked by user preferences (category=${input.category})`,
+            userId: input.userId,
+          },
+          select: { id: true },
+        });
+        return { notificationId: skipped.id, skipped: true };
+      }
     }
 
     const notification = await this.prisma.notification.create({


### PR DESCRIPTION
## Summary

Symmetric к push preferences (#381) — теперь `NotifyService.send()` тоже respect-ает `user.preferences.channels[email]` для category. После merge: marketing email-кампании автоматически skip-аются для users с `marketing.enabled=false` (default).

## Что внутри

### `SendInput.category?: NotificationCategory`

Новый optional параметр. Если задан вместе с `userId` — `preferences.shouldNotify(userId, category, 'email')` проверяется перед отправкой.

```diff
 await notify.send({
   channel: 'email',
   to: user.email,
   templateId: 'tour-recommendation',
   userId,
+  category: 'marketing',  // → preferences check (152-ФЗ opt-in)
 });
```

Если blocked → `Notification.status='failed'` + `errorMessage='blocked by user preferences (category=...)'` для аналитики, return `{notificationId, skipped: true}`.

### Existing callers получили `category: 'system'`

- `WelcomeEmailListener` → `system` (welcome обязательный onboarding)
- `SuspiciousLoginListener` → `system` (security-critical)
- `PasswordResetService` → `system` (восстановление пароля)

System категория **не блокируется** preferences (preferences.shouldNotify для system → true если default включён, что и есть).

## Recommendation

> **Обязательно для marketing email-flow:** при создании listener'ов для тур-recommendation / promotion / newsletter — **всегда** указывайте `category: 'marketing'`. **Почему:** 152-ФЗ ст. 18 — opt-in для коммерческих коммуникаций. Default `marketing.enabled=false` → user должен явно включить через `/profile/notifications`. Без правильной category — все user'ы получат рассылку → жалобы → штрафы Роскомнадзора (50-300k₽).

> **Нумерация категорий по типу email-а:**
> - `welcome`, `password-reset`, `suspicious-login`, `email-verification` → `system`
> - `trip-confirmed`, `payment-received`, `trip-starts-tomorrow`, `daily-feedback-request` → `trips`
> - `new-tour-launched`, `seasonal-offer`, `referral-bonus` → `marketing`
> - `sos-acked`, `sos-resolved` → `sos`

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check`, `build` — green
- [x] Existing flows (welcome, password-reset, suspicious-login) — добавили `category: 'system'` без regression
- [ ] **После deploy:** smoke - login с user'ом у которого `marketing.enabled=false` → trigger marketing-flow → проверить Notification.status='failed' с правильным errorMessage

## Closes

- Завершает #166 push+email preferences integration (вместе с #381)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_