### PR TITLE
feat(profile): A-01 + A-06 + A-07 + A-08 — FE подключение клиентского кабинета

### DIFF
--- a/apps/web/app/profile/consents/page.tsx
+++ b/apps/web/app/profile/consents/page.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import {
+  getActiveConsents,
+  grantConsent,
+  listConsents,
+  revokeConsent,
+  type Consent,
+  type ConsentType,
+} from '@/lib/api/consents';
+import { useCurrentUser } from '@/lib/auth/store';
+import { CONSENT_VERSION } from '@/lib/legal/versions';
+
+/**
+ * /profile/consents — управление 4 granular-согласиями (#A-06).
+ *
+ * Toggle на каждой позиции:
+ * - Включение → POST /consents/{type} с актуальной CONSENT_VERSION.
+ * - Отключение → confirm-modal → DELETE /consents/{type}.
+ *
+ * История версий: «вы согласились на 0.1.0 от 28 апреля 2026».
+ *
+ * Marketing — opt-in (152-ФЗ). По умолчанию выключен.
+ */
+
+interface ConsentMeta {
+  type: ConsentType;
+  title: string;
+  description: string;
+  /** Что перестанет работать при отзыве */
+  revokeWarning: string;
+}
+
+const CONSENTS: ConsentMeta[] = [
+  {
+    type: 'photo_video',
+    title: 'Фото и видео',
+    description: 'Использование фото/видео в дневнике поездки, маркетинге и соцсетях.',
+    revokeWarning: 'Дневник поездки больше не будет содержать фото от гида и ваши видео-кружки.',
+  },
+  {
+    type: 'geo',
+    title: 'Геолокация',
+    description: 'Передача координат при SOS-сигнале и live-tracking во время поездки.',
+    revokeWarning: 'SOS-кнопка не сможет автоматически передать ваше местоположение concierge.',
+  },
+  {
+    type: 'emergency_contacts',
+    title: 'Передача экстренным контактам',
+    description: 'Доступ к передаче ваших контактов экстренной связи при ЧП.',
+    revokeWarning:
+      'При SOS гид не сможет связаться с вашими экстренными контактами — только лично с вами.',
+  },
+  {
+    type: 'marketing',
+    title: 'Маркетинговые сообщения',
+    description: 'Спецпредложения, новые туры, акции. Можно отозвать в любой момент.',
+    revokeWarning: 'Вы перестанете получать информацию о новых турах и акциях.',
+  },
+];
+
+interface ConfirmRevoke {
+  type: ConsentType;
+  warning: string;
+}
+
+function formatGrantedAt(iso: string): string {
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(iso));
+}
+
+export default function ConsentsPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [consents, setConsents] = useState<Consent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState<Set<ConsentType>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<ConfirmRevoke | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    listConsents()
+      .then((data) => {
+        if (!cancelled) setConsents(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить согласия.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const active = getActiveConsents(consents);
+
+  function setBusy(type: ConsentType, busy: boolean): void {
+    setPending((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(type);
+      else next.delete(type);
+      return next;
+    });
+  }
+
+  async function handleGrant(type: ConsentType): Promise<void> {
+    setBusy(type, true);
+    setError(null);
+    try {
+      const granted = await grantConsent(type, { version: CONSENT_VERSION });
+      setConsents((prev) => [...prev.filter((c) => c.id !== granted.id), granted]);
+    } catch {
+      setError('Не удалось включить согласие. Попробуйте ещё раз.');
+    } finally {
+      setBusy(type, false);
+    }
+  }
+
+  async function handleRevoke(type: ConsentType): Promise<void> {
+    setBusy(type, true);
+    setError(null);
+    setConfirm(null);
+    try {
+      await revokeConsent(type);
+      const refreshed = await listConsents();
+      setConsents(refreshed);
+    } catch {
+      setError('Не удалось отозвать согласие. Попробуйте ещё раз.');
+    } finally {
+      setBusy(type, false);
+    }
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Согласия</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы управлять согласиями.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Согласия
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Управление обработкой ваших данных согласно 152-ФЗ. Каждое согласие можно отозвать в любой
+          момент — данные удалятся в течение 7 дней.
+        </p>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : (
+        <ul className="space-y-4">
+          {CONSENTS.map((meta) => {
+            const current = active.get(meta.type);
+            const isOn = Boolean(current);
+            const busy = pending.has(meta.type);
+            return (
+              <li key={meta.type} className="rounded-lg border border-border bg-card p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <h2 className="font-medium">{meta.title}</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">{meta.description}</p>
+                    {current ? (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        Согласие v{current.version} от {formatGrantedAt(current.grantedAt)}
+                      </p>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={isOn}
+                    disabled={busy}
+                    onClick={() => {
+                      if (busy) return;
+                      if (isOn) {
+                        setConfirm({ type: meta.type, warning: meta.revokeWarning });
+                      } else {
+                        void handleGrant(meta.type);
+                      }
+                    }}
+                    className={`relative h-6 w-11 shrink-0 rounded-full transition disabled:opacity-50 ${
+                      isOn ? 'bg-primary' : 'bg-muted'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition ${
+                        isOn ? 'left-5' : 'left-0.5'
+                      }`}
+                      aria-hidden
+                    />
+                    <span className="sr-only">
+                      {isOn ? `Отозвать ${meta.title}` : `Включить ${meta.title}`}
+                    </span>
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {confirm ? (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-title"
+        >
+          <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+            <h3 id="confirm-title" className="font-medium">
+              Отозвать согласие?
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground">{confirm.warning}</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Связанные данные удалятся в течение 7 дней.
+            </p>
+            <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setConfirm(null)}
+                className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+              >
+                Отмена
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleRevoke(confirm.type)}
+                className="rounded-lg bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+              >
+                Отозвать
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/app/profile/emergency/page.tsx
+++ b/apps/web/app/profile/emergency/page.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import {
+  deleteContact,
+  listContacts,
+  upsertContact,
+  type EmergencyContact,
+  type EmergencyContactPriority,
+} from '@/lib/api/emergency';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/emergency — экстренные контакты (#A-07).
+ *
+ * Список 1-2 контактов (primary/secondary) с CRUD.
+ * PII (имя/телефон) шифруются на бэке через AES-256-GCM.
+ *
+ * Лимит 2 контакта enforced backend'ом (uniqueness по priority).
+ */
+
+const PRIORITY_LABEL: Record<EmergencyContactPriority, string> = {
+  primary: 'Первый контакт',
+  secondary: 'Второй контакт',
+};
+
+const E164_PATTERN = /^\+\d{10,15}$/;
+const LANGUAGE_PATTERN = /^[a-z]{2}$/;
+
+interface FormState {
+  priority: EmergencyContactPriority;
+  name: string;
+  phone: string;
+  relation: string;
+  language: string;
+}
+
+function emptyForm(priority: EmergencyContactPriority): FormState {
+  return { priority, name: '', phone: '', relation: '', language: 'ru' };
+}
+
+function validate(form: FormState): string | null {
+  if (form.name.trim().length < 2) return 'Имя минимум 2 символа.';
+  if (!E164_PATTERN.test(form.phone)) {
+    return 'Телефон в формате +<код страны><номер>, 11–16 цифр (например +79161234567).';
+  }
+  if (form.relation.trim().length < 1) return 'Укажите кем приходится контакт.';
+  if (!LANGUAGE_PATTERN.test(form.language)) {
+    return 'Язык — 2 буквы lowercase (ru, en).';
+  }
+  return null;
+}
+
+export default function EmergencyContactsPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [contacts, setContacts] = useState<EmergencyContact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<FormState | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    listContacts()
+      .then((data) => {
+        if (!cancelled) setContacts(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить контакты.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  async function handleSubmit(): Promise<void> {
+    if (!editing) return;
+    const validationError = validate(editing);
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    setError(null);
+    try {
+      const saved = await upsertContact({
+        priority: editing.priority,
+        name: editing.name.trim(),
+        phone: editing.phone.trim(),
+        relation: editing.relation.trim(),
+        language: editing.language.trim(),
+      });
+      setContacts((prev) => {
+        const filtered = prev.filter((c) => c.priority !== saved.priority);
+        return [...filtered, saved].sort((a, b) =>
+          a.priority === 'primary' ? -1 : b.priority === 'primary' ? 1 : 0,
+        );
+      });
+      setEditing(null);
+    } catch {
+      setError('Не удалось сохранить контакт. Попробуйте ещё раз.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(id: string): Promise<void> {
+    setError(null);
+    try {
+      await deleteContact(id);
+      setContacts((prev) => prev.filter((c) => c.id !== id));
+    } catch {
+      setError('Не удалось удалить контакт.');
+    }
+  }
+
+  function startEdit(priority: EmergencyContactPriority): void {
+    const existing = contacts.find((c) => c.priority === priority);
+    if (existing) {
+      setEditing({
+        priority,
+        name: existing.name,
+        phone: existing.phone,
+        relation: existing.relation,
+        language: existing.language,
+      });
+    } else {
+      setEditing(emptyForm(priority));
+    }
+    setFormError(null);
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Экстренные контакты</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы добавить экстренные контакты.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Экстренные контакты
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          1–2 человека, с которыми мы свяжемся при ЧП во время вашей поездки. Данные шифруются.
+        </p>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : (
+        <div className="space-y-3">
+          {(['primary', 'secondary'] as EmergencyContactPriority[]).map((priority) => {
+            const contact = contacts.find((c) => c.priority === priority);
+            return (
+              <div key={priority} className="rounded-lg border border-border bg-card p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                      {PRIORITY_LABEL[priority]}
+                    </p>
+                    {contact ? (
+                      <>
+                        <p className="mt-1 font-medium">{contact.name}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {contact.phone} · {contact.relation} · {contact.language}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="mt-1 text-sm text-muted-foreground">Не указан</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(priority)}
+                      className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent"
+                    >
+                      {contact ? 'Изменить' : 'Добавить'}
+                    </button>
+                    {contact ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(contact.id)}
+                        className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10"
+                      >
+                        Удалить
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {editing ? (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edit-title"
+        >
+          <div className="w-full max-w-md space-y-4 rounded-lg border border-border bg-card p-6 shadow-lg">
+            <h3 id="edit-title" className="font-medium">
+              {PRIORITY_LABEL[editing.priority]}
+            </h3>
+
+            <label className="block">
+              <span className="text-sm">Имя</span>
+              <input
+                value={editing.name}
+                onChange={(e) => setEditing({ ...editing, name: e.target.value })}
+                placeholder="Анна Петрова"
+                className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                maxLength={100}
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm">Телефон</span>
+              <input
+                value={editing.phone}
+                onChange={(e) => setEditing({ ...editing, phone: e.target.value })}
+                placeholder="+79161234567"
+                inputMode="tel"
+                className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm">Кем приходится</span>
+              <input
+                value={editing.relation}
+                onChange={(e) => setEditing({ ...editing, relation: e.target.value })}
+                placeholder="Жена / Отец / Друг"
+                className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                maxLength={50}
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm">Язык общения</span>
+              <select
+                value={editing.language}
+                onChange={(e) => setEditing({ ...editing, language: e.target.value })}
+                className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+              >
+                <option value="ru">ru — русский</option>
+                <option value="en">en — английский</option>
+              </select>
+            </label>
+
+            {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                disabled={submitting}
+                className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent disabled:opacity-50"
+              >
+                Отмена
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSubmit()}
+                disabled={submitting}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {submitting ? 'Сохранение…' : 'Сохранить'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
+import { getMe, type ClientMe } from '@/lib/api/clients';
 import { useCurrentUser } from '@/lib/auth/store';
 
 /**
- * /profile — index личного кабинета.
+ * /profile — index личного кабинета (#A-01).
  *
- * Сейчас 1 раздел: Уведомления (#163, #166). Будут добавляться:
- * - Devices (отдельная страница если станет много опций)
- * - Security (2FA, sessions, password)
- * - Trips (history + active)
- * - Documents (паспорт, виза)
+ * Подтягивает профиль через GET /clients/me и показывает имя в шапке.
+ * При 404 (профиль ещё не provisioned listener'ом auth.user.registered) —
+ * fallback на email.
  *
  * Auth required.
  */
@@ -25,18 +25,55 @@ interface ProfileSection {
 
 const SECTIONS: ProfileSection[] = [
   {
+    href: '/profile/trips',
+    title: 'Мои поездки',
+    description: 'Активные и прошлые туры, программа, документы',
+  },
+  {
     href: '/profile/notifications',
     title: 'Уведомления',
-    description: 'Push, email, SMS, Telegram. Что и куда вам отправлять.',
+    description: 'Push, email, SMS, Telegram. Что и куда вам отправлять',
   },
-  // TODO когда будут готовы:
-  // { href: '/profile/security', title: 'Безопасность', description: 'Пароль, 2FA, активные сессии', badge: 'Скоро' },
-  // { href: '/profile/trips', title: 'Мои поездки', description: 'Активные и прошлые туры' },
-  // { href: '/profile/documents', title: 'Документы', description: 'Паспорт, виза, медполис' },
+  {
+    href: '/profile/consents',
+    title: 'Согласия',
+    description: 'Фото/видео, геолокация, экстренные контакты, маркетинг',
+  },
+  {
+    href: '/profile/emergency',
+    title: 'Экстренные контакты',
+    description: 'Кому звонить при ЧП во время поездки',
+  },
 ];
+
+function buildGreeting(me: ClientMe | null, fallbackEmail: string): string {
+  const firstName = me?.profile?.firstName?.trim();
+  if (firstName) return `Здравствуйте, ${firstName}`;
+  return `Здравствуйте, ${fallbackEmail}`;
+}
 
 export default function ProfileIndexPage(): React.ReactElement {
   const user = useCurrentUser();
+  const [me, setMe] = useState<ClientMe | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    getMe()
+      .then((data) => {
+        if (!cancelled) setMe(data);
+      })
+      .catch(() => {
+        // 404 (profile not yet provisioned) или сетевая — показываем email-fallback
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   if (user === null) {
     return (
@@ -59,7 +96,7 @@ export default function ProfileIndexPage(): React.ReactElement {
           Личный кабинет
         </p>
         <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
-          Здравствуйте, {user.email}
+          {loaded ? buildGreeting(me, user.email) : 'Загрузка…'}
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">Управление вашим профилем и поездками.</p>
       </header>

--- a/apps/web/app/profile/trips/page.tsx
+++ b/apps/web/app/profile/trips/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+import { listMyTrips, type TripStatus, type TripSummary } from '@/lib/api/trips';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/trips — список всех поездок клиента (#A-08).
+ *
+ * Группировка: «Активная» (in_progress) / «Предстоящие» (tentative+confirmed)
+ * / «Прошедшие» (completed+cancelled).
+ *
+ * Empty state с CTA «Посмотреть туры» если нет поездок.
+ */
+
+const STATUS_LABEL: Record<TripStatus, string> = {
+  tentative: 'Черновик',
+  confirmed: 'Подтверждена',
+  in_progress: 'В пути',
+  completed: 'Завершена',
+  cancelled: 'Отменена',
+};
+
+const STATUS_TONE: Record<TripStatus, string> = {
+  tentative: 'bg-muted text-muted-foreground',
+  confirmed: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
+  in_progress: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100',
+  completed: 'bg-muted text-muted-foreground',
+  cancelled: 'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-100',
+};
+
+interface Buckets {
+  active: TripSummary[];
+  upcoming: TripSummary[];
+  past: TripSummary[];
+}
+
+function groupTrips(items: TripSummary[]): Buckets {
+  const active: TripSummary[] = [];
+  const upcoming: TripSummary[] = [];
+  const past: TripSummary[] = [];
+  for (const t of items) {
+    if (t.status === 'in_progress') active.push(t);
+    else if (t.status === 'tentative' || t.status === 'confirmed') upcoming.push(t);
+    else past.push(t);
+  }
+  // По датам: active по startsAt, upcoming по startsAt asc, past по endsAt desc.
+  active.sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime());
+  upcoming.sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime());
+  past.sort((a, b) => new Date(b.endsAt).getTime() - new Date(a.endsAt).getTime());
+  return { active, upcoming, past };
+}
+
+function formatDateRange(startsAt: string, endsAt: string): string {
+  const fmt = new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'short', year: 'numeric' });
+  return `${fmt.format(new Date(startsAt))} — ${fmt.format(new Date(endsAt))}`;
+}
+
+function formatPrice(amount: string | null, currency: string | null): string | null {
+  if (!amount) return null;
+  const value = Number(amount);
+  if (!Number.isFinite(value)) return null;
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: currency ?? 'RUB',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function TripCard({ trip }: { trip: TripSummary }): React.ReactElement {
+  const price = formatPrice(trip.totalAmount, trip.currency);
+  return (
+    <Link
+      href={`/profile/trips/${trip.id}`}
+      className="block rounded-lg border border-border bg-card p-5 transition hover:border-primary/40"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="font-medium">{trip.region}</h3>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs uppercase tracking-wide ${STATUS_TONE[trip.status]}`}
+            >
+              {STATUS_LABEL[trip.status]}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {formatDateRange(trip.startsAt, trip.endsAt)}
+          </p>
+        </div>
+        {price ? <span className="shrink-0 font-medium">{price}</span> : null}
+      </div>
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  trips,
+}: {
+  title: string;
+  trips: TripSummary[];
+}): React.ReactElement | null {
+  if (trips.length === 0) return null;
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+        {title}
+      </h2>
+      <div className="space-y-2">
+        {trips.map((t) => (
+          <TripCard key={t.id} trip={t} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function MyTripsPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [items, setItems] = useState<TripSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    listMyTrips()
+      .then((data) => {
+        if (!cancelled) setItems(data.items);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить поездки. Попробуйте обновить страницу.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const buckets = useMemo(() => groupTrips(items), [items]);
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Мои поездки</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы увидеть свои поездки.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Мои поездки
+        </h1>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+          <p className="text-muted-foreground">У вас пока нет поездок.</p>
+          <Link
+            href="/tours"
+            className="mt-4 inline-block font-medium text-primary hover:underline"
+          >
+            Посмотреть туры →
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          <Section title="Активная" trips={buckets.active} />
+          <Section title="Предстоящие" trips={buckets.upcoming} />
+          <Section title="Прошедшие" trips={buckets.past} />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/lib/api/clients.ts
+++ b/apps/web/lib/api/clients.ts
@@ -1,0 +1,62 @@
+/**
+ * Clients API client (#A-01, #A-02).
+ *
+ * GET   /clients/me — профиль клиента + расшифрованные ПДн
+ * PATCH /clients/me — обновить поля профиля (diff-only)
+ *
+ * Профиль создаётся через listener на `auth.user.registered` событие.
+ * Edge case: register прошёл, но listener ещё не отработал → 404.
+ * Frontend показывает skeleton + retry.
+ */
+import { apiClient } from './client';
+
+export interface ClientProfile {
+  id: string;
+  clientId: string;
+  firstName: string | null;
+  lastName: string | null;
+  dateOfBirth: string | null;
+  citizenship: string | null;
+  phone: string | null;
+  telegramHandle: string | null;
+  preferences: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ClientMe {
+  id: string;
+  userId: string;
+  status: 'active' | 'archived';
+  createdAt: string;
+  updatedAt: string;
+  profile: ClientProfile | null;
+}
+
+export async function getMe(): Promise<ClientMe> {
+  const res = await apiClient.get<ClientMe>('/clients/me');
+  return res.data;
+}
+
+/**
+ * Patch-семантика: omitted поле = нет изменений, явный null = очистить.
+ * Шифрование ПДн (firstName/lastName/dateOfBirth/phone) на бэке прозрачно.
+ */
+export interface UpdateClientProfilePatch {
+  firstName?: string | null;
+  lastName?: string | null;
+  /** ISO date YYYY-MM-DD */
+  dateOfBirth?: string | null;
+  /** ISO 3166-1 alpha-2 (RU, IN, ...) */
+  citizenship?: string | null;
+  /** E.164 phone: +<10-15 digits> */
+  phone?: string | null;
+  /** Telegram handle без @ (5–32 chars, latin/digits/underscore) */
+  telegramHandle?: string | null;
+  preferences?: Record<string, unknown>;
+}
+
+export async function updateMe(patch: UpdateClientProfilePatch): Promise<ClientProfile> {
+  const res = await apiClient.patch<ClientProfile>('/clients/me', patch);
+  return res.data;
+}

--- a/apps/web/lib/api/consents.ts
+++ b/apps/web/lib/api/consents.ts
@@ -1,0 +1,64 @@
+/**
+ * Consents API client (#A-06).
+ *
+ * GET    /clients/me/consents              — все consent-записи (active + history)
+ * POST   /clients/me/consents/:type        — grant (создать активный)
+ * DELETE /clients/me/consents/:type        — revoke активный
+ *
+ * Типы: photo_video | geo | emergency_contacts | marketing.
+ */
+import { apiClient } from './client';
+
+export type ConsentType = 'photo_video' | 'geo' | 'emergency_contacts' | 'marketing';
+
+export interface Consent {
+  id: string;
+  clientId: string;
+  type: ConsentType;
+  /** "1.2" — версия текста на момент grant'а */
+  version: string;
+  grantedAt: string;
+  revokedAt: string | null;
+  context: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export async function listConsents(): Promise<Consent[]> {
+  const res = await apiClient.get<Consent[]>('/clients/me/consents');
+  return res.data;
+}
+
+export interface GrantConsentPayload {
+  /** SemVer версия текста, на который соглашаемся */
+  version: string;
+  /** опциональный контекст: where_granted, ip и т.п. */
+  context?: Record<string, unknown>;
+}
+
+export async function grantConsent(
+  type: ConsentType,
+  payload: GrantConsentPayload,
+): Promise<Consent> {
+  const res = await apiClient.post<Consent>(`/clients/me/consents/${type}`, payload);
+  return res.data;
+}
+
+export async function revokeConsent(type: ConsentType): Promise<void> {
+  await apiClient.delete(`/clients/me/consents/${type}`);
+}
+
+/**
+ * Возвращает map активных согласий по типам.
+ * Активный = grantedAt && !revokedAt && самый свежий.
+ */
+export function getActiveConsents(consents: Consent[]): Map<ConsentType, Consent> {
+  const active = new Map<ConsentType, Consent>();
+  for (const c of consents) {
+    if (c.revokedAt) continue;
+    const existing = active.get(c.type);
+    if (!existing || new Date(c.grantedAt) > new Date(existing.grantedAt)) {
+      active.set(c.type, c);
+    }
+  }
+  return active;
+}

--- a/apps/web/lib/api/emergency.ts
+++ b/apps/web/lib/api/emergency.ts
@@ -1,0 +1,52 @@
+/**
+ * Emergency Contacts API client (#A-07).
+ *
+ * GET    /clients/me/emergency-contacts        — список (1-2 шт.)
+ * POST   /clients/me/emergency-contacts        — upsert (по priority)
+ * DELETE /clients/me/emergency-contacts/:id    — удалить
+ *
+ * PII (имя/телефон) шифруются на бэке через AES-256-GCM. Frontend получает
+ * расшифрованные значения (только для владельца профиля).
+ */
+import { apiClient } from './client';
+
+export type EmergencyContactPriority = 'primary' | 'secondary';
+
+export interface EmergencyContact {
+  id: string;
+  clientId: string;
+  name: string;
+  phone: string;
+  relation: string;
+  /** ISO 639-1: "ru" / "en" / ... */
+  language: string;
+  priority: EmergencyContactPriority;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listContacts(): Promise<EmergencyContact[]> {
+  const res = await apiClient.get<EmergencyContact[]>('/clients/me/emergency-contacts');
+  return res.data;
+}
+
+export interface UpsertEmergencyContactPayload {
+  name: string;
+  /** E.164: +<country><10-15 digits> */
+  phone: string;
+  relation: string;
+  /** ISO 639-1, lowercase */
+  language: string;
+  priority: EmergencyContactPriority;
+}
+
+export async function upsertContact(
+  payload: UpsertEmergencyContactPayload,
+): Promise<EmergencyContact> {
+  const res = await apiClient.post<EmergencyContact>('/clients/me/emergency-contacts', payload);
+  return res.data;
+}
+
+export async function deleteContact(id: string): Promise<void> {
+  await apiClient.delete(`/clients/me/emergency-contacts/${id}`);
+}

--- a/apps/web/lib/api/trips.ts
+++ b/apps/web/lib/api/trips.ts
@@ -1,0 +1,70 @@
+/**
+ * Trips API client (#A-08, #A-09).
+ *
+ * GET /trips/me — список trip'ов с RBAC (client → only own).
+ * GET /trips/:id — детали trip + bookingsCount + hasPublishedItinerary.
+ * GET /trips/:id/itinerary — последняя published-itinerary.
+ */
+import { apiClient } from './client';
+
+export type TripStatus = 'tentative' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface TripSummary {
+  id: string;
+  clientId: string;
+  status: TripStatus;
+  region: string;
+  startsAt: string;
+  endsAt: string;
+  totalAmount: string | null;
+  currency: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TripDetail extends TripSummary {
+  bookingsCount: number;
+  hasPublishedItinerary: boolean;
+}
+
+export interface DayPlan {
+  dayNumber: number;
+  title: string;
+  description: string | null;
+  location: string | null;
+  activities: string[];
+}
+
+export interface Itinerary {
+  id: string;
+  tripId: string;
+  version: number;
+  publishedAt: string | null;
+  days: DayPlan[];
+}
+
+export async function listMyTrips(): Promise<{ items: TripSummary[] }> {
+  const res = await apiClient.get<{ items: TripSummary[] }>('/trips/me');
+  return res.data;
+}
+
+export async function getTrip(id: string): Promise<TripDetail> {
+  const res = await apiClient.get<TripDetail>(`/trips/${id}`);
+  return res.data;
+}
+
+export async function getItinerary(tripId: string): Promise<Itinerary | null> {
+  try {
+    const res = await apiClient.get<Itinerary>(`/trips/${tripId}/itinerary`);
+    return res.data;
+  } catch (err: unknown) {
+    // 404 = нет published itinerary
+    const isAxiosError =
+      typeof err === 'object' &&
+      err !== null &&
+      'response' in err &&
+      (err as { response?: { status?: number } }).response?.status === 404;
+    if (isAxiosError) return null;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Реализованы **4 issues** из [EPIC #404](https://github.com/Rivega42/indiahorizone/issues/404) Track A — клиентский кабинет дотянут до уже работающих backend-эндпоинтов:

- **#405 (A-01)** — Profile index подтягивает имя через `GET /clients/me`
- **#410 (A-06)** — `/profile/consents`: управление 4 granular-согласиями (фото/видео, гео, экстренные контакты, маркетинг)
- **#411 (A-07)** — `/profile/emergency`: CRUD экстренных контактов с E.164 валидацией
- **#412 (A-08)** — `/profile/trips`: список поездок с группировкой active / upcoming / past

**Backend изменения: 0.** Все endpoints уже работают, добавлено только подключение фронта.

## Что внутри

### `apps/web/lib/api/`
- `clients.ts` — `getMe()`, `updateMe(patch)` с типами `ClientMe`, `ClientProfile`
- `trips.ts` — `listMyTrips()`, `getTrip(id)`, `getItinerary(id)` с обработкой 404
- `consents.ts` — `listConsents()`, `grantConsent(type, payload)`, `revokeConsent(type)` + хелпер `getActiveConsents()` для дедуп активных
- `emergency.ts` — `listContacts()`, `upsertContact(payload)`, `deleteContact(id)`

### `apps/web/app/profile/`
- `page.tsx` — обновлён: подтягивает имя из `getMe()`, fallback на email при 404, меню расширено до 4 разделов
- `trips/page.tsx` — список с buckets (active/upcoming/past), TripCard inline, status badge, цена через Intl.NumberFormat, empty state
- `consents/page.tsx` — 4 toggle с историей версий, modal подтверждения отзыва с warning о последствиях
- `emergency/page.tsx` — primary/secondary cards, modal формы с E.164 валидацией, кнопки Изменить/Удалить

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm format:check` — green
- [x] `pnpm --filter @indiahorizone/web type-check` — green
- [x] `pnpm --filter @indiahorizone/web build` — green, 4 новых pre-rendered route
- [ ] Manual: dev API up + register → /profile → проверить имя, переходы по меню, toggle согласия, добавление контакта (требует запуска backend локально)

## Что осталось из EPIC #404 (для следующих PR'ов)

**Без блокеров:**
- A-02 (#406) PII edit — нужна форма с masking + react-hook-form/zod
- A-03 (#407) 2FA enrollment — multi-step wizard + qrcode.react
- A-04 (#408) 2FA challenge — login flow с challenge token
- A-09 (#413) Trip card + program — детальная страница поездки с tabs
- A-10 (#414) Chat UI — list threads + messages с idempotency
- A-11 (#415) Daily feedback — text + emoji форма
- A-13 (#417) Trip Dashboard — «Сейчас/Следующее»
- B-04 (#421) Quiz/anketa — multi-step + расширение Prisma `ClientProfile`

**С новыми BE endpoints (могу делать, но больше работы):**
- A-05 (#409) Sessions list — нужны новые `GET /auth/sessions` + `DELETE /auth/sessions/:id`

**Заблокированы внешними поставщиками** (только после получения credentials):
- A-12 (#416) Password reset — email-провайдер (#349)
- B-01 (#418) SOS — SMS-провайдер (#349)
- B-02 (#419) Payment — ЮKassa account
- B-03 (#420) Offer acceptance — SMS (#349) + юр-текст (#307)
- B-05 (#422) Media — S3 (#350)
- B-06 (#423) Diary — зависит от B-05

## Closes

- Closes #405
- Closes #410
- Closes #411
- Closes #412

(И связанные sub-issues #424, #425, #426, #427, #451-#455, #456-#460, #461-#465 — закрываются вручную после ревью.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_