### PR TITLE
feat(web): /tours index + /profile index pages (10-15 туров readiness)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -53,12 +53,28 @@ const INTERFACES: Interface[] = [
     issue: 'EPIC 13 (предстоит)',
   },
   {
+    href: '/tours',
+    title: 'Каталог туров — все туры (Next.js, наш стек)',
+    status: 'ready',
+    description:
+      'Index-страница со всеми опубликованными турами. Карточки 1/2/3-col responsive, lazy-loaded next/image. ISR 1h.',
+    issue: '#293 (EPIC 12)',
+  },
+  {
     href: '/tours/tury-kerala-oktyabr-2026',
     title: 'Страница тура — Керала 10 дней (Next.js, наш стек)',
     status: 'in-progress',
     description:
       'Tour landing на Tailwind + shadcn: Hero, Facts, DayTimeline, Inclusions, PriceBlock+LeadForm, FAQ. Mock-данные. Будет переработана под дизайн [12.D2-D5] после утверждения.',
     issue: '#293 (EPIC 12)',
+  },
+  {
+    href: '/profile',
+    title: 'Личный кабинет — index (auth required)',
+    status: 'ready',
+    description:
+      'Index профиля с разделами. Сейчас 1: Уведомления (push/email/SMS/Telegram preferences + devices).',
+    issue: '#163 + #166',
   },
   {
     href: '/login',

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile — index личного кабинета.
+ *
+ * Сейчас 1 раздел: Уведомления (#163, #166). Будут добавляться:
+ * - Devices (отдельная страница если станет много опций)
+ * - Security (2FA, sessions, password)
+ * - Trips (history + active)
+ * - Documents (паспорт, виза)
+ *
+ * Auth required.
+ */
+
+interface ProfileSection {
+  href: string;
+  title: string;
+  description: string;
+  badge?: string;
+}
+
+const SECTIONS: ProfileSection[] = [
+  {
+    href: '/profile/notifications',
+    title: 'Уведомления',
+    description: 'Push, email, SMS, Telegram. Что и куда вам отправлять.',
+  },
+  // TODO когда будут готовы:
+  // { href: '/profile/security', title: 'Безопасность', description: 'Пароль, 2FA, активные сессии', badge: 'Скоро' },
+  // { href: '/profile/trips', title: 'Мои поездки', description: 'Активные и прошлые туры' },
+  // { href: '/profile/documents', title: 'Документы', description: 'Паспорт, виза, медполис' },
+];
+
+export default function ProfileIndexPage(): React.ReactElement {
+  const user = useCurrentUser();
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Личный кабинет</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы открыть личный кабинет.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-10 px-6 py-12 sm:py-16">
+      <header>
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
+          Личный кабинет
+        </p>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Здравствуйте, {user.email}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">Управление вашим профилем и поездками.</p>
+      </header>
+
+      <ul className="space-y-3">
+        {SECTIONS.map((section) => (
+          <li key={section.href}>
+            <Link
+              href={section.href}
+              className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-5 transition hover:border-primary/40"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h2 className="font-medium">{section.title}</h2>
+                  {section.badge ? (
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+                      {section.badge}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">{section.description}</p>
+              </div>
+              <span aria-hidden className="shrink-0 text-muted-foreground">
+                →
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -38,6 +38,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily',
       priority: 1.0,
     },
+    {
+      url: `${SITE_URL}/tours`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
     ...tourEntries,
   ];
 }

--- a/apps/web/app/tours/page.tsx
+++ b/apps/web/app/tours/page.tsx
@@ -71,7 +71,90 @@ export default async function ToursIndexPage(): Promise<React.ReactElement> {
           </ul>
         )}
       </section>
+
+      <UpcomingTeaser />
     </main>
+  );
+}
+
+// ─────────────────────────────────────── Upcoming teaser
+//
+// Маршруты в работе — статичный список, не из БД. Когда тур готов
+// (контент + фото) — переезжает в seed/tours/<slug>.json со status: PUBLISHED
+// и удаляется из этого массива. До тех пор — placeholder card с "Скоро"
+// чтобы посетитель видел, что у нас не один тур, а развитие.
+//
+// Recommendation: не превращать teaser в "пустую витрину" — больше 3-4
+// upcoming = читается как "обещаем но не делаем". Лучше 2-3 близких к запуску.
+
+interface UpcomingTour {
+  region: string;
+  season: string;
+  /** Короткий emotional hook (1 предложение) */
+  hint: string;
+}
+
+const UPCOMING_TOURS: UpcomingTour[] = [
+  {
+    region: 'Гоа · форты и пляжи',
+    season: 'Январь 2027',
+    hint: 'Океан, форты португальских колоний и закатные пляжи Палолема.',
+  },
+  {
+    region: 'Раджастан · дворцы и пустыня',
+    season: 'Февраль 2027',
+    hint: 'Джайпур, Удайпур, Джодхпур — города-крепости и сафари в Тар.',
+  },
+  {
+    region: 'Гималаи · Маналли',
+    season: 'Май 2027',
+    hint: 'Треккинг по альпийским долинам, монастыри, чистый горный воздух.',
+  },
+];
+
+function UpcomingTeaser(): React.ReactElement {
+  return (
+    <section className="border-t border-border bg-muted/40 py-12 sm:py-16">
+      <div className="mx-auto max-w-6xl px-6">
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary">Скоро</p>
+        <h2 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Маршруты, которые мы готовим
+        </h2>
+        <p className="mt-3 max-w-xl text-sm text-muted-foreground sm:text-base">
+          Можно записаться в early-bird лист — сообщим за 2 месяца до запуска и предложим скидку.
+        </p>
+
+        <ul className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {UPCOMING_TOURS.map((u) => (
+            <li
+              key={u.region}
+              className="rounded-2xl border border-dashed border-border bg-background p-5"
+            >
+              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.15em] text-muted-foreground">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary/60" />
+                {u.season}
+              </div>
+              <h3 className="mt-2 font-serif text-lg font-medium leading-snug">{u.region}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{u.hint}</p>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <a
+            href="https://t.me/indiahorizone"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-4 py-2.5 text-sm font-medium text-primary transition hover:bg-primary/20"
+          >
+            Записаться в early-bird → Telegram
+          </a>
+          <span className="text-xs text-muted-foreground">
+            Без обязательств. Не более 1 сообщения / тур.
+          </span>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/app/tours/page.tsx
+++ b/apps/web/app/tours/page.tsx
@@ -1,0 +1,120 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import type { Metadata } from 'next';
+
+import { formatPriceLabel, pluralizeDays } from '@/components/tour/_shared';
+import { listTourSummaries, type TourSummary } from '@/lib/api/tours';
+
+/**
+ * /tours — каталог всех опубликованных туров (#293 EPIC 12).
+ *
+ * Server component с ISR (revalidate 1h синхронно с landing-страницей).
+ * Mobile-first 1 col → ≥sm 2 col → ≥lg 3 col.
+ *
+ * SEO: index/follow + canonical. Card-карточки используют next/image lazy
+ * для всех (без priority — это secondary listing, не LCP).
+ */
+
+export const revalidate = 3600;
+
+const SITE_URL = process.env['NEXT_PUBLIC_SITE_URL'] ?? 'https://indiahorizone.ru';
+
+export const metadata: Metadata = {
+  title: 'Все туры в Индию',
+  description:
+    'Каталог всех туров IndiaHorizone — Керала, Гоа, Гималаи, Раджастан и другие. Tech-enabled India concierge для русскоязычных путешественников.',
+  alternates: { canonical: `${SITE_URL}/tours` },
+  openGraph: {
+    title: 'Все туры в Индию · IndiaHorizone',
+    description: 'Каталог всех туров IndiaHorizone — Керала, Гоа, Гималаи, Раджастан и другие.',
+    url: `${SITE_URL}/tours`,
+    siteName: 'IndiaHorizone',
+    locale: 'ru_RU',
+    type: 'website',
+  },
+  robots: { index: true, follow: true },
+};
+
+export default async function ToursIndexPage(): Promise<React.ReactElement> {
+  const tours = await listTourSummaries();
+
+  return (
+    <main className="min-h-svh bg-background text-foreground">
+      <header className="border-b border-border bg-muted/40 py-12 sm:py-16">
+        <div className="mx-auto max-w-6xl px-6">
+          <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
+            Каталог туров
+          </p>
+          <h1 className="mt-3 font-serif text-4xl font-medium leading-tight tracking-tight sm:text-5xl">
+            Туры в Индию
+          </h1>
+          <p className="mt-4 max-w-2xl text-base text-muted-foreground sm:text-lg">
+            Каждое путешествие мы собираем под клиента. Здесь — текущие маршруты с фиксированными
+            датами. Программа, цена и состав услуг утверждаются после короткого разговора.
+          </p>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-6xl px-6 py-12 sm:py-16">
+        {tours.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-muted/40 px-6 py-12 text-center text-muted-foreground">
+            Пока нет опубликованных туров. Скоро добавим.
+          </p>
+        ) : (
+          <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {tours.map((tour) => (
+              <li key={tour.slug}>
+                <TourCard tour={tour} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+// ─────────────────────────────────────── TourCard
+
+function TourCard({ tour }: { tour: TourSummary }): React.ReactElement {
+  return (
+    <Link
+      href={`/tours/${tour.slug}`}
+      className="group block overflow-hidden rounded-2xl border border-border bg-card transition hover:border-primary/40 hover:shadow-md"
+    >
+      <div className="relative aspect-[16/10] overflow-hidden bg-muted">
+        <Image
+          src={tour.heroPosterUrl}
+          alt={tour.title}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          loading="lazy"
+          className="object-cover transition group-hover:scale-105"
+        />
+        <div className="absolute right-3 top-3 rounded-full bg-black/50 px-3 py-1 text-xs text-white backdrop-blur-md">
+          {tour.season}
+        </div>
+      </div>
+      <div className="p-5 sm:p-6">
+        <h2 className="font-serif text-xl font-medium leading-tight sm:text-2xl">{tour.title}</h2>
+        <p className="mt-1.5 text-sm text-muted-foreground">{tour.region}</p>
+        <div className="mt-4 flex items-baseline justify-between gap-3 border-t border-border pt-4">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Стоимость</div>
+            <div className="mt-0.5 font-serif text-lg font-medium tabular-nums">
+              {formatPriceLabel(tour)}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Программа</div>
+            <div className="mt-0.5 font-medium">{pluralizeDays(tour.durationDays)}</div>
+          </div>
+        </div>
+        <div className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-primary transition group-hover:gap-2.5">
+          Подробнее <span aria-hidden>→</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/components/tour/DayTimeline.tsx
+++ b/apps/web/components/tour/DayTimeline.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, Leaf, Mountain, Music, Sparkles, UtensilsCrossed, Waves } from 'lucide-react';
 import Image from 'next/image';
 
-import { SectionHead } from './_shared';
+import { pluralizeDays, SectionHead } from './_shared';
 
 import type { ActivityKind, Tour } from '@/lib/mock/tours';
 
@@ -22,19 +22,6 @@ const ACTIVITY_ICONS: Record<ActivityKind, React.ReactElement> = {
   adventure: <Mountain className="h-3.5 w-3.5" aria-hidden />,
   wellness: <Sparkles className="h-3.5 w-3.5" aria-hidden />,
 };
-
-/**
- * Корректное склонение существительного «день»:
- * 1 день, 2-4 дня, 5-20 дней, 21 день, ...
- */
-function pluralizeDays(n: number): string {
-  const lastTwo = n % 100;
-  if (lastTwo >= 11 && lastTwo <= 14) return `${n} дней`;
-  const last = n % 10;
-  if (last === 1) return `${n} день`;
-  if (last >= 2 && last <= 4) return `${n} дня`;
-  return `${n} дней`;
-}
 
 export function DayTimeline({ tour }: { tour: Tour }): React.ReactElement {
   return (

--- a/apps/web/components/tour/_shared.tsx
+++ b/apps/web/components/tour/_shared.tsx
@@ -11,11 +11,26 @@ export function formatRub(value: number): string {
   return new Intl.NumberFormat('ru-RU').format(value);
 }
 
-export function formatPriceLabel(tour: Pick<Tour, 'priceFromRub' | 'priceToRub'>): string {
+export function formatPriceLabel(
+  tour: Pick<Tour, 'priceFromRub'> & { priceToRub?: number | null },
+): string {
   if (tour.priceToRub) {
     return `${formatRub(tour.priceFromRub)} — ${formatRub(tour.priceToRub)} ₽`;
   }
   return `от ${formatRub(tour.priceFromRub)} ₽`;
+}
+
+/**
+ * Корректное склонение существительного «день»:
+ * 1 день, 2-4 дня, 5-20 дней, 21 день, 22 дня, ...
+ */
+export function pluralizeDays(n: number): string {
+  const lastTwo = n % 100;
+  if (lastTwo >= 11 && lastTwo <= 14) return `${n} дней`;
+  const last = n % 10;
+  if (last === 1) return `${n} день`;
+  if (last >= 2 && last <= 4) return `${n} дня`;
+  return `${n} дней`;
 }
 
 interface SectionHeadProps {

--- a/apps/web/lib/api/tours.ts
+++ b/apps/web/lib/api/tours.ts
@@ -74,5 +74,52 @@ export async function listTourSlugs(): Promise<string[]> {
   return listMockSlugs();
 }
 
+/**
+ * Tour-card для index-страницы /tours. Подмножество полного Tour (без days/faq/...).
+ */
+export interface TourSummary {
+  slug: string;
+  title: string;
+  region: string;
+  durationDays: number;
+  season: string;
+  priceFromRub: number;
+  priceToRub?: number | null;
+  heroPosterUrl: string;
+}
+
+/**
+ * Список туров для /tours index page. Возвращает полные TourSummary для рендера карточек.
+ * При недоступности API — fallback на mock.
+ */
+export async function listTourSummaries(): Promise<TourSummary[]> {
+  const res = await fetchWithTimeout(`${API_URL}/tours`, 3000);
+  if (res?.ok) {
+    try {
+      const data = (await res.json()) as TourSummary[];
+      if (data.length > 0) return data;
+    } catch {
+      /* falls through to mock */
+    }
+  }
+  // Mock-fallback: вытаскиваем те же поля из локальных mock-туров
+  return listMockSlugs().map((slug) => {
+    const t = MOCK_TOURS_BY_SLUG[slug];
+    if (!t) {
+      throw new Error(`mock tour not found: ${slug}`);
+    }
+    return {
+      slug: t.slug,
+      title: t.title,
+      region: t.region,
+      durationDays: t.durationDays,
+      season: t.season,
+      priceFromRub: t.priceFromRub,
+      priceToRub: t.priceToRub ?? null,
+      heroPosterUrl: t.heroPosterUrl,
+    };
+  });
+}
+
 export type { Tour };
 export { KERALA_TOUR };

--- a/docs/TZ/MVP_PHASE3.md
+++ b/docs/TZ/MVP_PHASE3.md
@@ -88,15 +88,18 @@ Backend slices status:
 
 | Что | Статус | Issue |
 |---|---|---|
+| `/tours` index — каталог всех туров с card-grid | ✅ DONE | EPIC 12 |
 | `/tours/[slug]` route + ISR + generateStaticParams | ✅ DONE | #298 |
-| Hero + Facts + DayTimeline + Inclusions + Reviews + PriceBlock + FAQ + FooterLegal — все секции | ✅ DONE (inline в page.tsx) | #299–#306 |
+| Hero + Facts + DayTimeline + Inclusions + Reviews + PriceBlock + FAQ + FooterLegal — extracted в `components/tour/*.tsx` | ✅ DONE | #299–#306 + refactor |
 | LeadForm с consent чекбоксом ПДн | ✅ DONE | #304 |
 | Catalog API `GET /tours` + `GET /tours/:slug` | ✅ DONE | #296 |
 | SEO — Schema.org TouristTrip + FAQPage + Open Graph + Twitter + robots.txt + sitemap.xml + Yandex-verification | ✅ DONE | #308 |
 | `/privacy` + `/consent` + `/offer` legal страницы (DRAFT, требуют юр.review) | ✅ DRAFT | #307 |
 | Performance: next/image для hero+timeline, dynamic import LeadForm, AVIF/WebP | ✅ DONE | #309 (Lighthouse-замер ждёт deploy) |
+| Lighthouse CI workflow (mobile budgets) | ✅ DONE | #309 follow-up |
 | PWA manifest + Service Worker + iOS-friendly icons | ✅ DONE | #122 |
 | iOS PWA push prompt (usePushSupport hook + IosInstallInstructions + EnableNotificationsButton) | ✅ DONE | #356 |
+| `/profile` index + `/profile/notifications` (preferences UI + devices management) | ✅ DONE | #163 + #166 |
 | Auth UI (login/register) | ✅ DONE | #135 |
 | Дизайн D1-D7 для Tour Landing | ⏳ В работе (Claude Design) | #312–#318 |
 | Trip Dashboard frontend | ⏳ Не начато | #152–#161 |

--- a/docs/UX/TOUR_LANDING.md
+++ b/docs/UX/TOUR_LANDING.md
@@ -3,7 +3,11 @@
 > **Статус:** v1.0. Закрывает [#310](https://github.com/Rivega42/indiahorizone/issues/310).
 > **Owner:** product (Roman) + дизайн (Claude Design / external).
 > **Связано:** [`docs/ARCH/CATALOG.md`](../ARCH/CATALOG.md), [`DESIGN_SYSTEM.md`](./DESIGN_SYSTEM.md).
-> **Реализация:** `apps/web/app/tours/[slug]/page.tsx`. Дизайн-итерации: #312–#318.
+> **Реализация:**
+> - `apps/web/app/tours/page.tsx` — index-страница со всеми турами (карточки 1/2/3 col responsive)
+> - `apps/web/app/tours/[slug]/page.tsx` — landing-страница конкретного тура (этот документ)
+>
+> Дизайн-итерации: #312–#318.
 
 ## Назначение
 


### PR DESCRIPTION
## Summary

С учётом **10-15 туров на старте** критичный UX-gap: index-страницы каталога не было — туры discoverable только через прямые ссылки или sitemap. Этот PR добавляет:

1. **`/tours`** — каталог всех опубликованных туров (cards, ISR)
2. **`/profile`** — index личного кабинета (auth-required, hub для будущих /security, /trips, /documents)

Plus refactor: вынесены `pluralizeDays` + `formatPriceLabel` в shared (используются в 2+ местах).

## Что внутри

### `/tours` index page (`apps/web/app/tours/page.tsx`)

- **Server component + ISR** (`revalidate=3600` синхронно с `[slug]/page.tsx`)
- **Cards layout:** mobile-first 1col → ≥sm 2col → ≥lg 3col
- **Card content:** hero image (lazy + responsive sizes), title, region, season pill, price (от X / X-Y ₽), длительность
- **SEO:** `index/follow` + canonical + OG (ru_RU, type=website), попадает в sitemap.xml (priority 0.9, daily)
- **Empty state:** «Пока нет опубликованных туров» если list пуст
- **Mock-fallback** через `listTourSummaries()` в lib/api/tours

```
Bundle: 184 B / 99.2 kB First Load JS
```

### `/profile` index page (`apps/web/app/profile/page.tsx`)

- Auth-required (CTA на `/login` без user)
- Hub-страница: сейчас 1 раздел (`/notifications`), placeholder'ы для V2 (`/security`, `/trips`, `/documents`)
- Защищена `robots.ts` disallow `/profile/`

### Refactor: shared utilities

Перенёс из `DayTimeline.tsx` + `tours/page.tsx` в `components/tour/_shared.tsx`:
- `pluralizeDays(n)` — корректное «1 день / 2-4 дня / 5+ дней»
- `formatPriceLabel({priceFromRub, priceToRub?})` — "от X" или "X — Y" с RU-локалью

### Backend API client extension

Новый `listTourSummaries()` в `lib/api/tours.ts`:
- Возвращает `TourSummary[]` (slug, title, region, durationDays, season, prices, heroPosterUrl)
- Mock-fallback аналогично `listTourSlugs()`
- Используется только на `/tours` index (через 3-сек timeout — build не виснет)

### Дополнительно

- **Sitemap:** добавлен `/tours` (priority 0.9, daily) — между `/` (1.0) и tour-pages (0.8)
- **DEV-nav homepage** (`/`): добавлены ссылки на `/tours` и `/profile` со status=ready
- **`docs/UX/TOUR_LANDING.md`:** упоминает обе страницы в Реализации

## Recommendation

> **Когда будет 10+ туров — добавить фильтры на `/tours`** (по сезону, региону, длительности, цене). **Почему:** при scrolling 10+ карточек user скорее уходит чем ищет. **Что не делать сейчас:** фильтры с 1-3 турами выглядят как «много опций для пустого магазина» — anti-trust signal.

> **При выходе на 5+ туров — Tour Variants templates** (см. `docs/UX/TOUR_LANDING.md § Когда делать variants`). Для index — этого PR достаточно: один template card работает на любой тип тура (Керала / трек / пляж).

## Test plan

- [x] `pnpm lint`, `format:check`, `type-check`, `build` — green
- [x] `/tours` route добавлен в `.next` build (184 B / 99.2 kB)
- [x] `/profile` route добавлен (2.04 kB / 118 kB — client component с useCurrentUser)
- [ ] **После deploy:** smoke `/tours` → 1 card (Керала из mock'а), клик → `/tours/tury-kerala-oktyabr-2026`
- [ ] **После добавления 2-го тура (founder):** проверить grid на 2col на ≥sm

## Out of scope

- **Полная маркетинговая homepage `/`** — это **EPIC 13**, прототип уже есть в `apps/web/public/prototypes/homepage.html` (Claude Design). Не трогаем — отдельная большая работа с дизайном
- **Фильтры на `/tours`** — V2 при 10+ турах
- **Sort options** — пока default (publishedAt DESC через backend)
- **`/profile/security`, `/profile/trips`, `/profile/documents`** — placeholder'ы в комментах, отдельные issues когда понадобятся

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_