### PR TITLE
feat(profile): A-02 + A-09 + A-10 — PII edit, trip detail, chat UI

### DIFF
--- a/apps/web/app/profile/chat/[id]/page.tsx
+++ b/apps/web/app/profile/chat/[id]/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  listMessages,
+  markRead,
+  newIdempotencyKey,
+  sendMessage,
+  type ChatMessage,
+} from '@/lib/api/chat';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/chat/[id] — конкретный thread (#A-10).
+ *
+ * - Загружает первую страницу messages (свежие сначала).
+ * - Polling 10s.
+ * - Send: idempotency-key + optimistic update (pending state).
+ * - Mark read при mount + после получения новых.
+ */
+
+const POLL_MS = 10_000;
+
+interface PendingMessage {
+  tempId: string;
+  body: string;
+  idempotencyKey: string;
+}
+
+function formatTime(iso: string): string {
+  return new Intl.DateTimeFormat('ru-RU', { hour: '2-digit', minute: '2-digit' }).format(
+    new Date(iso),
+  );
+}
+
+export default function ChatThreadPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const params = useParams<{ id: string }>();
+  const threadId = params?.id;
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [pending, setPending] = useState<PendingMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const refresh = useCallback(
+    async (silent = false): Promise<void> => {
+      if (!threadId) return;
+      try {
+        const data = await listMessages(threadId, { limit: 50 });
+        // Backend возвращает items от свежих к старым; для UI разворачиваем.
+        const ordered = [...data.items].reverse();
+        setMessages(ordered);
+        if (!silent) setError(null);
+      } catch {
+        if (!silent) setError('Не удалось загрузить сообщения.');
+      }
+    },
+    [threadId],
+  );
+
+  // Init load + mark read
+  useEffect(() => {
+    if (!user || !threadId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    void (async () => {
+      await refresh(false);
+      if (!cancelled) setLoading(false);
+      try {
+        await markRead(threadId);
+      } catch {
+        // не критично
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, threadId, refresh]);
+
+  // Polling + visibility-aware
+  useEffect(() => {
+    if (!user || !threadId) return undefined;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    function start(): void {
+      if (timer) return;
+      timer = setInterval(() => void refresh(true), POLL_MS);
+    }
+    function stop(): void {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+    function onVis(): void {
+      if (document.visibilityState === 'visible') {
+        void refresh(true);
+        start();
+      } else {
+        stop();
+      }
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVis);
+      if (document.visibilityState === 'visible') start();
+    }
+    return () => {
+      stop();
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVis);
+      }
+    };
+  }, [user, threadId, refresh]);
+
+  // Auto-scroll на последнее сообщение
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length, pending.length]);
+
+  async function handleSend(): Promise<void> {
+    if (!threadId) return;
+    const body = draft.trim();
+    if (!body || sending) return;
+    const tempId = `pending-${Date.now()}`;
+    const idempotencyKey = newIdempotencyKey();
+    const pendingItem: PendingMessage = { tempId, body, idempotencyKey };
+
+    setPending((prev) => [...prev, pendingItem]);
+    setDraft('');
+    setSending(true);
+    setError(null);
+    try {
+      const sent = await sendMessage(threadId, { body }, idempotencyKey);
+      setMessages((prev) => [...prev, sent]);
+      setPending((prev) => prev.filter((p) => p.tempId !== tempId));
+    } catch {
+      setError('Не удалось отправить. Попробуйте ещё раз.');
+      // Возвращаем текст в input для retry
+      setDraft(body);
+      setPending((prev) => prev.filter((p) => p.tempId !== tempId));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Чат</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы открыть чат.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="mx-auto flex max-w-2xl flex-col px-6 py-8 sm:py-12"
+      style={{ minHeight: '90vh' }}
+    >
+      <header className="mb-4">
+        <Link
+          href="/profile/chat"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Сообщения
+        </Link>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : (
+        <>
+          <ul className="flex-1 space-y-3 overflow-y-auto rounded-lg border border-border bg-card p-4">
+            {messages.length === 0 && pending.length === 0 ? (
+              <li className="text-center text-sm italic text-muted-foreground">
+                Сообщений пока нет — напишите первым.
+              </li>
+            ) : null}
+            {messages.map((m) => {
+              const isMine = m.senderId === user.id;
+              return (
+                <li key={m.id} className={`flex ${isMine ? 'justify-end' : 'justify-start'}`}>
+                  <div
+                    className={`max-w-[80%] rounded-lg px-3 py-2 text-sm ${
+                      isMine ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
+                    }`}
+                  >
+                    <p className="whitespace-pre-wrap break-words">{m.body}</p>
+                    <p
+                      className={`mt-1 text-xs ${
+                        isMine ? 'text-primary-foreground/70' : 'text-muted-foreground'
+                      }`}
+                    >
+                      {formatTime(m.createdAt)} ✓
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+            {pending.map((p) => (
+              <li key={p.tempId} className="flex justify-end">
+                <div className="max-w-[80%] rounded-lg bg-primary/60 px-3 py-2 text-sm text-primary-foreground">
+                  <p className="whitespace-pre-wrap break-words">{p.body}</p>
+                  <p className="mt-1 text-xs text-primary-foreground/70">отправляется…</p>
+                </div>
+              </li>
+            ))}
+            <div ref={messagesEndRef} />
+          </ul>
+
+          {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+
+          <div className="mt-4 flex gap-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  void handleSend();
+                }
+              }}
+              placeholder="Сообщение…"
+              rows={2}
+              className="flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm"
+              disabled={sending}
+              maxLength={4000}
+            />
+            <button
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={!draft.trim() || sending}
+              className="self-end rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {sending ? '…' : 'Отправить'}
+            </button>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/profile/chat/page.tsx
+++ b/apps/web/app/profile/chat/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { listThreads, type ChatThread } from '@/lib/api/chat';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/chat — список threads (#A-10).
+ *
+ * Polling 10s через setInterval (без WebSocket — phase 4).
+ * Pause при невидимом tab через document.visibilityState.
+ */
+
+const POLL_MS = 10_000;
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) {
+    return new Intl.DateTimeFormat('ru-RU', { hour: '2-digit', minute: '2-digit' }).format(d);
+  }
+  return new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'short' }).format(d);
+}
+
+function threadTitle(thread: ChatThread): string {
+  if (thread.kind === 'client_concierge') return 'Concierge';
+  if (thread.kind === 'client_guide') return 'Гид';
+  return thread.kind;
+}
+
+export default function ChatThreadsPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [threads, setThreads] = useState<ChatThread[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function load(showSpinner = false): Promise<void> {
+      if (showSpinner) setLoading(true);
+      try {
+        const data = await listThreads();
+        if (!cancelled) {
+          setThreads(data.items);
+          setError(null);
+        }
+      } catch {
+        if (!cancelled && showSpinner) {
+          setError('Не удалось загрузить чаты.');
+        }
+      } finally {
+        if (!cancelled && showSpinner) setLoading(false);
+      }
+    }
+
+    void load(true);
+
+    function startPolling(): void {
+      if (timer) return;
+      timer = setInterval(() => void load(false), POLL_MS);
+    }
+    function stopPolling(): void {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+
+    function onVisibility(): void {
+      if (document.visibilityState === 'visible') {
+        void load(false);
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    }
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibility);
+      if (document.visibilityState === 'visible') startPolling();
+    }
+
+    return () => {
+      cancelled = true;
+      stopPolling();
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibility);
+      }
+    };
+  }, [user]);
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Сообщения</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы открыть чаты.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-6 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Сообщения
+        </h1>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : threads.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Чаты появятся, когда менеджер добавит вас в обсуждение поездки.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {threads.map((t) => (
+            <li key={t.id}>
+              <Link
+                href={`/profile/chat/${t.id}`}
+                className="flex items-start justify-between gap-4 rounded-lg border border-border bg-card p-4 transition hover:border-primary/40"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <h2 className="truncate font-medium">{threadTitle(t)}</h2>
+                    {t.unreadCount && t.unreadCount > 0 ? (
+                      <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+                        {t.unreadCount}
+                      </span>
+                    ) : null}
+                  </div>
+                  {t.lastMessageBody ? (
+                    <p className="mt-1 truncate text-sm text-muted-foreground">
+                      {t.lastMessageBody}
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-sm italic text-muted-foreground">Сообщений пока нет</p>
+                  )}
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDate(t.lastMessageAt)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/profile/personal/page.tsx
+++ b/apps/web/app/profile/personal/page.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+import { getMe, updateMe, type ClientMe, type UpdateClientProfilePatch } from '@/lib/api/clients';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/personal — редактирование PII (#A-02).
+ *
+ * - Pre-fill из GET /clients/me.
+ * - PII (телефон, дата рождения) показаны masked, toggle «Показать».
+ * - Submit отправляет diff-only patch через PATCH /clients/me.
+ * - Backend шифрует firstName/lastName/dateOfBirth/phone через AES-256-GCM.
+ */
+
+const E164_PATTERN = /^\+\d{10,15}$/;
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_COUNTRY_PATTERN = /^[A-Z]{2}$/;
+const TG_HANDLE_PATTERN = /^[A-Za-z0-9_]{5,32}$/;
+
+interface FormState {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  citizenship: string;
+  phone: string;
+  telegramHandle: string;
+}
+
+const EMPTY_FORM: FormState = {
+  firstName: '',
+  lastName: '',
+  dateOfBirth: '',
+  citizenship: '',
+  phone: '',
+  telegramHandle: '',
+};
+
+function fromProfile(me: ClientMe | null): FormState {
+  const p = me?.profile;
+  if (!p) return EMPTY_FORM;
+  return {
+    firstName: p.firstName ?? '',
+    lastName: p.lastName ?? '',
+    dateOfBirth: p.dateOfBirth ?? '',
+    citizenship: p.citizenship ?? '',
+    phone: p.phone ?? '',
+    telegramHandle: p.telegramHandle ?? '',
+  };
+}
+
+function maskPhone(phone: string): string {
+  // +79161234512 → +7 *** *** ** 12
+  if (!E164_PATTERN.test(phone)) return phone;
+  const last = phone.slice(-2);
+  const cc = phone.slice(0, 2);
+  return `${cc} *** *** ** ${last}`;
+}
+
+function maskDate(date: string): string {
+  // 1990-06-15 → **.**.1990
+  if (!ISO_DATE_PATTERN.test(date)) return date;
+  return `**.**.${date.slice(0, 4)}`;
+}
+
+function diffPatch(initial: FormState, current: FormState): UpdateClientProfilePatch {
+  const patch: UpdateClientProfilePatch = {};
+  const fields: (keyof FormState)[] = [
+    'firstName',
+    'lastName',
+    'dateOfBirth',
+    'citizenship',
+    'phone',
+    'telegramHandle',
+  ];
+  for (const f of fields) {
+    if (initial[f] !== current[f]) {
+      // Пустая строка → null (очистить поле)
+      patch[f] = current[f] === '' ? null : current[f];
+    }
+  }
+  return patch;
+}
+
+function validate(form: FormState): string | null {
+  if (form.phone && !E164_PATTERN.test(form.phone)) {
+    return 'Телефон в формате +<код страны><номер>, например +79161234567.';
+  }
+  if (form.dateOfBirth && !ISO_DATE_PATTERN.test(form.dateOfBirth)) {
+    return 'Дата рождения в формате YYYY-MM-DD.';
+  }
+  if (form.citizenship && !ISO_COUNTRY_PATTERN.test(form.citizenship)) {
+    return 'Гражданство — 2 буквы в верхнем регистре (RU, IN, ...).';
+  }
+  if (form.telegramHandle && !TG_HANDLE_PATTERN.test(form.telegramHandle)) {
+    return 'Telegram: 5–32 латинских/цифр/подчёркивания, без @.';
+  }
+  return null;
+}
+
+export default function PersonalProfilePage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [initial, setInitial] = useState<FormState>(EMPTY_FORM);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [showPhone, setShowPhone] = useState(false);
+  const [showDob, setShowDob] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    getMe()
+      .then((data) => {
+        if (cancelled) return;
+        const initialForm = fromProfile(data);
+        setInitial(initialForm);
+        setForm(initialForm);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить профиль.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const patch = useMemo(() => diffPatch(initial, form), [initial, form]);
+  const hasChanges = Object.keys(patch).length > 0;
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    const validationError = validate(form);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (!hasChanges) return;
+    setSubmitting(true);
+    setError(null);
+    setToast(null);
+    try {
+      await updateMe(patch);
+      setInitial(form); // diff обнулится
+      setToast('Сохранено');
+      setTimeout(() => setToast(null), 3000);
+    } catch {
+      setError('Не удалось сохранить. Проверьте данные и попробуйте ещё раз.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Личные данные</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы редактировать профиль.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Личные данные
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          ФИО, дата рождения, телефон. Конфиденциальные поля шифруются на сервере (AES-256-GCM).
+        </p>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+          <label className="block">
+            <span className="text-sm font-medium">Имя</span>
+            <input
+              value={form.firstName}
+              onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+              maxLength={100}
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+              placeholder="Анна"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium">Фамилия</span>
+            <input
+              value={form.lastName}
+              onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+              maxLength={100}
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+              placeholder="Петрова"
+            />
+          </label>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Дата рождения</span>
+              {form.dateOfBirth ? (
+                <button
+                  type="button"
+                  onClick={() => setShowDob((v) => !v)}
+                  className="text-xs font-medium text-primary hover:underline"
+                >
+                  {showDob ? 'Скрыть' : 'Показать'}
+                </button>
+              ) : null}
+            </div>
+            <input
+              type="date"
+              value={showDob ? form.dateOfBirth : ''}
+              onChange={(e) => setForm({ ...form, dateOfBirth: e.target.value })}
+              onFocus={() => setShowDob(true)}
+              placeholder={form.dateOfBirth ? maskDate(form.dateOfBirth) : '1990-06-15'}
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+            />
+            {!showDob && form.dateOfBirth ? (
+              <p className="mt-1 text-xs text-muted-foreground">{maskDate(form.dateOfBirth)}</p>
+            ) : null}
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium">Гражданство</span>
+            <input
+              value={form.citizenship}
+              onChange={(e) =>
+                setForm({ ...form, citizenship: e.target.value.toUpperCase().slice(0, 2) })
+              }
+              placeholder="RU"
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm uppercase"
+              maxLength={2}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              ISO 3166-1 alpha-2: RU, IN, US, GB.
+            </p>
+          </label>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Телефон</span>
+              {form.phone ? (
+                <button
+                  type="button"
+                  onClick={() => setShowPhone((v) => !v)}
+                  className="text-xs font-medium text-primary hover:underline"
+                >
+                  {showPhone ? 'Скрыть' : 'Показать'}
+                </button>
+              ) : null}
+            </div>
+            <input
+              value={showPhone ? form.phone : maskPhone(form.phone)}
+              onChange={(e) => {
+                setShowPhone(true);
+                setForm({ ...form, phone: e.target.value });
+              }}
+              onFocus={() => setShowPhone(true)}
+              placeholder="+79161234567"
+              inputMode="tel"
+              className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">E.164 формат: + и 10–15 цифр.</p>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium">Telegram</span>
+            <div className="relative mt-1">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                @
+              </span>
+              <input
+                value={form.telegramHandle}
+                onChange={(e) => setForm({ ...form, telegramHandle: e.target.value })}
+                placeholder="username"
+                className="w-full rounded-lg border border-input bg-background py-2 pl-7 pr-3 text-sm"
+                maxLength={32}
+              />
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">5–32 символа, латиница/цифры/_</p>
+          </label>
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {toast ? <p className="text-sm text-emerald-700 dark:text-emerald-400">{toast}</p> : null}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={!hasChanges || submitting}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting ? 'Сохранение…' : 'Сохранить'}
+            </button>
+          </div>
+        </form>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/profile/trips/[id]/page.tsx
+++ b/apps/web/app/profile/trips/[id]/page.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import {
+  getItinerary,
+  getTrip,
+  type Itinerary,
+  type TripDetail,
+  type TripStatus,
+} from '@/lib/api/trips';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/trips/[id] — детали поездки + программа (#A-09).
+ *
+ * Tabs (через ?tab= query param для URL persistence):
+ * - program — DayTimeline из последней published-itinerary
+ * - documents — placeholder, реализуется отдельно (B-05 + #68)
+ * - chat — ссылка на /profile/chat (для конкретного thread'а — позже)
+ * - feedback — ссылка на /profile/trips/{id}/feedback (A-11)
+ *
+ * Баннер «Поездка отменена» при status=cancelled.
+ */
+
+type Tab = 'program' | 'documents' | 'chat' | 'feedback';
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'program', label: 'Программа' },
+  { id: 'documents', label: 'Документы' },
+  { id: 'chat', label: 'Чат' },
+  { id: 'feedback', label: 'Фидбэк' },
+];
+
+const STATUS_LABEL: Record<TripStatus, string> = {
+  tentative: 'Черновик',
+  confirmed: 'Подтверждена',
+  in_progress: 'В пути',
+  completed: 'Завершена',
+  cancelled: 'Отменена',
+};
+
+const STATUS_TONE: Record<TripStatus, string> = {
+  tentative: 'bg-muted text-muted-foreground',
+  confirmed: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-100',
+  in_progress: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100',
+  completed: 'bg-muted text-muted-foreground',
+  cancelled: 'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-100',
+};
+
+function formatDateRange(startsAt: string, endsAt: string): string {
+  const fmt = new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' });
+  return `${fmt.format(new Date(startsAt))} — ${fmt.format(new Date(endsAt))}`;
+}
+
+function ProgramTab({ itinerary }: { itinerary: Itinerary | null }): React.ReactElement {
+  if (!itinerary) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+        <p className="text-sm text-muted-foreground">Программа в подготовке менеджером.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {itinerary.days.map((day) => (
+        <details
+          key={day.dayNumber}
+          className="group overflow-hidden rounded-lg border border-border bg-card transition hover:border-primary/40"
+        >
+          <summary className="flex cursor-pointer list-none items-center gap-4 p-5 [&::-webkit-details-marker]:hidden">
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary/10 font-serif text-xl font-medium text-primary">
+              {day.dayNumber}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                День {day.dayNumber}
+                {day.location ? ` · ${day.location}` : ''}
+              </p>
+              <h3 className="mt-1 truncate font-medium">{day.title}</h3>
+            </div>
+            <span className="shrink-0 text-muted-foreground transition group-open:rotate-180">
+              ▾
+            </span>
+          </summary>
+          <div className="space-y-3 px-5 pb-5">
+            {day.description ? (
+              <p className="text-sm text-muted-foreground">{day.description}</p>
+            ) : null}
+            {day.activities.length > 0 ? (
+              <ul className="flex flex-wrap gap-2">
+                {day.activities.map((a) => (
+                  <li
+                    key={a}
+                    className="rounded-full bg-muted px-2.5 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {a}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function DocumentsTab(): React.ReactElement {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
+      <p className="text-sm text-muted-foreground">
+        Документы (паспорт, виза, билеты, страховка) появятся здесь после загрузки.
+      </p>
+      <p className="mt-2 text-xs text-muted-foreground">Раздел в разработке (issue #422).</p>
+    </div>
+  );
+}
+
+function ChatTab(): React.ReactElement {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <p className="text-sm">
+        Чат с concierge и гидом — в разделе{' '}
+        <Link href="/profile/chat" className="font-medium text-primary hover:underline">
+          Сообщения
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}
+
+function FeedbackTab({ tripId }: { tripId: string }): React.ReactElement {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <p className="text-sm text-muted-foreground">
+        Ежедневный фидбэк по дням поездки — в работе (issue #415).
+      </p>
+      <p className="mt-2 text-xs text-muted-foreground">Trip ID: {tripId}</p>
+    </div>
+  );
+}
+
+export default function TripDetailPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const search = useSearchParams();
+  const tripId = params?.id;
+
+  const initialTab = (search?.get('tab') as Tab | null) ?? 'program';
+  const [tab, setTab] = useState<Tab>(
+    TABS.some((t) => t.id === initialTab) ? initialTab : 'program',
+  );
+
+  const [trip, setTrip] = useState<TripDetail | null>(null);
+  const [itinerary, setItinerary] = useState<Itinerary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  function setTabAndUrl(next: Tab): void {
+    setTab(next);
+    const sp = new URLSearchParams(search?.toString() ?? '');
+    sp.set('tab', next);
+    router.replace(`?${sp.toString()}`, { scroll: false });
+  }
+
+  useEffect(() => {
+    if (!user || !tripId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    Promise.all([getTrip(tripId), getItinerary(tripId)])
+      .then(([tripData, itin]) => {
+        if (cancelled) return;
+        setTrip(tripData);
+        setItinerary(itin);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Поездка не найдена или нет доступа.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, tripId]);
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Поездка</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы открыть поездку.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile/trips"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Мои поездки
+        </Link>
+        {loading ? (
+          <p className="mt-3 text-sm text-muted-foreground">Загрузка…</p>
+        ) : error ? (
+          <p className="mt-3 text-sm text-destructive">{error}</p>
+        ) : trip ? (
+          <>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <h1 className="font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+                {trip.region}
+              </h1>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs uppercase tracking-wide ${STATUS_TONE[trip.status]}`}
+              >
+                {STATUS_LABEL[trip.status]}
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {formatDateRange(trip.startsAt, trip.endsAt)}
+            </p>
+          </>
+        ) : null}
+      </header>
+
+      {trip?.status === 'cancelled' ? (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-100">
+          Поездка отменена. Если у вас остались вопросы — напишите менеджеру в чат.
+        </div>
+      ) : null}
+
+      {trip ? (
+        <>
+          <nav className="flex gap-1 overflow-x-auto rounded-lg border border-border bg-card p-1">
+            {TABS.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTabAndUrl(t.id)}
+                aria-selected={tab === t.id}
+                className={`flex-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition ${
+                  tab === t.id
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-accent'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          <section>
+            {tab === 'program' ? <ProgramTab itinerary={itinerary} /> : null}
+            {tab === 'documents' ? <DocumentsTab /> : null}
+            {tab === 'chat' ? <ChatTab /> : null}
+            {tab === 'feedback' && tripId ? <FeedbackTab tripId={tripId} /> : null}
+          </section>
+        </>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/lib/api/chat.ts
+++ b/apps/web/lib/api/chat.ts
@@ -1,0 +1,86 @@
+/**
+ * Chat API client (#A-10).
+ *
+ * GET    /chat/threads
+ * GET    /chat/threads/:id/messages?limit=&cursor=
+ * POST   /chat/threads/:id/messages   (Idempotency-Key обязателен)
+ * POST   /chat/threads/:id/read
+ *
+ * Idempotency-Key — UUID v4 на каждое сообщение. При retry (плохая сеть)
+ * с тем же ключом backend вернёт оригинальное сообщение → нет дубликатов.
+ */
+import { apiClient } from './client';
+
+export interface ChatThread {
+  id: string;
+  /** "client_concierge" | "client_guide" — тип треда */
+  kind: string;
+  participants: string[];
+  unreadCount?: number;
+  lastMessageAt: string | null;
+  lastMessageBody: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  threadId: string;
+  senderId: string;
+  body: string;
+  attachments: string[];
+  createdAt: string;
+  readBy: string[];
+}
+
+export async function listThreads(): Promise<{ items: ChatThread[] }> {
+  const res = await apiClient.get<{ items: ChatThread[] }>('/chat/threads');
+  return res.data;
+}
+
+export interface ListMessagesResponse {
+  items: ChatMessage[];
+  nextCursor: string | null;
+}
+
+export async function listMessages(
+  threadId: string,
+  opts: { limit?: number; cursor?: string } = {},
+): Promise<ListMessagesResponse> {
+  const params = new URLSearchParams();
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  if (opts.cursor) params.set('cursor', opts.cursor);
+  const qs = params.toString();
+  const url = `/chat/threads/${threadId}/messages${qs ? `?${qs}` : ''}`;
+  const res = await apiClient.get<ListMessagesResponse>(url);
+  return res.data;
+}
+
+export interface SendMessagePayload {
+  body: string;
+  attachments?: string[];
+}
+
+export async function sendMessage(
+  threadId: string,
+  payload: SendMessagePayload,
+  idempotencyKey: string,
+): Promise<ChatMessage> {
+  const res = await apiClient.post<ChatMessage>(`/chat/threads/${threadId}/messages`, payload, {
+    headers: { 'Idempotency-Key': idempotencyKey },
+  });
+  return res.data;
+}
+
+export async function markRead(threadId: string): Promise<{ updated: number }> {
+  const res = await apiClient.post<{ updated: number }>(`/chat/threads/${threadId}/read`);
+  return res.data;
+}
+
+/**
+ * Генерирует UUID v4 для Idempotency-Key.
+ * Используем crypto.randomUUID() (доступен в Node 19+ и современных браузерах).
+ */
+export function newIdempotencyKey(): string {
+  return globalThis.crypto.randomUUID();
+}

--- a/apps/web/lib/api/clients.ts
+++ b/apps/web/lib/api/clients.ts
@@ -1,0 +1,62 @@
+/**
+ * Clients API client (#A-01, #A-02).
+ *
+ * GET   /clients/me — профиль клиента + расшифрованные ПДн
+ * PATCH /clients/me — обновить поля профиля (diff-only)
+ *
+ * Профиль создаётся через listener на `auth.user.registered` событие.
+ * Edge case: register прошёл, но listener ещё не отработал → 404.
+ * Frontend показывает skeleton + retry.
+ */
+import { apiClient } from './client';
+
+export interface ClientProfile {
+  id: string;
+  clientId: string;
+  firstName: string | null;
+  lastName: string | null;
+  dateOfBirth: string | null;
+  citizenship: string | null;
+  phone: string | null;
+  telegramHandle: string | null;
+  preferences: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ClientMe {
+  id: string;
+  userId: string;
+  status: 'active' | 'archived';
+  createdAt: string;
+  updatedAt: string;
+  profile: ClientProfile | null;
+}
+
+export async function getMe(): Promise<ClientMe> {
+  const res = await apiClient.get<ClientMe>('/clients/me');
+  return res.data;
+}
+
+/**
+ * Patch-семантика: omitted поле = нет изменений, явный null = очистить.
+ * Шифрование ПДн (firstName/lastName/dateOfBirth/phone) на бэке прозрачно.
+ */
+export interface UpdateClientProfilePatch {
+  firstName?: string | null;
+  lastName?: string | null;
+  /** ISO date YYYY-MM-DD */
+  dateOfBirth?: string | null;
+  /** ISO 3166-1 alpha-2 (RU, IN, ...) */
+  citizenship?: string | null;
+  /** E.164 phone: +<10-15 digits> */
+  phone?: string | null;
+  /** Telegram handle без @ (5–32 chars, latin/digits/underscore) */
+  telegramHandle?: string | null;
+  preferences?: Record<string, unknown>;
+}
+
+export async function updateMe(patch: UpdateClientProfilePatch): Promise<ClientProfile> {
+  const res = await apiClient.patch<ClientProfile>('/clients/me', patch);
+  return res.data;
+}

--- a/apps/web/lib/api/trips.ts
+++ b/apps/web/lib/api/trips.ts
@@ -1,0 +1,70 @@
+/**
+ * Trips API client (#A-08, #A-09).
+ *
+ * GET /trips/me — список trip'ов с RBAC (client → only own).
+ * GET /trips/:id — детали trip + bookingsCount + hasPublishedItinerary.
+ * GET /trips/:id/itinerary — последняя published-itinerary.
+ */
+import { apiClient } from './client';
+
+export type TripStatus = 'tentative' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface TripSummary {
+  id: string;
+  clientId: string;
+  status: TripStatus;
+  region: string;
+  startsAt: string;
+  endsAt: string;
+  totalAmount: string | null;
+  currency: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TripDetail extends TripSummary {
+  bookingsCount: number;
+  hasPublishedItinerary: boolean;
+}
+
+export interface DayPlan {
+  dayNumber: number;
+  title: string;
+  description: string | null;
+  location: string | null;
+  activities: string[];
+}
+
+export interface Itinerary {
+  id: string;
+  tripId: string;
+  version: number;
+  publishedAt: string | null;
+  days: DayPlan[];
+}
+
+export async function listMyTrips(): Promise<{ items: TripSummary[] }> {
+  const res = await apiClient.get<{ items: TripSummary[] }>('/trips/me');
+  return res.data;
+}
+
+export async function getTrip(id: string): Promise<TripDetail> {
+  const res = await apiClient.get<TripDetail>(`/trips/${id}`);
+  return res.data;
+}
+
+export async function getItinerary(tripId: string): Promise<Itinerary | null> {
+  try {
+    const res = await apiClient.get<Itinerary>(`/trips/${tripId}/itinerary`);
+    return res.data;
+  } catch (err: unknown) {
+    // 404 = нет published itinerary
+    const isAxiosError =
+      typeof err === 'object' &&
+      err !== null &&
+      'response' in err &&
+      (err as { response?: { status?: number } }).response?.status === 404;
+    if (isAxiosError) return null;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Реализованы **3 issues** из [EPIC #404](https://github.com/Rivega42/indiahorizone/issues/404) Track A:

- **#406 (A-02)** — `/profile/personal`: форма редактирования PII с masking телефона и даты рождения (toggle «Показать»), diff-only `PATCH /clients/me`
- **#413 (A-09)** — `/profile/trips/[id]`: детали поездки с tabs (Программа / Документы / Чат / Фидбэк), URL-persisted `?tab=`, баннер «Отменена» при `status=cancelled`
- **#414 (A-10)** — `/profile/chat` + `/profile/chat/[id]`: список threads с polling 10s (visibility-aware) + thread с idempotency-key на send, optimistic pending state, mark read при mount

**Backend изменения: 0.** Все endpoints уже работают.

## Что внутри

### `apps/web/lib/api/`
- `chat.ts` — новый: `listThreads`, `listMessages`, `sendMessage` (с Idempotency-Key header), `markRead`, `newIdempotencyKey()`
- `clients.ts` + `trips.ts` — скопированы из ветки PR #532 (идентичный контент, чтобы type-check проходил автономно)

### `apps/web/app/profile/`
- `personal/page.tsx` — react-форма с masking PII через простую маску `+7 *** *** ** 12`, `**.**.1990`. Diff-only patch (только изменённые поля). Toggle «Показать» отдельно для phone и dateOfBirth. Validation E.164 / ISO 3166-1 / Telegram handle.
- `trips/[id]/page.tsx` — header с регионом + status badge + диапазон дат (Intl), tabs nav (URL persistence через `?tab=`), inline `<details>` accordion для программы по дням. Tabs Documents/Chat/Feedback пока placeholder со ссылками на соответствующие разделы (или будущие issues).
- `chat/page.tsx` — список threads с unread badge, last message preview, smart date format (today → time, else → day month). Polling каждые 10s через `setInterval`, pause при `document.visibilityState === 'hidden'`.
- `chat/[id]/page.tsx` — thread с messages bubbles (mine/other tone), auto-scroll на последнее, textarea с Enter-send (Shift+Enter — newline). Pending state перед ack от backend (`bg-primary/60`), при ошибке текст возвращается в input для retry. UUID v4 idempotency-key на каждое сообщение.

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm format:check` — green
- [x] `pnpm --filter @indiahorizone/web type-check` — green
- [x] `pnpm --filter @indiahorizone/web build` — green, новые pre-rendered route'ы
- [ ] Manual: dev API up + register → /profile/personal → edit phone → save → reload → персистентность; /profile/chat → отправить сообщение → проверить idempotency на retry

## Зависимость от PR #532

Этот PR содержит файлы `apps/web/lib/api/clients.ts` и `apps/web/lib/api/trips.ts` дублирующие то же содержимое из [PR #532](https://github.com/Rivega42/indiahorizone/pull/532). Сделано так, чтобы type-check работал автономно. При merge:
- Если #532 merge'ится **первым** → этот PR сольётся без конфликтов (Git увидит идентичные файлы).
- Если этот PR merge'ится **первым** → #532 сольётся без конфликтов.

Порядок не важен.

## Closes

- Closes #406
- Closes #413
- Closes #414

(И связанные sub-issues #428-#432, #466-#470, #471-#476.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_