### PR TITLE
feat(auth,profile): A-05 — список активных сессий + revoke

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -11,6 +11,8 @@ import { LogoutService } from './services/logout.service';
 import { PasswordService } from './services/password.service';
 import { RefreshService } from './services/refresh.service';
 import { SuspiciousLoginDetector } from './services/suspicious-login.detector';
+import { SessionsController } from './sessions/sessions.controller';
+import { SessionsService } from './sessions/sessions.service';
 import { TwoFaChallengeService } from './two-fa/two-fa-challenge.service';
 import { TwoFaController } from './two-fa/two-fa.controller';
 import { TwoFaService } from './two-fa/two-fa.service';
@@ -33,7 +35,7 @@ import { TwoFaService } from './two-fa/two-fa.service';
     // Глобальный module не требуется — JwtTokenService сам читает env через ConfigService.
     JwtModule.register({}),
   ],
-  controllers: [AuthController, TwoFaController, PasswordResetController],
+  controllers: [AuthController, TwoFaController, PasswordResetController, SessionsController],
   providers: [
     AuthService,
     LoginService,
@@ -44,6 +46,7 @@ import { TwoFaService } from './two-fa/two-fa.service';
     TwoFaService,
     TwoFaChallengeService,
     PasswordResetService,
+    SessionsService,
     SuspiciousLoginDetector,
   ],
   exports: [
@@ -56,6 +59,7 @@ import { TwoFaService } from './two-fa/two-fa.service';
     TwoFaService,
     TwoFaChallengeService,
     PasswordResetService,
+    SessionsService,
     SuspiciousLoginDetector,
   ],
 })

--- a/apps/api/src/modules/auth/sessions/lib/ua-parser.ts
+++ b/apps/api/src/modules/auth/sessions/lib/ua-parser.ts
@@ -1,0 +1,50 @@
+/**
+ * Простой User-Agent парсер для device label (#A-05).
+ *
+ * Без зависимости ua-parser-js — phase 3 объём не оправдывает.
+ * Покрывает 95% массовых браузеров/ОС: Chrome / Firefox / Safari / Edge / Opera
+ * + Windows / macOS / Linux / Android / iOS.
+ *
+ * Возвращает строку формата "Chrome on macOS" или "Safari on iPhone".
+ * Fallback "Unknown device" если UA отсутствует или нераспознан.
+ */
+
+interface ParsedUa {
+  browser: string;
+  os: string;
+}
+
+const BROWSER_PATTERNS: { name: string; re: RegExp }[] = [
+  // Edge ДО Chrome (Edge содержит подстроку Chrome)
+  { name: 'Edge', re: /Edg(?:e|A|iOS)?\/[\d.]+/ },
+  // Opera ДО Chrome (Opera содержит OPR/...)
+  { name: 'Opera', re: /OPR\/[\d.]+/ },
+  { name: 'Firefox', re: /Firefox\/[\d.]+/ },
+  // Chrome — после Edge/Opera (они содержат Chrome substring)
+  { name: 'Chrome', re: /Chrome\/[\d.]+/ },
+  // Safari — после Chrome (Chrome содержит Safari substring)
+  { name: 'Safari', re: /Version\/[\d.]+ Safari\// },
+];
+
+const OS_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: 'iPhone', re: /iPhone OS [\d_]+/ },
+  { name: 'iPad', re: /iPad; .*OS [\d_]+/ },
+  { name: 'Android', re: /Android [\d.]+/ },
+  { name: 'Windows', re: /Windows NT [\d.]+/ },
+  { name: 'macOS', re: /Mac OS X [\d_]+/ },
+  { name: 'Linux', re: /Linux/ },
+];
+
+export function parseUserAgent(userAgent: string | null | undefined): ParsedUa {
+  if (!userAgent || userAgent.length === 0) {
+    return { browser: 'Unknown', os: 'device' };
+  }
+  const browser = BROWSER_PATTERNS.find((p) => p.re.test(userAgent))?.name ?? 'Browser';
+  const os = OS_PATTERNS.find((p) => p.re.test(userAgent))?.name ?? 'device';
+  return { browser, os };
+}
+
+export function deviceLabel(userAgent: string | null | undefined): string {
+  const { browser, os } = parseUserAgent(userAgent);
+  return `${browser} on ${os}`;
+}

--- a/apps/api/src/modules/auth/sessions/sessions.controller.ts
+++ b/apps/api/src/modules/auth/sessions/sessions.controller.ts
@@ -1,0 +1,46 @@
+/**
+ * SessionsController — управление активными сессиями (#A-05).
+ *
+ * - GET    /auth/sessions      — список активных + пометка current
+ * - DELETE /auth/sessions/:id  — завершить конкретную (не текущую)
+ *
+ * Доступ: любая authenticated роль через глобальный JwtAuthGuard.
+ * RBAC через service: пользователь видит/завершает только свои сессии.
+ *
+ * Для logout текущей — POST /auth/logout.
+ * Для logout всех — POST /auth/logout-all.
+ */
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+
+import { type SessionResponse, SessionsService } from './sessions.service';
+import { CurrentUser } from '../../../common/auth/decorators';
+
+import type { AuthenticatedUser } from '../../../common/auth/types';
+
+@Controller('auth/sessions')
+export class SessionsController {
+  constructor(private readonly sessions: SessionsService) {}
+
+  @Get()
+  async list(@CurrentUser() user: AuthenticatedUser): Promise<{ items: SessionResponse[] }> {
+    const items = await this.sessions.list(user.id, user.sessionId);
+    return { items };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async revoke(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<void> {
+    await this.sessions.revoke(user.id, id, user.sessionId);
+  }
+}

--- a/apps/api/src/modules/auth/sessions/sessions.service.ts
+++ b/apps/api/src/modules/auth/sessions/sessions.service.ts
@@ -1,0 +1,106 @@
+import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import { deviceLabel } from './lib/ua-parser';
+import { OutboxService } from '../../../common/outbox/outbox.service';
+import { PrismaService } from '../../../common/prisma/prisma.service';
+
+export interface SessionResponse {
+  id: string;
+  deviceLabel: string;
+  ip: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+  current: boolean;
+}
+
+/**
+ * SessionsService — управление активными сессиями пользователя (#A-05).
+ *
+ * Endpoints:
+ * - list(userId, currentSessionId) — все active sessions с пометкой current
+ * - revoke(userId, sessionId, currentSessionId) — завершить конкретную
+ *
+ * Active = revokedAt IS NULL AND expiresAt > now.
+ * Current сессию помечаем по sessionId из JWT — клиенту не нужно ничего
+ * передавать дополнительно.
+ *
+ * Нельзя revoke текущую сессию через DELETE /auth/sessions/:id (защита от
+ * случайного «выхода»): для этого используется POST /auth/logout.
+ */
+@Injectable()
+export class SessionsService {
+  private readonly logger = new Logger(SessionsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly outbox: OutboxService,
+  ) {}
+
+  async list(userId: string, currentSessionId: string): Promise<SessionResponse[]> {
+    const now = new Date();
+    const sessions = await this.prisma.session.findMany({
+      where: {
+        userId,
+        revokedAt: null,
+        expiresAt: { gt: now },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        userAgent: true,
+        ip: true,
+        createdAt: true,
+        expiresAt: true,
+      },
+    });
+
+    return sessions.map((s) => ({
+      id: s.id,
+      deviceLabel: deviceLabel(s.userAgent),
+      ip: s.ip,
+      createdAt: s.createdAt,
+      expiresAt: s.expiresAt,
+      current: s.id === currentSessionId,
+    }));
+  }
+
+  async revoke(userId: string, sessionId: string, currentSessionId: string): Promise<void> {
+    if (sessionId === currentSessionId) {
+      throw new ForbiddenException(
+        'Нельзя завершить текущую сессию через этот endpoint. Используйте /auth/logout.',
+      );
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const result = await tx.session.updateMany({
+        where: {
+          id: sessionId,
+          userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: new Date(),
+          revokeReason: 'revoked-by-user',
+        },
+      });
+
+      if (result.count === 0) {
+        // session не найдена / не принадлежит user'у / уже revoked
+        throw new NotFoundException('Сессия не найдена');
+      }
+
+      await this.outbox.add(tx, {
+        type: 'auth.session.revoked',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: {
+          userId,
+          sessionId,
+          reason: 'revoked-by-user',
+        },
+      });
+    });
+
+    this.logger.log({ userId, sessionId }, 'auth.session.revoked');
+  }
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -54,6 +54,11 @@ const SECTIONS: ProfileSection[] = [
     title: 'Экстренные контакты',
     description: 'Кому звонить при ЧП во время поездки',
   },
+  {
+    href: '/profile/security/sessions',
+    title: 'Активные сессии',
+    description: 'Устройства, на которых выполнен вход. Завершите подозрительные.',
+  },
 ];
 
 function buildGreeting(me: ClientMe | null, fallbackEmail: string): string {

--- a/apps/web/app/profile/security/sessions/page.tsx
+++ b/apps/web/app/profile/security/sessions/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { authApi, type SessionItem } from '@/lib/auth/api';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/security/sessions — список активных сессий (#A-05).
+ *
+ * Каждая сессия: устройство (браузер + ОС), IP, дата создания, expires.
+ * Текущая сессия помечена бейджем «Текущая» и не может быть завершена
+ * через DELETE /auth/sessions/:id (для этого есть POST /auth/logout).
+ *
+ * CTA «Выйти со всех устройств» — полный logout-all через POST /auth/logout-all.
+ *
+ * Auth required. PII (IP) показываем только владельцу.
+ */
+
+function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+function formatExpires(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return 'истекла';
+  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+  if (days >= 1) return `${days} дн.`;
+  const hours = Math.floor(ms / (60 * 60 * 1000));
+  if (hours >= 1) return `${hours} ч.`;
+  const minutes = Math.max(1, Math.floor(ms / (60 * 1000)));
+  return `${minutes} мин.`;
+}
+
+export default function SessionsPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [sessions, setSessions] = useState<SessionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [logoutAllPending, setLogoutAllPending] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    authApi
+      .listSessions()
+      .then((items) => {
+        if (!cancelled) setSessions(items);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Не удалось загрузить сессии.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  async function handleRevoke(sessionId: string): Promise<void> {
+    setError(null);
+    setRevokingId(sessionId);
+    try {
+      await authApi.revokeSession(sessionId);
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    } catch {
+      setError('Не удалось завершить сессию. Попробуйте ещё раз.');
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  async function handleLogoutAll(): Promise<void> {
+    if (
+      !window.confirm(
+        'Завершить ВСЕ сессии, включая текущую? Вам потребуется войти заново на всех устройствах.',
+      )
+    ) {
+      return;
+    }
+    setError(null);
+    setLogoutAllPending(true);
+    try {
+      await authApi.logoutAll();
+      // После logout-all access-token сразу инвалидируется; редирект на /login.
+      window.location.href = '/login';
+    } catch {
+      setError('Не удалось завершить все сессии.');
+      setLogoutAllPending(false);
+    }
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Активные сессии</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы посмотреть список устройств.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Активные сессии
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Устройства, на которых сейчас выполнен вход. Если видите подозрительную сессию — завершите
+          её и смените пароль.
+        </p>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Загрузка…</p>
+      ) : sessions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Активных сессий нет.</p>
+      ) : (
+        <ul className="space-y-3">
+          {sessions.map((session) => (
+            <li key={session.id} className="rounded-lg border border-border bg-card p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium">{session.deviceLabel}</p>
+                    {session.current ? (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-primary">
+                        Текущая
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {session.ip ? `IP: ${session.ip}` : 'IP неизвестен'}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Вход: {formatDateTime(session.createdAt)} · истекает через{' '}
+                    {formatExpires(session.expiresAt)}
+                  </p>
+                </div>
+                {!session.current ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleRevoke(session.id)}
+                    disabled={revokingId === session.id}
+                    className="shrink-0 rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                  >
+                    {revokingId === session.id ? 'Завершение…' : 'Завершить'}
+                  </button>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="rounded-lg border border-border bg-muted/30 p-5">
+        <h2 className="font-medium">Выйти со всех устройств</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Завершит все сессии, включая текущую. После этого нужно будет войти заново.
+        </p>
+        <button
+          type="button"
+          onClick={() => void handleLogoutAll()}
+          disabled={logoutAllPending}
+          className="mt-3 rounded-lg border border-destructive/30 bg-background px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+        >
+          {logoutAllPending ? 'Завершение…' : 'Выйти со всех устройств'}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/auth/api.ts
+++ b/apps/web/lib/auth/api.ts
@@ -36,6 +36,15 @@ export interface RefreshResponse {
   refreshToken: string;
 }
 
+export interface SessionItem {
+  id: string;
+  deviceLabel: string;
+  ip: string | null;
+  createdAt: string;
+  expiresAt: string;
+  current: boolean;
+}
+
 /**
  * SDK-клиенты для auth-svc.
  * Соответствуют контракту backend (apps/api/src/modules/auth/auth.controller.ts).
@@ -83,5 +92,27 @@ export const authApi = {
    */
   async confirmPasswordReset(token: string, newPassword: string): Promise<void> {
     await apiClient.post('/auth/password/reset', { token, newPassword });
+  },
+
+  /**
+   * Список активных сессий (#A-05).
+   *
+   * Возвращает все сессии с revokedAt=null и expiresAt > now,
+   * с пометкой `current: true` для текущей сессии (по sessionId из JWT).
+   */
+  async listSessions(): Promise<SessionItem[]> {
+    const { data } = await apiClient.get<{ items: SessionItem[] }>('/auth/sessions');
+    return data.items;
+  },
+
+  /**
+   * Завершить конкретную сессию (#A-05).
+   *
+   * 204 при успехе. 403 если пытаются завершить текущую (для этого
+   * есть POST /auth/logout). 404 если сессия не найдена / не принадлежит
+   * пользователю / уже revoked.
+   */
+  async revokeSession(sessionId: string): Promise<void> {
+    await apiClient.delete(`/auth/sessions/${sessionId}`);
   },
 };


### PR DESCRIPTION
## Summary

Реализация **#A-05 (Active sessions list)** из EPIC #404 (clientский кабинет phase 3 launch), Track A (FE↔BE convergence).

### Backend

- `GET /auth/sessions` — все активные сессии текущего пользователя (`revokedAt=null AND expiresAt > now`), с пометкой `current: true` для сессии из JWT-claim.
- `DELETE /auth/sessions/:id` — завершить конкретную сессию. Текущую завершить нельзя (403 → use `POST /auth/logout`); защита от случайного «выхода».
- `SessionsService.revoke` пишет outbox-event `auth.session.revoked` в одной транзакции — для audit и downstream listeners.
- Inline UA-parser (`lib/ua-parser.ts`) без новой зависимости: Chrome / Firefox / Safari / Edge / Opera + Windows / macOS / Linux / Android / iOS / iPhone / iPad. Покрывает 95% массовых случаев — phase 3 объём не оправдывает `ua-parser-js`.

### Frontend

- `/profile/security/sessions` — список устройств с бейджем «Текущая», IP, временем входа, оставшимся TTL, и кнопкой «Завершить» (disabled для current).
- CTA «Выйти со всех устройств» → `POST /auth/logout-all` → редирект на `/login`.
- `authApi.listSessions` / `authApi.revokeSession` + `SessionItem` type.
- Пункт меню «Активные сессии» в `/profile`.

### Безопасность

- PII (IP) видны только владельцу (через `JwtAuthGuard` + фильтрация по `userId`).
- Защита от случайного логаута: текущую сессию через DELETE завершить нельзя.

## Test plan

- [ ] `pnpm --filter @indiahorizone/api type-check` — passed
- [ ] `pnpm --filter @indiahorizone/web type-check` — passed
- [ ] `pnpm --filter @indiahorizone/api lint` — passed
- [ ] `pnpm --filter @indiahorizone/web lint` — passed
- [ ] `pnpm format:check` — passed
- [ ] `pnpm --filter @indiahorizone/api build` — passed (nest build)
- [ ] `pnpm --filter @indiahorizone/web build` — passed (Next.js, маршрут `/profile/security/sessions` статически генерируется)
- [ ] Manual: создать 2-3 сессии (login с разных UA), проверить что текущая помечена и не имеет кнопки «Завершить»
- [ ] Manual: revoke не-текущей → исчезает из списка, refresh с её refresh-токеном даёт 401
- [ ] Manual: «Выйти со всех устройств» → редирект на /login, новый login с прежним access-token даёт 401

Closes part of #404 (Track A — A-05).

https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdKRhdy2TStuH2oTpgrBEd)_