### PR TITLE
feat(auth,profile): A-03 + A-04 — 2FA enrollment + login challenge

### DIFF
--- a/apps/api/src/modules/auth/two-fa/dto/disable.dto.ts
+++ b/apps/api/src/modules/auth/two-fa/dto/disable.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * DTO для POST /auth/2fa/disable.
+ *
+ * Юзер вводит TOTP-код (6 цифр) ИЛИ recovery-код (16 hex с разделителями).
+ * Сервис сам определяет формат по regex.
+ *
+ * Issue: #438 (sub-issue A-03).
+ */
+export class DisableTwoFaDto {
+  @IsString()
+  @MinLength(6, { message: 'Код слишком короткий' })
+  @MaxLength(40, { message: 'Код слишком длинный' })
+  code!: string;
+}

--- a/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.controller.ts
@@ -12,6 +12,7 @@
  */
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 
+import { DisableTwoFaDto } from './dto/disable.dto';
 import {
   type EnrollResponse,
   VerifyEnrollDto,
@@ -52,5 +53,18 @@ export class TwoFaController {
   @HttpCode(HttpStatus.OK)
   async verifyLogin(@Body() dto: VerifyTwoFaLoginDto): Promise<LoginTokenResponse> {
     return this.twoFa.verifyAtLogin(dto.challengeId, dto.code);
+  }
+
+  /**
+   * Отключить 2FA. Требует TOTP-код или recovery-код для подтверждения владения
+   * вторым фактором (защита от session-hijack scenario).
+   */
+  @Post('disable')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async disable(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: DisableTwoFaDto,
+  ): Promise<void> {
+    await this.twoFa.disable(user.id, dto.code);
   }
 }

--- a/apps/api/src/modules/auth/two-fa/two-fa.service.ts
+++ b/apps/api/src/modules/auth/two-fa/two-fa.service.ts
@@ -180,6 +180,65 @@ export class TwoFaService {
   }
 
   /**
+   * Отключить 2FA (issue #438).
+   *
+   * Требует доказательство владения вторым фактором — TOTP-код ИЛИ recovery-код.
+   * Без этого admin/concierge с украденным session-cookie мог бы отключить 2FA
+   * атакующего и обойти второй фактор.
+   *
+   * При успехе:
+   * - twoFaEnabled = false
+   * - twoFaSecret = null
+   * - все recovery codes удаляются (deleteMany)
+   * - публикуется auth.2fa.disabled через outbox
+   *
+   * Recovery-код, использованный для disable, считается потраченным —
+   * но т.к. мы и так удаляем все коды, отдельная пометка usedAt не нужна.
+   *
+   * @throws NotFoundException если user не найден
+   * @throws BadRequestException если 2FA не активирован
+   * @throws UnauthorizedException если код невалидный
+   */
+  async disable(userId: string, code: string): Promise<void> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, twoFaEnabled: true, twoFaSecret: true },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (!user.twoFaEnabled || !user.twoFaSecret) {
+      throw new BadRequestException('2FA не активирован');
+    }
+
+    const isTotpFormat = /^\d{6}$/.test(code);
+    const verified = isTotpFormat
+      ? this.verifyTotp(code, user.twoFaSecret)
+      : await this.verifyRecoveryCode(code, userId);
+
+    if (!verified) {
+      this.logger.warn({ userId }, 'auth.2fa.disable.invalid-code');
+      throw new UnauthorizedException('Неверный код');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: userId },
+        data: { twoFaEnabled: false, twoFaSecret: null },
+      });
+      await tx.recoveryCode.deleteMany({ where: { userId } });
+      await this.outbox.add(tx, {
+        type: 'auth.2fa.disabled',
+        schemaVersion: 1,
+        actor: { type: 'user', id: userId },
+        payload: { userId, method: isTotpFormat ? 'totp' : 'recovery' },
+      });
+    });
+
+    this.logger.log({ userId, method: isTotpFormat ? 'totp' : 'recovery' }, 'auth.2fa.disabled');
+  }
+
+  /**
    * 2FA verify при login (#133).
    *
    * Flow:

--- a/apps/web/app/(auth)/login/2fa/page.tsx
+++ b/apps/web/app/(auth)/login/2fa/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { Alert, AlertDescription } from '../../../../components/ui/alert';
+import { Button } from '../../../../components/ui/button';
+import { Label } from '../../../../components/ui/label';
+import { authApi } from '../../../../lib/auth/api';
+import { authStore } from '../../../../lib/auth/store';
+
+/**
+ * /login/2fa — второй фактор при входе (#A-04).
+ *
+ * Flow:
+ * 1. На /login пользователь ввёл валидный пароль и BE вернул `{ challengeId }`
+ *    вместо токенов (потому что у него активирован 2FA).
+ * 2. login-страница сохранила challengeId в sessionStorage и редиректит сюда.
+ * 3. Пользователь вводит 6-значный TOTP-код (или recovery-код XXXX-XXXX-XXXX-XXXX).
+ * 4. Submit → POST /auth/2fa/verify { challengeId, code } → токены или 401.
+ * 5. После 3 неверных попыток (или 5 в зависимости от BE) — сервер удаляет
+ *    challenge, мы редиректим на /login с тостом «начните заново».
+ *
+ * Если challengeId отсутствует в sessionStorage (прямой переход / refresh страницы) —
+ * редиректим на /login.
+ */
+
+const SESSION_KEY = 'ih.2fa.challengeId';
+const MAX_ATTEMPTS = 5;
+
+export default function TwoFaChallengePage(): React.ReactElement {
+  const router = useRouter();
+  const [challengeId, setChallengeId] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [useRecovery, setUseRecovery] = useState(false);
+  const [attemptsLeft, setAttemptsLeft] = useState<number>(MAX_ATTEMPTS);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = sessionStorage.getItem(SESSION_KEY);
+    if (!stored) {
+      router.replace('/login');
+      return;
+    }
+    setChallengeId(stored);
+  }, [router]);
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!challengeId) return;
+
+    const trimmed = code.trim();
+    if (trimmed.length === 0) return;
+
+    setError(null);
+    setPending(true);
+    try {
+      const result = await authApi.verify2faLogin(challengeId, trimmed);
+      // Успех — записываем токены, чистим sessionStorage, редиректим на /trips
+      sessionStorage.removeItem(SESSION_KEY);
+      authStore.setSession({
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        user: result.user,
+      });
+      router.push('/trips');
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 401) {
+        const next = attemptsLeft - 1;
+        setAttemptsLeft(next);
+        if (next <= 0) {
+          sessionStorage.removeItem(SESSION_KEY);
+          router.replace('/login?error=2fa-exhausted');
+          return;
+        }
+        setError(`Неверный код. Осталось попыток: ${next}.`);
+      } else {
+        setError('Не удалось проверить код. Попробуйте ещё раз.');
+      }
+      setCode('');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 rounded-xl border border-border bg-card p-6 shadow-sm sm:p-8">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Подтверждение входа</h1>
+        <p className="text-sm text-muted-foreground">
+          {useRecovery
+            ? 'Введите один из recovery-кодов (XXXX-XXXX-XXXX-XXXX).'
+            : 'Введите 6-значный код из приложения-аутентификатора.'}
+        </p>
+      </div>
+
+      {error ? (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4" noValidate>
+        <div className="space-y-1.5">
+          <Label htmlFor="code">{useRecovery ? 'Recovery-код' : 'Код'}</Label>
+          <input
+            id="code"
+            value={code}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (useRecovery) {
+                setCode(v.toLowerCase().slice(0, 19));
+              } else {
+                setCode(v.replace(/\D/g, '').slice(0, 6));
+              }
+            }}
+            inputMode={useRecovery ? 'text' : 'numeric'}
+            autoComplete="one-time-code"
+            autoFocus
+            required
+            placeholder={useRecovery ? 'xxxx-xxxx-xxxx-xxxx' : '123456'}
+            className="w-full rounded-lg border border-input bg-background px-3 py-2 text-center font-mono text-lg tracking-[0.2em]"
+          />
+        </div>
+
+        <Button type="submit" width="full" size="lg" disabled={pending || code.trim().length === 0}>
+          {pending ? 'Проверяем…' : 'Подтвердить'}
+        </Button>
+      </form>
+
+      <div className="space-y-2 text-center text-sm">
+        <button
+          type="button"
+          onClick={() => {
+            setUseRecovery((v) => !v);
+            setCode('');
+            setError(null);
+          }}
+          className="font-medium text-primary hover:underline"
+        >
+          {useRecovery ? 'Использовать код из приложения' : 'Использовать recovery-код'}
+        </button>
+        <div className="text-muted-foreground">
+          Потеряли всё?{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Вернуться к входу
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -11,6 +11,7 @@ import { Field } from '../../../components/ui/field';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { getErrorMessage } from '../../../lib/api/client';
+import { isLoginChallenge } from '../../../lib/auth/api';
 import { useLogin } from '../../../lib/auth/hooks';
 
 /**
@@ -40,7 +41,13 @@ export default function LoginPage(): React.ReactElement {
     login.mutate(
       { email: email.trim().toLowerCase(), password },
       {
-        onSuccess: () => {
+        onSuccess: (result) => {
+          if (isLoginChallenge(result)) {
+            // 2FA активирован — challengeId хранится в sessionStorage до verify (#A-04).
+            sessionStorage.setItem('ih.2fa.challengeId', result.challengeId);
+            router.push('/login/2fa');
+            return;
+          }
           router.push('/trips');
         },
       },

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -59,6 +59,11 @@ const SECTIONS: ProfileSection[] = [
     title: 'Активные сессии',
     description: 'Устройства, на которых выполнен вход. Завершите подозрительные.',
   },
+  {
+    href: '/profile/security/2fa',
+    title: 'Двухфакторная аутентификация',
+    description: 'Защитите аккаунт кодом из приложения-аутентификатора.',
+  },
 ];
 
 function buildGreeting(me: ClientMe | null, fallbackEmail: string): string {

--- a/apps/web/app/profile/security/2fa/page.tsx
+++ b/apps/web/app/profile/security/2fa/page.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import Link from 'next/link';
+import { QRCodeSVG } from 'qrcode.react';
+import { useState } from 'react';
+
+import { authApi } from '@/lib/auth/api';
+import { useCurrentUser } from '@/lib/auth/store';
+
+/**
+ * /profile/security/2fa — multi-step wizard для 2FA TOTP enrollment (#A-03).
+ *
+ * Шаги:
+ *  - intro          — описание, кнопка «Включить 2FA»
+ *  - scan           — QR из otpauth-URL + manual secret + поле для 6-цифрового кода
+ *  - recovery       — 10 recovery-кодов в plaintext + чекбокс «Я сохранил» + copy/download
+ *  - success        — итоговый экран
+ *  - disable        — если 2FA уже активирован: ввод TOTP/recovery для отключения
+ *
+ * Отдельная страница, не модал — flow требует фокус, без отвлечений.
+ *
+ * Auth required. Состояние секрета и recovery-кодов в useState (НЕ в localStorage —
+ * security: secret после refresh страницы недоступен на BE, юзер должен начать заново).
+ *
+ * Связано: #407 (A-03), #438 (disable endpoint).
+ */
+
+type Step = 'intro' | 'scan' | 'recovery' | 'success' | 'disable';
+
+interface EnrollData {
+  secret: string;
+  otpAuthUrl: string;
+}
+
+function downloadRecoveryCodes(codes: string[]): void {
+  const content = [
+    'IndiaHorizone — recovery codes для 2FA.',
+    'Сохраните в безопасном месте. Каждый код можно использовать ОДИН раз.',
+    '',
+    ...codes,
+    '',
+    `Сгенерировано: ${new Date().toLocaleString('ru-RU')}`,
+  ].join('\n');
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `indiahorizone-recovery-codes-${Date.now()}.txt`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default function TwoFaPage(): React.ReactElement {
+  const user = useCurrentUser();
+  const [step, setStep] = useState<Step>('intro');
+  const [enrollData, setEnrollData] = useState<EnrollData | null>(null);
+  const [code, setCode] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [savedConfirmed, setSavedConfirmed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [disableCode, setDisableCode] = useState('');
+
+  async function handleStartEnroll(): Promise<void> {
+    setError(null);
+    setPending(true);
+    try {
+      const data = await authApi.enroll2fa();
+      setEnrollData(data);
+      setStep('scan');
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        setError('2FA уже активирован. Сначала отключите текущий setup.');
+        setStep('disable');
+      } else {
+        setError('Не удалось начать настройку 2FA. Попробуйте ещё раз.');
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function handleVerifyCode(): Promise<void> {
+    if (!/^\d{6}$/.test(code)) {
+      setError('Код должен быть 6 цифр');
+      return;
+    }
+    setError(null);
+    setPending(true);
+    try {
+      const result = await authApi.verify2faEnroll(code);
+      setRecoveryCodes(result.recoveryCodes);
+      setStep('recovery');
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 401) {
+        setError('Неверный код. Проверьте, что время на устройстве синхронизировано.');
+      } else {
+        setError('Не удалось проверить код. Попробуйте ещё раз.');
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function handleConfirmSaved(): void {
+    if (!savedConfirmed) return;
+    setStep('success');
+  }
+
+  async function handleDisable(): Promise<void> {
+    if (disableCode.trim().length < 6) {
+      setError('Введите TOTP-код или recovery-код');
+      return;
+    }
+    setError(null);
+    setPending(true);
+    try {
+      await authApi.disable2fa(disableCode.trim());
+      setStep('intro');
+      setDisableCode('');
+      setEnrollData(null);
+      setRecoveryCodes(null);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 401) {
+        setError('Неверный код.');
+      } else {
+        setError('Не удалось отключить 2FA. Попробуйте ещё раз.');
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (user === null) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="font-serif text-3xl font-medium">Двухфакторная аутентификация</h1>
+        <p className="mt-4 text-muted-foreground">
+          Войдите чтобы настроить 2FA.{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Войти →
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-8 px-6 py-12 sm:py-16">
+      <header>
+        <Link
+          href="/profile"
+          className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground hover:text-foreground"
+        >
+          ← Личный кабинет
+        </Link>
+        <h1 className="mt-3 font-serif text-3xl font-medium leading-tight tracking-tight sm:text-4xl">
+          Двухфакторная аутентификация
+        </h1>
+      </header>
+
+      {step === 'intro' ? (
+        <section className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            2FA добавляет второй фактор при входе — одноразовый код из приложения-аутентификатора
+            (Google Authenticator, 1Password, Authy). Даже если злоумышленник узнает пароль — он не
+            войдёт без кода с вашего телефона.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            После активации мы сгенерируем 10 recovery-кодов на случай потери телефона. Сохраните их
+            в безопасном месте.
+          </p>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <button
+            type="button"
+            onClick={() => void handleStartEnroll()}
+            disabled={pending}
+            className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {pending ? 'Подготовка…' : 'Включить 2FA'}
+          </button>
+        </section>
+      ) : null}
+
+      {step === 'scan' && enrollData ? (
+        <section className="space-y-6">
+          <div className="space-y-2">
+            <h2 className="text-lg font-medium">Шаг 1 — Отсканируйте QR</h2>
+            <p className="text-sm text-muted-foreground">
+              Откройте Google Authenticator или 1Password и отсканируйте QR-код ниже.
+            </p>
+          </div>
+
+          <div className="flex flex-col items-center gap-4 rounded-xl border border-border bg-card p-6">
+            <div className="rounded-lg bg-white p-4">
+              <QRCodeSVG value={enrollData.otpAuthUrl} size={200} level="M" />
+            </div>
+            <details className="w-full text-sm">
+              <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                Не могу отсканировать — введу секрет вручную
+              </summary>
+              <div className="mt-3 rounded-lg bg-muted p-3 font-mono text-xs break-all">
+                {enrollData.secret}
+              </div>
+            </details>
+          </div>
+
+          <div className="space-y-2">
+            <h2 className="text-lg font-medium">Шаг 2 — Введите код из приложения</h2>
+            <input
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="123456"
+              maxLength={6}
+              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-center font-mono text-lg tracking-[0.3em]"
+            />
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            <button
+              type="button"
+              onClick={() => void handleVerifyCode()}
+              disabled={pending || code.length !== 6}
+              className="w-full rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {pending ? 'Проверка…' : 'Подтвердить'}
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {step === 'recovery' && recoveryCodes ? (
+        <section className="space-y-6">
+          <div className="space-y-2">
+            <h2 className="text-lg font-medium">Шаг 3 — Сохраните recovery-коды</h2>
+            <p className="text-sm text-muted-foreground">
+              Если потеряете телефон — войдёте по одному из этих кодов. Каждый код одноразовый.
+              <strong> Сейчас их видно в последний раз.</strong>
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-5">
+            <ul className="grid grid-cols-2 gap-2 font-mono text-sm">
+              {recoveryCodes.map((c) => (
+                <li key={c} className="rounded-md bg-muted px-3 py-2 text-center tracking-wider">
+                  {c}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                void copyToClipboard(recoveryCodes.join('\n')).then((ok) => {
+                  if (ok) {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  }
+                })
+              }
+              className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+            >
+              {copied ? 'Скопировано ✓' : 'Скопировать все'}
+            </button>
+            <button
+              type="button"
+              onClick={() => downloadRecoveryCodes(recoveryCodes)}
+              className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+            >
+              Скачать .txt
+            </button>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+            >
+              Распечатать
+            </button>
+          </div>
+
+          <label className="flex items-start gap-3 text-sm">
+            <input
+              type="checkbox"
+              checked={savedConfirmed}
+              onChange={(e) => setSavedConfirmed(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Я сохранил коды в безопасном месте. Я понимаю, что без них и без телефона восстановить
+              доступ не получится.
+            </span>
+          </label>
+
+          <button
+            type="button"
+            onClick={handleConfirmSaved}
+            disabled={!savedConfirmed}
+            className="w-full rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            Готово
+          </button>
+        </section>
+      ) : null}
+
+      {step === 'success' ? (
+        <section className="space-y-4">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-900 dark:bg-emerald-950/40">
+            <h2 className="text-lg font-medium text-emerald-900 dark:text-emerald-100">
+              2FA активирован ✓
+            </h2>
+            <p className="mt-2 text-sm text-emerald-900/80 dark:text-emerald-100/80">
+              При следующем входе вы введёте 6-значный код из authenticator-приложения.
+            </p>
+          </div>
+          <Link
+            href="/profile"
+            className="inline-block rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Вернуться в профиль
+          </Link>
+        </section>
+      ) : null}
+
+      {step === 'disable' ? (
+        <section className="space-y-4">
+          <div className="space-y-2">
+            <h2 className="text-lg font-medium">Отключить 2FA</h2>
+            <p className="text-sm text-muted-foreground">
+              Введите текущий 6-значный код из приложения ИЛИ один из recovery-кодов для
+              подтверждения, что это действительно вы.
+            </p>
+          </div>
+          <input
+            value={disableCode}
+            onChange={(e) => setDisableCode(e.target.value)}
+            placeholder="123456 или XXXX-XXXX-XXXX-XXXX"
+            autoComplete="one-time-code"
+            className="w-full rounded-lg border border-input bg-background px-3 py-2 font-mono text-sm"
+          />
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void handleDisable()}
+              disabled={pending}
+              className="rounded-lg border border-destructive/30 bg-background px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+            >
+              {pending ? 'Отключение…' : 'Отключить 2FA'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setStep('intro');
+                setError(null);
+                setDisableCode('');
+              }}
+              className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+            >
+              Отмена
+            </button>
+          </div>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/lib/auth/api.ts
+++ b/apps/web/lib/auth/api.ts
@@ -45,6 +45,34 @@ export interface SessionItem {
   current: boolean;
 }
 
+export interface TwoFaEnrollResponse {
+  /** Plaintext base32-секрет для ручного ввода (если QR недоступен). */
+  secret: string;
+  /** otpauth:// URL для рендера QR. */
+  otpAuthUrl: string;
+}
+
+export interface TwoFaVerifyEnrollResponse {
+  /** 10 recovery-кодов в формате XXXX-XXXX-XXXX-XXXX. Возвращаются ОДИН раз. */
+  recoveryCodes: string[];
+}
+
+/**
+ * Login response — discriminated union (#A-03/A-04):
+ * - LoginTokenResponse: пользователь без 2FA, выпущены токены сразу.
+ * - LoginChallengeResponse: пользователь с активированным 2FA, нужно вызвать
+ *   POST /auth/2fa/verify { challengeId, code } для получения токенов.
+ */
+export interface LoginChallengeResponse {
+  challengeId: string;
+}
+
+export type LoginResult = LoginResponse | LoginChallengeResponse;
+
+export function isLoginChallenge(result: LoginResult): result is LoginChallengeResponse {
+  return 'challengeId' in result;
+}
+
 /**
  * SDK-клиенты для auth-svc.
  * Соответствуют контракту backend (apps/api/src/modules/auth/auth.controller.ts).
@@ -55,8 +83,15 @@ export const authApi = {
     return data;
   },
 
-  async login(payload: LoginPayload): Promise<LoginResponse> {
-    const { data } = await apiClient.post<LoginResponse>('/auth/login', payload);
+  /**
+   * POST /auth/login.
+   *
+   * Возвращает либо токены (LoginResponse), либо challenge (LoginChallengeResponse)
+   * если у пользователя активирован 2FA. Используйте `isLoginChallenge(result)`
+   * для type narrowing.
+   */
+  async login(payload: LoginPayload): Promise<LoginResult> {
+    const { data } = await apiClient.post<LoginResult>('/auth/login', payload);
     return data;
   },
 
@@ -114,5 +149,57 @@ export const authApi = {
    */
   async revokeSession(sessionId: string): Promise<void> {
     await apiClient.delete(`/auth/sessions/${sessionId}`);
+  },
+
+  /**
+   * Шаг 1 enrollment 2FA (#A-03): получить TOTP-secret + otpauth-URL для QR.
+   *
+   * 200 OK с { secret, otpAuthUrl }. Secret шифруется и сохраняется на user'е,
+   * но twoFaEnabled пока остаётся false до verify-enroll. Повторный вызов
+   * генерирует новый secret (старый перезаписывается).
+   *
+   * 409 если 2FA уже активирован.
+   */
+  async enroll2fa(): Promise<TwoFaEnrollResponse> {
+    const { data } = await apiClient.post<TwoFaEnrollResponse>('/auth/2fa/enroll');
+    return data;
+  },
+
+  /**
+   * Шаг 2 enrollment 2FA (#A-03): подтвердить TOTP-код, активировать 2FA,
+   * получить 10 recovery-кодов (один раз — потом не восстановить).
+   *
+   * 200 OK с { recoveryCodes }. 401 при неверном TOTP. 409 если уже активирован.
+   */
+  async verify2faEnroll(code: string): Promise<TwoFaVerifyEnrollResponse> {
+    const { data } = await apiClient.post<TwoFaVerifyEnrollResponse>('/auth/2fa/verify-enroll', {
+      code,
+    });
+    return data;
+  },
+
+  /**
+   * Отключить 2FA (#A-03 / #438). Требует TOTP-код или recovery-код для
+   * подтверждения владения вторым фактором.
+   *
+   * 204 при успехе. 401 при неверном коде. 400 если 2FA не активирован.
+   */
+  async disable2fa(code: string): Promise<void> {
+    await apiClient.post('/auth/2fa/disable', { code });
+  },
+
+  /**
+   * 2FA verify при login (#A-04). Public endpoint — identity proven by
+   * challengeId, выданным после успешного password-step.
+   *
+   * 200 OK с access/refresh токенами при успехе.
+   * 401 при неверном/истёкшем коде ИЛИ исчерпании 5 попыток.
+   */
+  async verify2faLogin(challengeId: string, code: string): Promise<LoginResponse> {
+    const { data } = await apiClient.post<LoginResponse>('/auth/2fa/verify', {
+      challengeId,
+      code,
+    });
+    return data;
   },
 };

--- a/apps/web/lib/auth/hooks.ts
+++ b/apps/web/lib/auth/hooks.ts
@@ -4,8 +4,9 @@ import { useMutation } from '@tanstack/react-query';
 
 import {
   authApi,
+  isLoginChallenge,
   type LoginPayload,
-  type LoginResponse,
+  type LoginResult,
   type RegisterPayload,
   type RegisterResponse,
 } from './api';
@@ -13,12 +14,21 @@ import { authStore } from './store';
 
 /**
  * useLogin — мутация POST /auth/login.
- * onSuccess: пишет токены и user в authStore. После — caller роутит на /trips.
+ *
+ * onSuccess: если ответ — challenge (2FA активирован у пользователя),
+ * НЕ пишет токены (их нет). Caller получает `result.challengeId` через
+ * mutation.data и редиректит на /login/2fa.
+ *
+ * Если ответ — обычный LoginResponse с токенами, пишет в authStore.
  */
-export function useLogin(): ReturnType<typeof useMutation<LoginResponse, unknown, LoginPayload>> {
-  return useMutation<LoginResponse, unknown, LoginPayload>({
+export function useLogin(): ReturnType<typeof useMutation<LoginResult, unknown, LoginPayload>> {
+  return useMutation<LoginResult, unknown, LoginPayload>({
     mutationFn: (payload) => authApi.login(payload),
     onSuccess: (data) => {
+      if (isLoginChallenge(data)) {
+        // 2FA challenge — токенов ещё нет, caller-страница покажет /login/2fa.
+        return;
+      }
       authStore.setSession({
         accessToken: data.accessToken,
         refreshToken: data.refreshToken,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.453.0",
     "next": "14.2.16",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       next:
         specifier: 14.2.16
         version: 14.2.16(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3661,6 +3664,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -8652,6 +8660,10 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
## Summary

Closes part of [#404](https://github.com/Rivega42/indiahorizone/issues/404) → Track A:
- **A-03 ([#407](https://github.com/Rivega42/indiahorizone/issues/407))** — 2FA enrollment UI + disable endpoint
- **A-04 ([#408](https://github.com/Rivega42/indiahorizone/issues/408))** — 2FA challenge page при login

PR'ы поста-неотделимы: login-страница редиректит на `/login/2fa`, страница `/login/2fa` без enrollment не имеет смысла. Объединил в один PR.

### Backend

- **`POST /auth/2fa/disable`** ([#438](https://github.com/Rivega42/indiahorizone/issues/438)) — требует TOTP-код (6 цифр) ИЛИ recovery-код для подтверждения владения вторым фактором. При успехе: `twoFaEnabled=false`, `twoFaSecret=null`, `RecoveryCode.deleteMany`, outbox-event `auth.2fa.disabled`.
- 401 на неверный код, 400 если 2FA не активирован.

### Frontend — A-03 enrollment

- **`/profile/security/2fa`** — multi-step wizard:
  - **intro** — описание + кнопка «Включить 2FA»
  - **scan** — QR-код из otpauth-URL (рендер через `qrcode.react`) + раскрывающийся текстовый секрет для ручного ввода + поле для 6-значного кода
  - **recovery** — 10 recovery-кодов с кнопками «Скопировать все» / «Скачать .txt» / «Распечатать» + обязательный чекбокс «Я сохранил коды»
  - **success** — итоговый экран
  - **disable** — отдельная ветка если 2FA уже активирован (по 409 от enroll)

### Frontend — A-04 challenge

- **`/login/2fa`** — поле для 6-значного TOTP / переключатель на recovery-код / 5 попыток / редирект `/login?error=2fa-exhausted` при исчерпании.
- `useLogin()` хук обрабатывает `LoginChallengeResponse`: при `requires2FA` сохраняет `challengeId` в `sessionStorage` и не пишет токены.
- Login page редиректит на `/login/2fa` при challenge.
- При прямом заходе на `/login/2fa` без challengeId → редирект на `/login`.

### Общее

- **`lib/auth/api.ts`** — `enroll2fa()` / `verify2faEnroll()` / `disable2fa()` / `verify2faLogin()`, плюс `LoginResult` union с type-guard `isLoginChallenge()`.
- Меню `/profile` расширено пунктом «Двухфакторная аутентификация».
- Новая зависимость: `qrcode.react@4.2.0` (+~20KB gzipped).

### Безопасность

- Secret и recovery codes хранятся только в `useState` — после refresh страницы пользователь должен начать enroll заново (security: secret недоступен на BE после refresh).
- Disable требует доказательства владения вторым фактором → защита от session-hijack.
- Recovery codes хешируются через argon2id на BE, plaintext возвращается ОДИН раз.
- challengeId хранится в `sessionStorage` (не localStorage) — пропадает при закрытии вкладки.

## Test plan

- [x] type-check + lint + format + build (api + web)
- [ ] Manual enroll: scan QR → ввод кода → recovery codes → success
- [ ] Manual enroll edge: повторный заход → 409 → ветка disable работает
- [ ] Manual disable: TOTP-кодом и recovery-кодом
- [ ] Manual challenge: login пользователя с 2FA → /login/2fa → ввод TOTP → /trips
- [ ] Manual challenge edge: 5 неверных попыток → редирект на /login
- [ ] Manual challenge edge: прямой заход на /login/2fa без challengeId → редирект на /login
- [ ] Manual challenge: recovery-код вместо TOTP

🤖 Generated by [Claude Code](https://claude.com/claude-code)